### PR TITLE
feat: Complete Web GUI — 17 features across 4 sprints

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -5,7 +5,8 @@
       "name": "server",
       "runtimeExecutable": "npm",
       "runtimeArgs": ["run", "server:dev"],
-      "port": 3000
+      "env": { "PORT": "3001" },
+      "port": 3001
     },
     {
       "name": "web",

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "@types/express": "^5.0.3",
         "@types/node": "^24.10.1",
         "@types/ws": "^8.5.14",
+        "concurrently": "^10.0.3",
         "tsx": "^4.21.0",
         "typescript": "^5.9.3",
         "vitest": "^4.0.14"
@@ -1149,6 +1150,32 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/array-flatten": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
@@ -1261,6 +1288,21 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/cliui": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
+      "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^7.2.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/commander": {
       "version": "14.0.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
@@ -1268,6 +1310,31 @@
       "license": "MIT",
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/concurrently": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-10.0.3.tgz",
+      "integrity": "sha512-hc3LH4UaKWd/bbyDK/IGVa4RB6PtQ3CUYwtrkzqHn+wIG3Hr5fhpRlk0L/gCa8ZE1L/Ufj50Zho69cI5w8SQBA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "5.6.2",
+        "rxjs": "7.8.2",
+        "shell-quote": "1.8.4",
+        "supports-color": "10.2.2",
+        "tree-kill": "1.2.2",
+        "yargs": "18.0.0"
+      },
+      "bin": {
+        "conc": "dist/bin/index.js",
+        "concurrently": "dist/bin/index.js"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "funding": {
+        "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
       }
     },
     "node_modules/content-disposition": {
@@ -1388,6 +1455,13 @@
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
       "license": "MIT"
     },
+    "node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/encodeurl": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
@@ -1474,6 +1548,16 @@
         "@esbuild/win32-arm64": "0.28.0",
         "@esbuild/win32-ia32": "0.28.0",
         "@esbuild/win32-x64": "0.28.0"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/escape-html": {
@@ -1652,6 +1736,29 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/get-intrinsic": {
@@ -2477,6 +2584,16 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -2553,6 +2670,19 @@
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "license": "ISC"
+    },
+    "node_modules/shell-quote": {
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/side-channel": {
       "version": "1.1.0",
@@ -2666,6 +2796,53 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -2762,13 +2939,22 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tree-kill": "cli.js"
+      }
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
-      "license": "0BSD",
-      "optional": true
+      "license": "0BSD"
     },
     "node_modules/tsx": {
       "version": "4.22.2",
@@ -3061,6 +3247,24 @@
         "node": ">=8"
       }
     },
+    "node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/ws": {
       "version": "8.20.1",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
@@ -3080,6 +3284,44 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz",
+      "integrity": "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^9.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "string-width": "^7.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^22.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+      "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
       }
     },
     "node_modules/zod": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "server": "node dist/server/index.js",
     "server:dev": "tsx src/server/index.ts",
     "web:dev": "cd web && npm run dev",
-    "web:build": "cd web && npm run build"
+    "web:build": "cd web && npm run build",
+    "dev:all": "concurrently -n backend,frontend -c cyan,magenta \"PORT=3001 npm run server:dev\" \"npm run web:dev\""
   },
   "keywords": [
     "cli",
@@ -51,9 +52,9 @@
     "@types/express": "^5.0.3",
     "@types/node": "^24.10.1",
     "@types/ws": "^8.5.14",
+    "concurrently": "^10.0.3",
     "tsx": "^4.21.0",
     "typescript": "^5.9.3",
     "vitest": "^4.0.14"
   }
 }
-

--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -40,6 +40,41 @@ export class AgentLoop {
       description: 'Compress conversation context',
       handler: (_args, messages) => this.handleCompact(messages),
     });
+    this.slashCommands.set('help', {
+      name: 'help',
+      description: 'List available slash commands',
+      handler: (_args, messages) => ({
+        messages,
+        output: [
+          '**Available slash commands:**',
+          '',
+          '| Command | Description |',
+          '|---------|-------------|',
+          '| `/clear` | Clear conversation (client-side) |',
+          '| `/compact` | Compress context to save tokens |',
+          '| `/git` | Show git branch, commits, changed files |',
+          '| `/plan` | Plan the task before executing |',
+          '| `/help` | Show this help |',
+        ].join('\n'),
+      }),
+    });
+    this.slashCommands.set('git', {
+      name: 'git',
+      description: 'Show git status',
+      handler: (_args, messages) => ({
+        messages: [...messages, { role: 'user' as const, content: 'Run git_status to show the current git branch, recent commits, and changed files.' }],
+      }),
+    });
+    this.slashCommands.set('plan', {
+      name: 'plan',
+      description: 'Plan before executing',
+      handler: (args, messages) => ({
+        messages: [...messages, {
+          role: 'user' as const,
+          content: `Create a detailed step-by-step plan for the following task. List each step clearly with a numbered list. Do NOT execute any steps yet — only plan.\n\nTask: ${args || '(describe the task)'}`,
+        }],
+      }),
+    });
   }
 
   /** Process a user message through the full state machine */

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -8,6 +8,7 @@ import { sessionsRouter } from './routes/sessions.js';
 import { toolsRouter } from './routes/tools.js';
 import { configRouter } from './routes/config.js';
 import { filesRouter } from './routes/files.js';
+import { gitRouter } from './routes/git.js';
 import { handleWebSocket } from './wsHandler.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -23,6 +24,7 @@ app.use('/api/sessions', sessionsRouter);
 app.use('/api/tools', toolsRouter);
 app.use('/api/config', configRouter);
 app.use('/api/files', filesRouter);
+app.use('/api/git', gitRouter);
 
 // Serve built frontend in production
 const webDist = path.join(__dirname, '../../web/dist');

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -7,6 +7,7 @@ import { fileURLToPath } from 'node:url';
 import { sessionsRouter } from './routes/sessions.js';
 import { toolsRouter } from './routes/tools.js';
 import { configRouter } from './routes/config.js';
+import { filesRouter } from './routes/files.js';
 import { handleWebSocket } from './wsHandler.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -21,6 +22,7 @@ app.use(express.json());
 app.use('/api/sessions', sessionsRouter);
 app.use('/api/tools', toolsRouter);
 app.use('/api/config', configRouter);
+app.use('/api/files', filesRouter);
 
 // Serve built frontend in production
 const webDist = path.join(__dirname, '../../web/dist');

--- a/src/server/routes/files.ts
+++ b/src/server/routes/files.ts
@@ -1,0 +1,19 @@
+import { Router } from 'express';
+import glob from 'fast-glob';
+
+export const filesRouter = Router();
+
+filesRouter.get('/', async (req, res) => {
+  const cwd = typeof req.query.cwd === 'string' ? req.query.cwd : process.cwd();
+  try {
+    const files = await glob('**/*', {
+      cwd,
+      ignore: ['**/node_modules/**', '**/.git/**', '**/dist/**', '**/dist-bin/**', '**/.vite/**'],
+      onlyFiles: true,
+      followSymbolicLinks: false,
+    });
+    res.json(files.sort());
+  } catch {
+    res.json([]);
+  }
+});

--- a/src/server/routes/git.ts
+++ b/src/server/routes/git.ts
@@ -1,0 +1,17 @@
+import { Router } from 'express';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+const execAsync = promisify(execFile);
+export const gitRouter = Router();
+
+gitRouter.get('/', async (req, res) => {
+  const cwd = typeof req.query.cwd === 'string' ? req.query.cwd : process.cwd();
+  try {
+    const { stdout: branch } = await execAsync('git', ['branch', '--show-current'], { cwd });
+    const { stdout: log } = await execAsync('git', ['log', '--oneline', '-1'], { cwd });
+    res.json({ branch: branch.trim() || null, lastCommit: log.trim() || null });
+  } catch {
+    res.json({ branch: null, lastCommit: null });
+  }
+});

--- a/src/server/wsHandler.ts
+++ b/src/server/wsHandler.ts
@@ -1,3 +1,5 @@
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
 import type { WebSocket } from 'ws';
 import { ProviderManager } from '../providers/manager.js';
 import { scanProject } from '../core/projectScanner.js';
@@ -13,6 +15,29 @@ import {
 import { readConfig } from './configStore.js';
 import type { AgentEvent } from '../agent/types.js';
 
+type AgentMode = 'chat' | 'cowork' | 'code';
+
+const MODE_TOOLS: Record<AgentMode, string[] | null> = {
+  chat:   ['read_file', 'list_files', 'search_text'],
+  cowork: null, // all tools
+  code:   null, // all tools
+};
+
+const MODE_APPROVAL: Record<AgentMode, 'readonly' | 'auto-edit' | 'full-auto'> = {
+  chat:   'readonly',
+  cowork: 'auto-edit',
+  code:   'full-auto',
+};
+
+const MODE_PROMPT: Record<AgentMode, string> = {
+  chat:
+    'You are in Chat mode. Answer questions, explain code, and discuss ideas. Do NOT write, edit, delete files or run shell commands — read-only tools only.',
+  cowork:
+    'You are in Cowork mode. Work collaboratively. Briefly explain your plan before making changes. Prefer focused, surgical edits. File writes and shell commands require user approval.',
+  code:
+    'You are in Code mode. Work autonomously to complete the task efficiently. Use all available tools as needed.',
+};
+
 type ClientMessage =
   | {
       type: 'send';
@@ -22,7 +47,7 @@ type ClientMessage =
       allowWrite?: boolean;
       allowExecute?: boolean;
       approvalMode?: 'readonly' | 'auto-edit' | 'full-auto';
-      /** Optional override — falls back to saved config */
+      mode?: AgentMode;
       provider?: string;
     }
   | { type: 'interrupt' }
@@ -46,9 +71,33 @@ function send(ws: WebSocket, msg: ServerMessage): void {
   }
 }
 
+/** Expand @filepath references in the user's message by injecting file contents. */
+async function expandAtMentions(content: string, cwd: string): Promise<string> {
+  const mentionRegex = /@([\w./\-]+)/g;
+  const mentions = [...content.matchAll(mentionRegex)];
+  if (mentions.length === 0) return content;
+
+  let result = content;
+  for (const match of mentions) {
+    const relPath = match[1];
+    const absPath = path.resolve(cwd, relPath);
+    // Safety: must stay inside cwd
+    if (!absPath.startsWith(path.resolve(cwd))) continue;
+    try {
+      const fileContent = await readFile(absPath, 'utf8');
+      result = result.replace(
+        match[0],
+        `<file path="${relPath}">\n\`\`\`\n${fileContent}\n\`\`\`\n</file>`,
+      );
+    } catch {
+      // File not found — leave mention as-is
+    }
+  }
+  return result;
+}
+
 export function handleWebSocket(ws: WebSocket): void {
   let currentAbort: AbortController | null = null;
-  // Pending approval Promises keyed by approval id
   const pendingApprovals = new Map<string, (approved: boolean) => void>();
 
   ws.on('message', async (raw) => {
@@ -60,7 +109,6 @@ export function handleWebSocket(ws: WebSocket): void {
       return;
     }
 
-    // ── Interrupt ─────────────────────────────────────────────
     if (msg.type === 'interrupt') {
       currentAbort?.abort();
       currentAbort = null;
@@ -68,7 +116,6 @@ export function handleWebSocket(ws: WebSocket): void {
       return;
     }
 
-    // ── Approval response ─────────────────────────────────────
     if (msg.type === 'approval_response') {
       const resolve = pendingApprovals.get(msg.id);
       if (resolve) {
@@ -80,12 +127,13 @@ export function handleWebSocket(ws: WebSocket): void {
 
     if (msg.type !== 'send') return;
 
-    // Abort any in-flight turn before starting a new one
     currentAbort?.abort();
     const abort = new AbortController();
     currentAbort = abort;
 
     const cwd = msg.cwd ?? process.cwd();
+    const mode: AgentMode = msg.mode ?? 'code';
+    const approvalMode = msg.approvalMode ?? MODE_APPROVAL[mode];
 
     // Load or create session
     let session;
@@ -101,7 +149,7 @@ export function handleWebSocket(ws: WebSocket): void {
 
     send(ws, { type: 'session_id', sessionId: session.id });
 
-    // Set up provider — config file takes precedence over env vars
+    // Set up provider
     let provider;
     try {
       const cfg = await readConfig();
@@ -122,21 +170,25 @@ export function handleWebSocket(ws: WebSocket): void {
       return;
     }
 
-    // Scan workspace
-    const summary = await scanProject(cwd);
+    // Expand @mentions in user message
+    const userContent = await expandAtMentions(msg.content, cwd);
+
+    // Build tool registry filtered by mode
     const registry = createDefaultToolRegistry();
+    const allowedTools = MODE_TOOLS[mode];
+    registry.setAllowedTools(allowedTools);
+
     const tools = registry.list();
     const toolsDesc = tools
       .map((t) => `- ${t.name}: ${t.description} (access: ${t.access})`)
       .join('\n');
 
-    const sessionContext = session.summary
-      ? `\nPrevious session summary: ${session.summary}\n`
-      : '';
+    const summary = await scanProject(cwd);
+    const sessionContext = session.summary ? `\nPrevious session summary: ${session.summary}\n` : '';
 
     const systemPrompt = [
       'You are DvalinCode, an AI coding assistant.',
-      'The user is working on the following project. You can inspect files, run commands, and make changes.',
+      MODE_PROMPT[mode],
       '',
       `Project root: ${summary.root}`,
       `Files: ${summary.fileCount} files`,
@@ -144,9 +196,8 @@ export function handleWebSocket(ws: WebSocket): void {
       summary.signals.length > 0 ? `Signals: ${summary.signals.join(', ')}` : '',
       sessionContext,
       '',
-      '=== HOW TO USE TOOLS ===',
-      '',
-      `You have ${tools.length} tools available. To use a tool, embed this syntax in your response:`,
+      '=== TOOLS ===',
+      `You have ${tools.length} tools available. Use this syntax in your response:`,
       '',
       '@tool("tool_name", {"param": "value"})',
       '',
@@ -154,19 +205,17 @@ export function handleWebSocket(ws: WebSocket): void {
       toolsDesc,
       '',
       'RULES:',
-      '- Always use read tools first to understand the codebase before making changes.',
+      '- Always read files before modifying them.',
       '- Prefer focused, surgical changes.',
     ]
       .filter(Boolean)
       .join('\n');
 
-    // Build requestApproval callback — sends approval_request and waits for client response
     const requestApproval = (id: string, toolName: string, input: unknown): Promise<boolean> => {
       return new Promise((resolve) => {
         if (abort.signal.aborted) { resolve(false); return; }
         pendingApprovals.set(id, resolve);
         send(ws, { type: 'approval_request', id, toolName, input });
-        // Auto-deny if the turn is aborted while waiting
         abort.signal.addEventListener('abort', () => {
           if (pendingApprovals.has(id)) {
             pendingApprovals.delete(id);
@@ -181,9 +230,7 @@ export function handleWebSocket(ws: WebSocket): void {
       registry,
       context: createDvalinContext({
         cwd,
-        approvalMode: msg.approvalMode,
-        allowWrite: msg.allowWrite,
-        allowExecute: msg.allowExecute,
+        approvalMode,
         requestApproval,
       }),
       systemPrompt,
@@ -198,15 +245,18 @@ export function handleWebSocket(ws: WebSocket): void {
         case 'tool_call':
           send(ws, { type: 'tool_call', name: event.name, id: event.id, input: event.input });
           break;
-        case 'tool_result':
+        case 'tool_result': {
+          // Strip large/internal-only fields before sending over WebSocket
+          const { originalContent: _omit, ...safeMetadata } = (event.metadata ?? {}) as Record<string, unknown> & { originalContent?: unknown };
           send(ws, {
             type: 'tool_result',
             name: event.name,
             id: event.id,
             output: event.output,
-            metadata: event.metadata,
+            metadata: Object.keys(safeMetadata).length > 0 ? safeMetadata : undefined,
           });
           break;
+        }
         case 'tool_error':
           send(ws, { type: 'tool_error', name: event.name, id: event.id, error: event.error });
           break;
@@ -214,9 +264,9 @@ export function handleWebSocket(ws: WebSocket): void {
     };
 
     try {
-      const result = await loop.processMessage(msg.content, session.messages, onEvent, abort.signal);
+      const result = await loop.processMessage(userContent, session.messages, onEvent, abort.signal);
 
-      if (abort.signal.aborted) return; // Don't save or respond if interrupted
+      if (abort.signal.aborted) return;
 
       session.messages = result.messages;
       session.updatedAt = new Date().toISOString();

--- a/src/server/wsHandler.ts
+++ b/src/server/wsHandler.ts
@@ -1,5 +1,9 @@
 import { readFile } from 'node:fs/promises';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
 import path from 'node:path';
+
+const execAsync = promisify(execFile);
 import type { WebSocket } from 'ws';
 import { ProviderManager } from '../providers/manager.js';
 import { scanProject } from '../core/projectScanner.js';
@@ -69,6 +73,10 @@ function send(ws: WebSocket, msg: ServerMessage): void {
   if (ws.readyState === 1 /* OPEN */) {
     ws.send(JSON.stringify(msg));
   }
+}
+
+async function readTextFileSafe(filePath: string): Promise<string | null> {
+  try { return await readFile(filePath, 'utf8'); } catch { return null; }
 }
 
 /** Expand @filepath references in the user's message by injecting file contents. */
@@ -186,6 +194,23 @@ export function handleWebSocket(ws: WebSocket): void {
     const summary = await scanProject(cwd);
     const sessionContext = session.summary ? `\nPrevious session summary: ${session.summary}\n` : '';
 
+    // ── AGENTS.md project memory ─────────────────────────────────────────────
+    const agentsMd = await readTextFileSafe(path.join(cwd, 'AGENTS.md'));
+    const projectInstructions = agentsMd
+      ? `\n=== PROJECT INSTRUCTIONS (from AGENTS.md) ===\n${agentsMd}\n`
+      : '';
+
+    // ── Git context ──────────────────────────────────────────────────────────
+    let gitContext = '';
+    try {
+      const branch = (await execAsync('git', ['branch', '--show-current'], { cwd })).stdout.trim();
+      const status = (await execAsync('git', ['status', '--porcelain'], { cwd })).stdout.trim();
+      const changedCount = status ? status.split('\n').length : 0;
+      gitContext = `\nGit branch: ${branch || '(detached)'}${changedCount > 0 ? ` · ${changedCount} changed file(s)` : ' · clean'}\n`;
+    } catch {
+      // Not a git repo — silently skip
+    }
+
     const systemPrompt = [
       'You are DvalinCode, an AI coding assistant.',
       MODE_PROMPT[mode],
@@ -194,6 +219,8 @@ export function handleWebSocket(ws: WebSocket): void {
       `Files: ${summary.fileCount} files`,
       `Package manager(s): ${summary.packageManagers.join(', ') || 'none'}`,
       summary.signals.length > 0 ? `Signals: ${summary.signals.join(', ')}` : '',
+      gitContext,
+      projectInstructions,
       sessionContext,
       '',
       '=== TOOLS ===',

--- a/src/tools/editFile.ts
+++ b/src/tools/editFile.ts
@@ -62,10 +62,11 @@ export const editFileTool: Tool<Input> = {
       title: `Edit ${input.filePath}`,
       output,
       metadata: {
-        path: filePath,
+        path: input.filePath,
         bytesBefore: Buffer.byteLength(existing, 'utf8'),
         bytesAfter: Buffer.byteLength(updated, 'utf8'),
         occurrences,
+        diff,
       },
     };
   },

--- a/src/tools/gitStatus.ts
+++ b/src/tools/gitStatus.ts
@@ -1,0 +1,51 @@
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { z } from 'zod';
+import type { Tool } from './types.js';
+
+const execAsync = promisify(execFile);
+
+const inputSchema = z.object({}).strict();
+
+async function git(args: string[], cwd: string): Promise<string> {
+  const { stdout } = await execAsync('git', args, { cwd });
+  return stdout.trim();
+}
+
+export const gitStatusTool: Tool<z.infer<typeof inputSchema>> = {
+  name: 'git_status',
+  description:
+    'Show the current git branch, last 5 commits, and changed files. Use this to understand the git state before making changes.',
+  access: 'read',
+  inputSchema,
+  isConcurrencySafe: () => true,
+  isUndoable: () => false,
+
+  async run(_input, context) {
+    const cwd = context.cwd;
+    const parts: string[] = [];
+
+    try {
+      const branch = await git(['branch', '--show-current'], cwd);
+      parts.push(`Branch: ${branch || '(detached HEAD)'}`);
+
+      const log = await git(['log', '--oneline', '-5'], cwd);
+      if (log) {
+        parts.push('', 'Recent commits:');
+        for (const line of log.split('\n')) parts.push(`  ${line}`);
+      }
+
+      const status = await git(['status', '--porcelain'], cwd);
+      if (status) {
+        parts.push('', 'Changed files:');
+        for (const line of status.split('\n')) parts.push(`  ${line}`);
+      } else {
+        parts.push('', 'Working tree clean.');
+      }
+    } catch {
+      return { title: 'git_status', output: 'Not a git repository or git is not installed.' };
+    }
+
+    return { title: 'git status', output: parts.join('\n') };
+  },
+};

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -11,6 +11,12 @@ import type { Tool, ToolResult } from './types.js';
 
 export class ToolRegistry {
   private readonly tools = new Map<string, Tool<unknown>>();
+  private allowedToolNames: Set<string> | null = null;
+
+  /** Restrict which tools are visible / executable. Pass null to allow all. */
+  setAllowedTools(names: string[] | null): void {
+    this.allowedToolNames = names ? new Set(names) : null;
+  }
 
   register<Input>(tool: Tool<Input>): void {
     if (this.tools.has(tool.name)) {
@@ -21,10 +27,12 @@ export class ToolRegistry {
   }
 
   list(): Tool<unknown>[] {
-    return [...this.tools.values()].sort((a, b) => a.name.localeCompare(b.name));
+    const all = [...this.tools.values()].sort((a, b) => a.name.localeCompare(b.name));
+    return this.allowedToolNames ? all.filter(t => this.allowedToolNames!.has(t.name)) : all;
   }
 
   get(name: string): Tool<unknown> | undefined {
+    if (this.allowedToolNames && !this.allowedToolNames.has(name)) return undefined;
     return this.tools.get(name);
   }
 

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -7,6 +7,7 @@ import { searchTextTool } from './searchText.js';
 import { shellTool } from './shell.js';
 import { writeFileTool } from './writeFile.js';
 import { deleteFileTool } from './deleteFile.js';
+import { gitStatusTool } from './gitStatus.js';
 import type { Tool, ToolResult } from './types.js';
 
 export class ToolRegistry {
@@ -61,6 +62,7 @@ export class ToolRegistry {
 export function createDefaultToolRegistry(): ToolRegistry {
   const registry = new ToolRegistry();
   registry.register(editFileTool);
+  registry.register(gitStatusTool);
   registry.register(listFilesTool);
   registry.register(readFileTool);
   registry.register(searchTextTool);

--- a/src/tools/writeFile.ts
+++ b/src/tools/writeFile.ts
@@ -54,15 +54,16 @@ export const writeFileTool: Tool<Input> = {
 
     let output: string;
     let originalContent: string | undefined;
+    let diff: ReturnType<typeof generateDiff> | undefined;
     const exists = await fileExists(filePath);
 
     if (exists) {
       originalContent = await readFile(filePath, 'utf8');
-      const diff = generateDiff(originalContent, input.content);
+      diff = generateDiff(originalContent, input.content);
       output = formatDiff(diff);
     } else {
       await mkdir(path.dirname(filePath), { recursive: true });
-      output = `Creating new file: ${input.filePath}`;
+      output = `Created new file: ${input.filePath}`;
     }
 
     await writeFile(filePath, input.content, 'utf8');
@@ -71,10 +72,11 @@ export const writeFileTool: Tool<Input> = {
       title: `Write ${input.filePath}`,
       output,
       metadata: {
-        path: filePath,
+        path: input.filePath,
         bytes: Buffer.byteLength(input.content, 'utf8'),
         existed: exists,
-        originalContent,
+        originalContent,  // kept for undo; stripped before WebSocket send
+        diff,
       },
     };
   },

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -8,10 +8,12 @@
       "name": "dvalincode-web",
       "version": "0.1.0",
       "dependencies": {
+        "highlight.js": "^11.11.1",
         "lucide-react": "^0.511.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-markdown": "^9.0.3",
+        "rehype-highlight": "^7.0.2",
         "remark-gfm": "^4.0.1"
       },
       "devDependencies": {
@@ -2002,6 +2004,19 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hast-util-is-element": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-3.0.0.tgz",
+      "integrity": "sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-to-jsx-runtime": {
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
@@ -2029,6 +2044,22 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/hast-util-to-text": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/hast-util-to-text/-/hast-util-to-text-4.0.2.tgz",
+      "integrity": "sha512-KK6y/BN8lbaq654j7JgBydev7wuNMcID54lkRav1P0CaE1e47P72AWWPiGKXTJU271ooYzcvTAn/Zt0REnvc7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "hast-util-is-element": "^3.0.0",
+        "unist-util-find-after": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-whitespace": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
@@ -2040,6 +2071,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/highlight.js": {
+      "version": "11.11.1",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
+      "integrity": "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/html-url-attributes": {
@@ -2258,6 +2298,21 @@
       },
       "bin": {
         "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/lowlight": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lowlight/-/lowlight-3.3.0.tgz",
+      "integrity": "sha512-0JNhgFoPvP6U6lE/UdVsSq99tn6DhjjpAj5MxG49ewd2mOBVtwWYIT8ClyABhq198aXXODMU6Ox8DrGy/CpTZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "devlop": "^1.0.0",
+        "highlight.js": "~11.11.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/lru-cache": {
@@ -3574,6 +3629,23 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/rehype-highlight": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/rehype-highlight/-/rehype-highlight-7.0.2.tgz",
+      "integrity": "sha512-k158pK7wdC2qL3M5NcZROZ2tR/l7zOzjxXd5VGdcfIyoijjQqpHd3JKtYSBDpDZ38UI2WJWuFAtkMDxmx5kstA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-to-text": "^4.0.0",
+        "lowlight": "^3.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/remark-gfm": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
@@ -4032,6 +4104,20 @@
         "is-plain-obj": "^4.0.0",
         "trough": "^2.0.0",
         "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-find-after": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-find-after/-/unist-util-find-after-5.0.0.tgz",
+      "integrity": "sha512-amQa0Ep2m6hE2g72AugUItjbuM8X8cGQnFoHk0pGfrFeT9GZhzN5SW8nRsiGKK7Aif4CrACPENkA6P/Lw6fHGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
       },
       "funding": {
         "type": "opencollective",

--- a/web/package.json
+++ b/web/package.json
@@ -9,10 +9,12 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "highlight.js": "^11.11.1",
     "lucide-react": "^0.511.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-markdown": "^9.0.3",
+    "rehype-highlight": "^7.0.2",
     "remark-gfm": "^4.0.1"
   },
   "devDependencies": {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -5,9 +5,9 @@ import { Composer } from './components/Composer.tsx';
 import { SettingsPanel } from './components/SettingsPanel.tsx';
 import { LLMConfigModal } from './components/LLMConfigModal.tsx';
 import { ApprovalDialog } from './components/ApprovalDialog.tsx';
-import { ModeSwitcher } from './components/ModeSwitcher.tsx';
 import { useChat } from './hooks/useChat.ts';
 import { fetchSessions, fetchConfig, fetchGitInfo } from './lib/client.ts';
+import { estimateCost, formatCost } from './lib/pricing.ts';
 import type { ChatSettings } from './components/SettingsPanel.tsx';
 import type { AgentMode, ApprovalMode } from './types.ts';
 
@@ -23,6 +23,7 @@ export default function App() {
   const [activeModel, setActiveModel] = useState('');
   const [mode, setMode] = useState<AgentMode>('code');
   const [gitBranch, setGitBranch] = useState<string | null>(null);
+  const [sessionCost, setSessionCost] = useState(0);
   const [settings, setSettings] = useState<ChatSettings>({
     cwd: '',
     provider: 'deepseek',
@@ -73,6 +74,7 @@ export default function App() {
 
   const handleNewChat = useCallback(() => {
     chat.reset();
+    setSessionCost(0);
     setSidebarRefresh((n) => n + 1);
   }, [chat]);
 
@@ -110,6 +112,13 @@ export default function App() {
 
   const usage = chat.lastUsage;
 
+  // Accumulate cost whenever a turn finishes
+  useEffect(() => {
+    if (!usage) return;
+    const turnCost = estimateCost(usage.inputTokens, usage.outputTokens, activeModel);
+    setSessionCost((c) => c + turnCost);
+  }, [usage, activeModel]);
+
   return (
     <div className="flex h-full bg-bg text-fg">
       <Sidebar
@@ -118,6 +127,8 @@ export default function App() {
         onSelectSession={handleSelectSession}
         onOpenConfig={() => setShowLLMConfig(true)}
         refreshKey={sidebarRefresh}
+        mode={mode}
+        onModeChange={handleModeChange}
       />
 
       {/* Main area */}
@@ -146,15 +157,19 @@ export default function App() {
             )}
             {usage && (
               <span
-                className="text-[11px] text-muted-fg/70 font-mono flex-shrink-0"
+                className="text-[11px] text-muted-fg/70 font-mono flex-shrink-0 flex items-center gap-1.5"
                 title={`Input: ${usage.inputTokens.toLocaleString()} · Output: ${usage.outputTokens.toLocaleString()}`}
               >
-                {(usage.inputTokens + usage.outputTokens).toLocaleString()} tok
+                <span>{(usage.inputTokens + usage.outputTokens).toLocaleString()} tok</span>
+                {sessionCost > 0 && (
+                  <span className="text-emerald-500/70" title={`Session cost: ${formatCost(sessionCost)}`}>
+                    · {formatCost(sessionCost)}
+                  </span>
+                )}
               </span>
             )}
           </div>
           <div className="flex items-center gap-2 flex-shrink-0">
-            <ModeSwitcher value={mode} onChange={handleModeChange} />
             {/* Active model badge */}
             {activeModel && (
               <button
@@ -175,6 +190,7 @@ export default function App() {
         {/* Composer */}
         <Composer
           onSend={handleSend}
+          onClear={handleNewChat}
           onInterrupt={chat.interrupt}
           sending={chat.sending}
           disabled={false}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -7,7 +7,7 @@ import { LLMConfigModal } from './components/LLMConfigModal.tsx';
 import { ApprovalDialog } from './components/ApprovalDialog.tsx';
 import { ModeSwitcher } from './components/ModeSwitcher.tsx';
 import { useChat } from './hooks/useChat.ts';
-import { fetchSessions, fetchConfig } from './lib/client.ts';
+import { fetchSessions, fetchConfig, fetchGitInfo } from './lib/client.ts';
 import type { ChatSettings } from './components/SettingsPanel.tsx';
 import type { AgentMode, ApprovalMode } from './types.ts';
 
@@ -22,6 +22,7 @@ export default function App() {
   const [showLLMConfig, setShowLLMConfig] = useState(false);
   const [activeModel, setActiveModel] = useState('');
   const [mode, setMode] = useState<AgentMode>('code');
+  const [gitBranch, setGitBranch] = useState<string | null>(null);
   const [settings, setSettings] = useState<ChatSettings>({
     cwd: '',
     provider: 'deepseek',
@@ -39,7 +40,9 @@ export default function App() {
     fetchSessions()
       .then((sessions) => {
         if (sessions[0]?.cwd && !settings.cwd) {
-          setSettings((s) => ({ ...s, cwd: sessions[0].cwd }));
+          const cwd = sessions[0].cwd;
+          setSettings((s) => ({ ...s, cwd }));
+          fetchGitInfo(cwd).then((g) => setGitBranch(g.branch)).catch(() => {});
         }
       })
       .catch(() => {});
@@ -61,6 +64,12 @@ export default function App() {
   useEffect(() => {
     if (!chat.connected) chat.connect();
   }, [settings, mode]);
+
+  // Refresh git branch whenever cwd changes
+  useEffect(() => {
+    if (!settings.cwd) return;
+    fetchGitInfo(settings.cwd).then((g) => setGitBranch(g.branch)).catch(() => {});
+  }, [settings.cwd]);
 
   const handleNewChat = useCallback(() => {
     chat.reset();
@@ -127,6 +136,14 @@ export default function App() {
               }`}
               title={chat.connected ? 'Connected' : 'Disconnected'}
             />
+            {gitBranch && (
+              <span className="text-[11px] text-muted-fg/80 font-mono flex-shrink-0 flex items-center gap-1">
+                <svg width="10" height="10" viewBox="0 0 16 16" fill="currentColor" className="opacity-60">
+                  <path d="M5 3.25a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0zm0 2.122a2.25 2.25 0 1 0-1.5 0v.878A2.25 2.25 0 0 0 5.75 8.5h1.5v2.128a2.251 2.251 0 1 0 1.5 0V8.5h1.5a2.25 2.25 0 0 0 2.25-2.25v-.878a2.25 2.25 0 1 0-1.5 0v.878a.75.75 0 0 1-.75.75h-4.5A.75.75 0 0 1 5 6.25v-.878zm3.75 7.378a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0zm3-8.75a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0z"/>
+                </svg>
+                {gitBranch}
+              </span>
+            )}
             {usage && (
               <span
                 className="text-[11px] text-muted-fg/70 font-mono flex-shrink-0"

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -5,28 +5,36 @@ import { Composer } from './components/Composer.tsx';
 import { SettingsPanel } from './components/SettingsPanel.tsx';
 import { LLMConfigModal } from './components/LLMConfigModal.tsx';
 import { ApprovalDialog } from './components/ApprovalDialog.tsx';
-import { ApprovalModeSwitch } from './components/ApprovalModeSwitch.tsx';
+import { ModeSwitcher } from './components/ModeSwitcher.tsx';
 import { useChat } from './hooks/useChat.ts';
 import { fetchSessions, fetchConfig } from './lib/client.ts';
 import type { ChatSettings } from './components/SettingsPanel.tsx';
-import type { ApprovalMode } from './types.ts';
+import type { AgentMode, ApprovalMode } from './types.ts';
+
+const MODE_APPROVAL: Record<AgentMode, ApprovalMode> = {
+  chat:   'readonly',
+  cowork: 'auto-edit',
+  code:   'full-auto',
+};
 
 export default function App() {
   const [sidebarRefresh, setSidebarRefresh] = useState(0);
   const [showLLMConfig, setShowLLMConfig] = useState(false);
   const [activeModel, setActiveModel] = useState('');
+  const [mode, setMode] = useState<AgentMode>('code');
   const [settings, setSettings] = useState<ChatSettings>({
     cwd: '',
     provider: 'deepseek',
-    approvalMode: 'readonly',
+    approvalMode: 'full-auto',
   });
 
   const chat = useChat({
     cwd: settings.cwd || undefined,
-    approvalMode: settings.approvalMode,
+    approvalMode: MODE_APPROVAL[mode],
+    mode,
   });
 
-  // Auto-detect cwd from first session; load saved LLM config for topbar display
+  // Auto-detect cwd from first session; load saved LLM config
   useEffect(() => {
     fetchSessions()
       .then((sessions) => {
@@ -49,10 +57,10 @@ export default function App() {
     chat.connect();
   }, [chat.connect]);
 
-  // Reconnect when settings change
+  // Reconnect when settings / mode change
   useEffect(() => {
     if (!chat.connected) chat.connect();
-  }, [settings]);
+  }, [settings, mode]);
 
   const handleNewChat = useCallback(() => {
     chat.reset();
@@ -75,6 +83,11 @@ export default function App() {
     },
     [chat],
   );
+
+  const handleModeChange = useCallback((m: AgentMode) => {
+    setMode(m);
+    setSettings((s) => ({ ...s, approvalMode: MODE_APPROVAL[m] }));
+  }, []);
 
   const handleConfigClose = () => {
     setShowLLMConfig(false);
@@ -124,11 +137,8 @@ export default function App() {
             )}
           </div>
           <div className="flex items-center gap-2 flex-shrink-0">
-            <ApprovalModeSwitch
-              value={settings.approvalMode}
-              onChange={(mode: ApprovalMode) => setSettings((s) => ({ ...s, approvalMode: mode }))}
-            />
-            {/* Active model badge — clickable */}
+            <ModeSwitcher value={mode} onChange={handleModeChange} />
+            {/* Active model badge */}
             {activeModel && (
               <button
                 onClick={() => setShowLLMConfig(true)}
@@ -151,13 +161,14 @@ export default function App() {
           onInterrupt={chat.interrupt}
           sending={chat.sending}
           disabled={false}
+          cwd={settings.cwd || undefined}
         />
       </div>
 
       {/* LLM Config Modal */}
       {showLLMConfig && <LLMConfigModal onClose={handleConfigClose} />}
 
-      {/* Approval dialogs — show one at a time (oldest first) */}
+      {/* Approval dialog */}
       {chat.pendingApprovals[0] && (
         <ApprovalDialog
           approval={chat.pendingApprovals[0]}

--- a/web/src/components/AgentActivity.tsx
+++ b/web/src/components/AgentActivity.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { ChevronRight, Terminal, CheckCircle, XCircle, Loader } from 'lucide-react';
-import type { ToolCallEvent } from '../types.ts';
+import type { ToolCallEvent, DiffLine } from '../types.ts';
+import { DiffViewer } from './DiffViewer.tsx';
 
 const TOOL_ICONS: Record<string, string> = {
   read_file: '📄',
@@ -51,15 +52,21 @@ function ToolCallItem({ tc }: { tc: ToolCallEvent }) {
             </pre>
           </div>
 
-          {/* Output */}
-          {(tc.output || tc.error) && (
+          {/* Diff viewer for write/edit tools */}
+          {Array.isArray(tc.metadata?.diff) && (
+            <div className="border-t border-border px-3 py-2">
+              <DiffViewer
+                diff={tc.metadata!.diff as DiffLine[]}
+                filePath={typeof tc.metadata!.path === 'string' ? tc.metadata!.path : undefined}
+              />
+            </div>
+          )}
+
+          {/* Raw output / error (skip output for write tools that already show diff) */}
+          {(tc.error || (tc.output && !tc.metadata?.diff)) && (
             <div className="border-t border-border px-3 py-2">
               <div className="text-muted-fg mb-1">
-                {tc.error ? (
-                  <span className="text-red-400">error</span>
-                ) : (
-                  'output'
-                )}
+                {tc.error ? <span className="text-red-400">error</span> : 'output'}
               </div>
               <pre className="font-mono text-fg overflow-x-auto whitespace-pre-wrap break-all leading-relaxed max-h-64">
                 {tc.error ?? tc.output}

--- a/web/src/components/Composer.tsx
+++ b/web/src/components/Composer.tsx
@@ -1,5 +1,6 @@
-import { useState, useRef, useEffect } from 'react';
-import { Send, Square } from 'lucide-react';
+import { useState, useRef, useEffect, useCallback } from 'react';
+import { Send, Square, File } from 'lucide-react';
+import { fetchFiles } from '../lib/client.ts';
 
 type Props = {
   onSend: (text: string) => void;
@@ -7,10 +8,17 @@ type Props = {
   disabled?: boolean;
   sending?: boolean;
   placeholder?: string;
+  cwd?: string;
 };
 
-export function Composer({ onSend, onInterrupt, disabled, sending, placeholder }: Props) {
+const MAX_MENTION_RESULTS = 8;
+
+export function Composer({ onSend, onInterrupt, disabled, sending, placeholder, cwd }: Props) {
   const [text, setText] = useState('');
+  const [allFiles, setAllFiles] = useState<string[]>([]);
+  const [mentionQuery, setMentionQuery] = useState<string | null>(null);
+  const [mentionFiles, setMentionFiles] = useState<string[]>([]);
+  const [mentionIndex, setMentionIndex] = useState(0);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
   // Auto-resize textarea
@@ -21,56 +29,168 @@ export function Composer({ onSend, onInterrupt, disabled, sending, placeholder }
     el.style.height = `${Math.min(el.scrollHeight, 200)}px`;
   }, [text]);
 
+  // Load file list once when cwd changes and @mention is first needed
+  const loadFiles = useCallback(async () => {
+    if (!cwd || allFiles.length > 0) return;
+    try {
+      const files = await fetchFiles(cwd);
+      setAllFiles(files);
+    } catch {
+      // ignore — file list is optional
+    }
+  }, [cwd, allFiles.length]);
+
+  /** Detect @mention in text up to cursor and return the query string (or null). */
+  const detectMention = (value: string, cursorPos: number): string | null => {
+    const before = value.slice(0, cursorPos);
+    const match = before.match(/@([\w./\-]*)$/);
+    return match ? match[1] : null;
+  };
+
+  const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    const val = e.target.value;
+    setText(val);
+
+    const cursor = e.target.selectionStart ?? val.length;
+    const query = detectMention(val, cursor);
+    if (query !== null) {
+      setMentionQuery(query);
+      const filtered = allFiles
+        .filter((f) => f.toLowerCase().includes(query.toLowerCase()))
+        .slice(0, MAX_MENTION_RESULTS);
+      setMentionFiles(filtered);
+      setMentionIndex(0);
+      if (allFiles.length === 0) void loadFiles();
+    } else {
+      setMentionQuery(null);
+    }
+  };
+
+  const insertMention = (file: string) => {
+    const textarea = textareaRef.current;
+    if (!textarea) return;
+    const cursor = textarea.selectionStart ?? text.length;
+    const before = text.slice(0, cursor);
+    const after = text.slice(cursor);
+    const match = before.match(/@([\w./\-]*)$/);
+    if (!match) return;
+    const newBefore = before.slice(0, before.length - match[0].length) + `@${file}`;
+    setText(newBefore + after);
+    setMentionQuery(null);
+    // Restore focus and position cursor after the inserted mention
+    setTimeout(() => {
+      textarea.focus();
+      const pos = newBefore.length;
+      textarea.setSelectionRange(pos, pos);
+    }, 0);
+  };
+
   const submit = () => {
     const trimmed = text.trim();
     if (!trimmed || disabled || sending) return;
     onSend(trimmed);
     setText('');
-    if (textareaRef.current) {
-      textareaRef.current.style.height = 'auto';
-    }
+    setMentionQuery(null);
+    if (textareaRef.current) textareaRef.current.style.height = 'auto';
   };
 
-  const handleKeyDown = (e: React.KeyboardEvent) => {
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    // Mention navigation
+    if (mentionQuery !== null && mentionFiles.length > 0) {
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        setMentionIndex((i) => Math.min(i + 1, mentionFiles.length - 1));
+        return;
+      }
+      if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        setMentionIndex((i) => Math.max(i - 1, 0));
+        return;
+      }
+      if (e.key === 'Tab' || e.key === 'Enter') {
+        const selected = mentionFiles[mentionIndex];
+        if (selected) {
+          e.preventDefault();
+          insertMention(selected);
+          return;
+        }
+      }
+      if (e.key === 'Escape') {
+        setMentionQuery(null);
+        return;
+      }
+    }
+
     if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault();
       submit();
     }
   };
 
+  const showDropdown = mentionQuery !== null && mentionFiles.length > 0;
+
   return (
     <div className="border-t border-border bg-surface px-4 py-3">
-      <div className="flex items-end gap-3 bg-[#0f0f0f] border border-border rounded-xl px-4 py-3 focus-within:border-accent/40 transition-colors">
-        <textarea
-          ref={textareaRef}
-          value={text}
-          onChange={(e) => setText(e.target.value)}
-          onKeyDown={handleKeyDown}
-          placeholder={placeholder ?? 'Ask DvalinCode anything…'}
-          disabled={disabled}
-          rows={1}
-          className="flex-1 bg-transparent resize-none outline-none text-fg placeholder-muted-fg text-sm leading-relaxed min-h-[24px] disabled:opacity-50"
-        />
-        {sending ? (
-          <button
-            onClick={onInterrupt}
-            title="Stop generation"
-            className="flex-shrink-0 w-8 h-8 rounded-lg bg-red-500/80 hover:bg-red-500 flex items-center justify-center transition-colors"
-          >
-            <Square size={12} className="text-white fill-white" />
-          </button>
-        ) : (
-          <button
-            onClick={submit}
-            disabled={!text.trim() || disabled}
-            className="flex-shrink-0 w-8 h-8 rounded-lg bg-accent/90 hover:bg-accent disabled:bg-muted/30 disabled:cursor-not-allowed flex items-center justify-center transition-colors"
-          >
-            <Send size={13} className="text-white" />
-          </button>
+      <div className="relative">
+        {/* @mention dropdown */}
+        {showDropdown && (
+          <div className="absolute bottom-full mb-1 left-0 w-full max-w-sm bg-surface border border-border rounded-xl shadow-2xl overflow-hidden z-50">
+            <div className="px-3 py-1.5 border-b border-border flex items-center gap-1.5 text-[11px] text-muted-fg">
+              <File size={10} />
+              <span>Files matching <span className="text-accent font-mono">@{mentionQuery}</span></span>
+            </div>
+            {mentionFiles.map((file, i) => (
+              <button
+                key={file}
+                onMouseDown={(e) => { e.preventDefault(); insertMention(file); }}
+                className={`w-full text-left px-3 py-1.5 text-xs font-mono transition-colors flex items-center gap-2 ${
+                  i === mentionIndex
+                    ? 'bg-accent/10 text-fg'
+                    : 'text-muted-fg hover:bg-[#1a1a1a] hover:text-fg'
+                }`}
+              >
+                <File size={10} className="flex-shrink-0 opacity-60" />
+                {file}
+              </button>
+            ))}
+            <div className="px-3 py-1 border-t border-border text-[10px] text-muted-fg/50">
+              ↑↓ navigate · Tab/Enter select · Esc dismiss
+            </div>
+          </div>
         )}
+
+        <div className="flex items-end gap-3 bg-[#0f0f0f] border border-border rounded-xl px-4 py-3 focus-within:border-accent/40 transition-colors">
+          <textarea
+            ref={textareaRef}
+            value={text}
+            onChange={handleChange}
+            onKeyDown={handleKeyDown}
+            placeholder={placeholder ?? 'Ask DvalinCode anything… (type @ to reference a file)'}
+            disabled={disabled}
+            rows={1}
+            className="flex-1 bg-transparent resize-none outline-none text-fg placeholder-muted-fg text-sm leading-relaxed min-h-[24px] disabled:opacity-50"
+          />
+          {sending ? (
+            <button
+              onClick={onInterrupt}
+              title="Stop generation"
+              className="flex-shrink-0 w-8 h-8 rounded-lg bg-red-500/80 hover:bg-red-500 flex items-center justify-center transition-colors"
+            >
+              <Square size={12} className="text-white fill-white" />
+            </button>
+          ) : (
+            <button
+              onClick={submit}
+              disabled={!text.trim() || disabled}
+              className="flex-shrink-0 w-8 h-8 rounded-lg bg-accent/90 hover:bg-accent disabled:bg-muted/30 disabled:cursor-not-allowed flex items-center justify-center transition-colors"
+            >
+              <Send size={13} className="text-white" />
+            </button>
+          )}
+        </div>
       </div>
       <p className="text-[11px] text-muted-fg mt-2 text-center">
-        Enter to send · Shift+Enter for newline
+        Enter to send · Shift+Enter for newline · @ to reference a file
       </p>
     </div>
   );

--- a/web/src/components/Composer.tsx
+++ b/web/src/components/Composer.tsx
@@ -1,9 +1,10 @@
 import { useState, useRef, useEffect, useCallback } from 'react';
-import { Send, Square, File } from 'lucide-react';
+import { Send, Square, File, Terminal } from 'lucide-react';
 import { fetchFiles } from '../lib/client.ts';
 
 type Props = {
   onSend: (text: string) => void;
+  onClear?: () => void;
   onInterrupt?: () => void;
   disabled?: boolean;
   sending?: boolean;
@@ -11,17 +12,68 @@ type Props = {
   cwd?: string;
 };
 
+/* ── Slash commands ─────────────────────────────────────────────── */
+
+type SlashCommand = {
+  name: string;
+  description: string;
+  icon: React.ReactNode;
+  /** If provided, insert this text; if null, handle via onClear/etc. */
+  insertText: string | null;
+};
+
+const SLASH_COMMANDS: SlashCommand[] = [
+  {
+    name: '/clear',
+    description: 'Clear the current conversation',
+    icon: <Terminal size={11} />,
+    insertText: null, // handled by onClear
+  },
+  {
+    name: '/compact',
+    description: 'Compress conversation context to save tokens',
+    icon: <Terminal size={11} />,
+    insertText: '/compact',
+  },
+  {
+    name: '/git',
+    description: 'Show current git branch, commits, and changed files',
+    icon: <Terminal size={11} />,
+    insertText: '/git',
+  },
+  {
+    name: '/plan',
+    description: 'Ask the agent to plan the task before executing',
+    icon: <Terminal size={11} />,
+    insertText: '/plan',
+  },
+  {
+    name: '/help',
+    description: 'Show available slash commands',
+    icon: <Terminal size={11} />,
+    insertText: '/help',
+  },
+];
+
 const MAX_MENTION_RESULTS = 8;
 
-export function Composer({ onSend, onInterrupt, disabled, sending, placeholder, cwd }: Props) {
+export function Composer({ onSend, onClear, onInterrupt, disabled, sending, placeholder, cwd }: Props) {
   const [text, setText] = useState('');
   const [allFiles, setAllFiles] = useState<string[]>([]);
+
+  // @mention state
   const [mentionQuery, setMentionQuery] = useState<string | null>(null);
   const [mentionFiles, setMentionFiles] = useState<string[]>([]);
   const [mentionIndex, setMentionIndex] = useState(0);
+
+  // slash command state
+  const [slashQuery, setSlashQuery] = useState<string | null>(null);
+  const [slashMatches, setSlashMatches] = useState<SlashCommand[]>([]);
+  const [slashIndex, setSlashIndex] = useState(0);
+
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
-  // Auto-resize textarea
+  // Auto-resize
   useEffect(() => {
     const el = textareaRef.current;
     if (!el) return;
@@ -29,47 +81,59 @@ export function Composer({ onSend, onInterrupt, disabled, sending, placeholder, 
     el.style.height = `${Math.min(el.scrollHeight, 200)}px`;
   }, [text]);
 
-  // Load file list once when cwd changes and @mention is first needed
   const loadFiles = useCallback(async () => {
     if (!cwd || allFiles.length > 0) return;
-    try {
-      const files = await fetchFiles(cwd);
-      setAllFiles(files);
-    } catch {
-      // ignore — file list is optional
-    }
+    try { setAllFiles(await fetchFiles(cwd)); } catch { /* ignore */ }
   }, [cwd, allFiles.length]);
 
-  /** Detect @mention in text up to cursor and return the query string (or null). */
   const detectMention = (value: string, cursorPos: number): string | null => {
+    const match = value.slice(0, cursorPos).match(/@([\w./\-]*)$/);
+    return match ? match[1] : null;
+  };
+
+  const detectSlash = (value: string, cursorPos: number): string | null => {
+    // Only show slash menu when / is at the very start (or after a newline)
     const before = value.slice(0, cursorPos);
-    const match = before.match(/@([\w./\-]*)$/);
+    const match = before.match(/(?:^|\n)(\/[\w]*)$/);
     return match ? match[1] : null;
   };
 
   const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     const val = e.target.value;
     setText(val);
-
     const cursor = e.target.selectionStart ?? val.length;
-    const query = detectMention(val, cursor);
-    if (query !== null) {
-      setMentionQuery(query);
+
+    // @mention detection
+    const mq = detectMention(val, cursor);
+    if (mq !== null) {
+      setMentionQuery(mq);
       const filtered = allFiles
-        .filter((f) => f.toLowerCase().includes(query.toLowerCase()))
+        .filter((f) => f.toLowerCase().includes(mq.toLowerCase()))
         .slice(0, MAX_MENTION_RESULTS);
       setMentionFiles(filtered);
       setMentionIndex(0);
+      setSlashQuery(null);
       if (allFiles.length === 0) void loadFiles();
-    } else {
-      setMentionQuery(null);
+      return;
     }
+    setMentionQuery(null);
+
+    // slash command detection
+    const sq = detectSlash(val, cursor);
+    if (sq !== null) {
+      setSlashQuery(sq);
+      const q = sq.slice(1).toLowerCase();
+      setSlashMatches(SLASH_COMMANDS.filter((c) => c.name.slice(1).startsWith(q)));
+      setSlashIndex(0);
+      return;
+    }
+    setSlashQuery(null);
   };
 
   const insertMention = (file: string) => {
-    const textarea = textareaRef.current;
-    if (!textarea) return;
-    const cursor = textarea.selectionStart ?? text.length;
+    const ta = textareaRef.current;
+    if (!ta) return;
+    const cursor = ta.selectionStart ?? text.length;
     const before = text.slice(0, cursor);
     const after = text.slice(cursor);
     const match = before.match(/@([\w./\-]*)$/);
@@ -77,12 +141,36 @@ export function Composer({ onSend, onInterrupt, disabled, sending, placeholder, 
     const newBefore = before.slice(0, before.length - match[0].length) + `@${file}`;
     setText(newBefore + after);
     setMentionQuery(null);
-    // Restore focus and position cursor after the inserted mention
     setTimeout(() => {
-      textarea.focus();
-      const pos = newBefore.length;
-      textarea.setSelectionRange(pos, pos);
+      ta.focus();
+      ta.setSelectionRange(newBefore.length, newBefore.length);
     }, 0);
+  };
+
+  const applySlashCommand = (cmd: SlashCommand) => {
+    setSlashQuery(null);
+    setSlashMatches([]);
+    if (cmd.name === '/clear') {
+      setText('');
+      onClear?.();
+      return;
+    }
+    if (cmd.insertText !== null) {
+      // Replace the /... text with the command
+      const ta = textareaRef.current;
+      if (!ta) return;
+      const cursor = ta.selectionStart ?? text.length;
+      const before = text.slice(0, cursor);
+      const after = text.slice(cursor);
+      const match = before.match(/(?:^|\n)(\/[\w]*)$/);
+      if (!match) return;
+      const newBefore = before.slice(0, before.length - match[1].length) + cmd.insertText + ' ';
+      setText(newBefore + after);
+      setTimeout(() => {
+        ta.focus();
+        ta.setSelectionRange(newBefore.length, newBefore.length);
+      }, 0);
+    }
   };
 
   const submit = () => {
@@ -91,34 +179,25 @@ export function Composer({ onSend, onInterrupt, disabled, sending, placeholder, 
     onSend(trimmed);
     setText('');
     setMentionQuery(null);
+    setSlashQuery(null);
     if (textareaRef.current) textareaRef.current.style.height = 'auto';
   };
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-    // Mention navigation
+    // @mention navigation
     if (mentionQuery !== null && mentionFiles.length > 0) {
-      if (e.key === 'ArrowDown') {
-        e.preventDefault();
-        setMentionIndex((i) => Math.min(i + 1, mentionFiles.length - 1));
-        return;
-      }
-      if (e.key === 'ArrowUp') {
-        e.preventDefault();
-        setMentionIndex((i) => Math.max(i - 1, 0));
-        return;
-      }
-      if (e.key === 'Tab' || e.key === 'Enter') {
-        const selected = mentionFiles[mentionIndex];
-        if (selected) {
-          e.preventDefault();
-          insertMention(selected);
-          return;
-        }
-      }
-      if (e.key === 'Escape') {
-        setMentionQuery(null);
-        return;
-      }
+      if (e.key === 'ArrowDown') { e.preventDefault(); setMentionIndex((i) => Math.min(i + 1, mentionFiles.length - 1)); return; }
+      if (e.key === 'ArrowUp')   { e.preventDefault(); setMentionIndex((i) => Math.max(i - 1, 0)); return; }
+      if ((e.key === 'Tab' || e.key === 'Enter') && mentionFiles[mentionIndex]) { e.preventDefault(); insertMention(mentionFiles[mentionIndex]); return; }
+      if (e.key === 'Escape') { setMentionQuery(null); return; }
+    }
+
+    // slash command navigation
+    if (slashQuery !== null && slashMatches.length > 0) {
+      if (e.key === 'ArrowDown') { e.preventDefault(); setSlashIndex((i) => Math.min(i + 1, slashMatches.length - 1)); return; }
+      if (e.key === 'ArrowUp')   { e.preventDefault(); setSlashIndex((i) => Math.max(i - 1, 0)); return; }
+      if ((e.key === 'Tab' || e.key === 'Enter') && slashMatches[slashIndex]) { e.preventDefault(); applySlashCommand(slashMatches[slashIndex]); return; }
+      if (e.key === 'Escape') { setSlashQuery(null); return; }
     }
 
     if (e.key === 'Enter' && !e.shiftKey) {
@@ -127,13 +206,14 @@ export function Composer({ onSend, onInterrupt, disabled, sending, placeholder, 
     }
   };
 
-  const showDropdown = mentionQuery !== null && mentionFiles.length > 0;
+  const showMentionDropdown = mentionQuery !== null && mentionFiles.length > 0;
+  const showSlashDropdown   = slashQuery !== null && slashMatches.length > 0;
 
   return (
     <div className="border-t border-border bg-surface px-4 py-3">
       <div className="relative">
         {/* @mention dropdown */}
-        {showDropdown && (
+        {showMentionDropdown && (
           <div className="absolute bottom-full mb-1 left-0 w-full max-w-sm bg-surface border border-border rounded-xl shadow-2xl overflow-hidden z-50">
             <div className="px-3 py-1.5 border-b border-border flex items-center gap-1.5 text-[11px] text-muted-fg">
               <File size={10} />
@@ -144,18 +224,40 @@ export function Composer({ onSend, onInterrupt, disabled, sending, placeholder, 
                 key={file}
                 onMouseDown={(e) => { e.preventDefault(); insertMention(file); }}
                 className={`w-full text-left px-3 py-1.5 text-xs font-mono transition-colors flex items-center gap-2 ${
-                  i === mentionIndex
-                    ? 'bg-accent/10 text-fg'
-                    : 'text-muted-fg hover:bg-[#1a1a1a] hover:text-fg'
+                  i === mentionIndex ? 'bg-accent/10 text-fg' : 'text-muted-fg hover:bg-[#1a1a1a] hover:text-fg'
                 }`}
               >
                 <File size={10} className="flex-shrink-0 opacity-60" />
                 {file}
               </button>
             ))}
-            <div className="px-3 py-1 border-t border-border text-[10px] text-muted-fg/50">
-              ↑↓ navigate · Tab/Enter select · Esc dismiss
+            <div className="px-3 py-1 border-t border-border text-[10px] text-muted-fg/50">↑↓ navigate · Tab/Enter select · Esc dismiss</div>
+          </div>
+        )}
+
+        {/* Slash command dropdown */}
+        {showSlashDropdown && (
+          <div className="absolute bottom-full mb-1 left-0 w-72 bg-surface border border-border rounded-xl shadow-2xl overflow-hidden z-50">
+            <div className="px-3 py-1.5 border-b border-border text-[11px] text-muted-fg flex items-center gap-1.5">
+              <Terminal size={10} />
+              Commands
             </div>
+            {slashMatches.map((cmd, i) => (
+              <button
+                key={cmd.name}
+                onMouseDown={(e) => { e.preventDefault(); applySlashCommand(cmd); }}
+                className={`w-full text-left px-3 py-2 text-xs transition-colors flex items-start gap-2.5 ${
+                  i === slashIndex ? 'bg-accent/10 text-fg' : 'text-muted-fg hover:bg-[#1a1a1a] hover:text-fg'
+                }`}
+              >
+                <span className="mt-0.5 opacity-60">{cmd.icon}</span>
+                <div>
+                  <div className="font-mono font-medium">{cmd.name}</div>
+                  <div className="text-[11px] opacity-70 mt-0.5">{cmd.description}</div>
+                </div>
+              </button>
+            ))}
+            <div className="px-3 py-1 border-t border-border text-[10px] text-muted-fg/50">↑↓ navigate · Tab/Enter select · Esc dismiss</div>
           </div>
         )}
 
@@ -165,7 +267,7 @@ export function Composer({ onSend, onInterrupt, disabled, sending, placeholder, 
             value={text}
             onChange={handleChange}
             onKeyDown={handleKeyDown}
-            placeholder={placeholder ?? 'Ask DvalinCode anything… (type @ to reference a file)'}
+            placeholder={placeholder ?? 'Ask DvalinCode… ( / for commands · @ for files )'}
             disabled={disabled}
             rows={1}
             className="flex-1 bg-transparent resize-none outline-none text-fg placeholder-muted-fg text-sm leading-relaxed min-h-[24px] disabled:opacity-50"
@@ -190,7 +292,7 @@ export function Composer({ onSend, onInterrupt, disabled, sending, placeholder, 
         </div>
       </div>
       <p className="text-[11px] text-muted-fg mt-2 text-center">
-        Enter to send · Shift+Enter for newline · @ to reference a file
+        Enter to send · Shift+Enter for newline · <span className="font-mono">/</span> commands · <span className="font-mono">@</span> files
       </p>
     </div>
   );

--- a/web/src/components/DiffViewer.tsx
+++ b/web/src/components/DiffViewer.tsx
@@ -1,0 +1,95 @@
+import { useState } from 'react';
+import { ChevronDown, ChevronUp } from 'lucide-react';
+import type { DiffLine } from '../types.ts';
+
+type Props = {
+  diff: DiffLine[];
+  filePath?: string;
+};
+
+const CONTEXT_LINES = 3;
+const COLLAPSE_THRESHOLD = 12;
+
+/** Return only changed lines ± CONTEXT_LINES neighbours for the compact view. */
+function compactDiff(diff: DiffLine[]): { lines: DiffLine[]; truncated: boolean } {
+  if (diff.length <= COLLAPSE_THRESHOLD) return { lines: diff, truncated: false };
+
+  const changedIdx = new Set<number>();
+  diff.forEach((l, i) => { if (l.type !== 'keep') changedIdx.add(i); });
+
+  const visible = new Set<number>();
+  changedIdx.forEach((i) => {
+    for (let j = Math.max(0, i - CONTEXT_LINES); j <= Math.min(diff.length - 1, i + CONTEXT_LINES); j++) {
+      visible.add(j);
+    }
+  });
+
+  return {
+    lines: [...visible].sort((a, b) => a - b).map((i) => diff[i]),
+    truncated: visible.size < diff.length,
+  };
+}
+
+function DiffLineRow({ line }: { line: DiffLine }) {
+  const bg =
+    line.type === 'add'
+      ? 'bg-emerald-500/10 text-emerald-300'
+      : line.type === 'remove'
+      ? 'bg-red-500/10 text-red-400'
+      : 'text-muted-fg/70';
+
+  const prefix = line.type === 'add' ? '+' : line.type === 'remove' ? '-' : ' ';
+
+  return (
+    <div className={`flex gap-2 px-3 py-0.5 leading-5 ${bg}`}>
+      <span className="select-none w-3 flex-shrink-0 opacity-60">{prefix}</span>
+      <span className="break-all whitespace-pre-wrap">{line.content}</span>
+    </div>
+  );
+}
+
+export function DiffViewer({ diff, filePath }: Props) {
+  const [expanded, setExpanded] = useState(false);
+
+  if (diff.length === 0) return null;
+
+  const { lines, truncated } = expanded ? { lines: diff, truncated: false } : compactDiff(diff);
+  const addCount = diff.filter((l) => l.type === 'add').length;
+  const removeCount = diff.filter((l) => l.type === 'remove').length;
+
+  return (
+    <div className="rounded border border-border overflow-hidden text-xs font-mono mt-1.5">
+      {/* Header */}
+      <div className="flex items-center justify-between px-3 py-1.5 bg-[#0d0d0d] border-b border-border">
+        <div className="flex items-center gap-2 min-w-0">
+          {filePath && (
+            <span className="text-muted-fg truncate">{filePath}</span>
+          )}
+          <span className="text-emerald-400 flex-shrink-0">+{addCount}</span>
+          <span className="text-red-400 flex-shrink-0">-{removeCount}</span>
+        </div>
+        {(truncated || expanded) && (
+          <button
+            onClick={() => setExpanded((v) => !v)}
+            className="flex items-center gap-1 text-muted-fg hover:text-fg transition-colors flex-shrink-0 ml-2"
+          >
+            {expanded ? <ChevronUp size={11} /> : <ChevronDown size={11} />}
+            {expanded ? 'collapse' : `show all ${diff.length} lines`}
+          </button>
+        )}
+      </div>
+
+      {/* Diff lines */}
+      <div className="overflow-x-auto bg-[#080808]">
+        {lines.map((line, i) => (
+          <DiffLineRow key={i} line={line} />
+        ))}
+        {truncated && (
+          <div className="px-3 py-1 text-muted-fg/50 italic">
+            … {diff.length - lines.length} more lines hidden
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/MessageBubble.tsx
+++ b/web/src/components/MessageBubble.tsx
@@ -1,5 +1,6 @@
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
+import rehypeHighlight from 'rehype-highlight';
 import { AgentActivity } from './AgentActivity.tsx';
 import type { ChatMessage } from '../types.ts';
 
@@ -51,7 +52,12 @@ export function MessageBubble({ message }: { message: ChatMessage }) {
           <ThinkingDots />
         ) : content ? (
           <div className="prose text-sm">
-            <ReactMarkdown remarkPlugins={[remarkGfm]}>{content}</ReactMarkdown>
+            <ReactMarkdown
+              remarkPlugins={[remarkGfm]}
+              rehypePlugins={[rehypeHighlight]}
+            >
+              {content}
+            </ReactMarkdown>
           </div>
         ) : null}
       </div>

--- a/web/src/components/ModeSwitcher.tsx
+++ b/web/src/components/ModeSwitcher.tsx
@@ -1,0 +1,62 @@
+import { MessageCircle, Users, Zap, type LucideIcon } from 'lucide-react';
+import type { AgentMode } from '../types.ts';
+
+type Props = {
+  value: AgentMode;
+  onChange: (mode: AgentMode) => void;
+};
+
+const MODES: {
+  value: AgentMode;
+  label: string;
+  Icon: LucideIcon;
+  color: string;
+  title: string;
+}[] = [
+  {
+    value: 'chat',
+    label: 'Chat',
+    Icon: MessageCircle,
+    color: 'text-blue-400',
+    title: 'Chat — Q&A only, no file changes',
+  },
+  {
+    value: 'cowork',
+    label: 'Cowork',
+    Icon: Users,
+    color: 'text-violet-400',
+    title: 'Cowork — explain plan then execute, writes need approval',
+  },
+  {
+    value: 'code',
+    label: 'Code',
+    Icon: Zap,
+    color: 'text-orange-400',
+    title: 'Code — autonomous agent, full tool access',
+  },
+];
+
+export function ModeSwitcher({ value, onChange }: Props) {
+  return (
+    <div className="flex items-center bg-[#111] border border-border rounded-lg p-0.5 gap-0.5">
+      {MODES.map((mode) => {
+        const active = value === mode.value;
+        return (
+          <button
+            key={mode.value}
+            onClick={() => onChange(mode.value)}
+            title={mode.title}
+            className={`flex items-center gap-1.5 px-2.5 py-1 rounded-md text-[11px] font-medium transition-all ${
+              active
+                ? `${mode.color} bg-[#1a1a1a] border border-border shadow-sm`
+                : 'text-muted-fg hover:text-fg'
+            }`}
+          >
+            <mode.Icon size={11} />
+            {mode.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/web/src/components/ModeSwitcher.tsx
+++ b/web/src/components/ModeSwitcher.tsx
@@ -4,6 +4,8 @@ import type { AgentMode } from '../types.ts';
 type Props = {
   value: AgentMode;
   onChange: (mode: AgentMode) => void;
+  /** When true, fills the parent width with equal-width tabs */
+  fullWidth?: boolean;
 };
 
 const MODES: {
@@ -11,6 +13,7 @@ const MODES: {
   label: string;
   Icon: LucideIcon;
   color: string;
+  activeBg: string;
   title: string;
 }[] = [
   {
@@ -18,6 +21,7 @@ const MODES: {
     label: 'Chat',
     Icon: MessageCircle,
     color: 'text-blue-400',
+    activeBg: 'bg-blue-500/10 border-blue-500/25',
     title: 'Chat — Q&A only, no file changes',
   },
   {
@@ -25,6 +29,7 @@ const MODES: {
     label: 'Cowork',
     Icon: Users,
     color: 'text-violet-400',
+    activeBg: 'bg-violet-500/10 border-violet-500/25',
     title: 'Cowork — explain plan then execute, writes need approval',
   },
   {
@@ -32,11 +37,40 @@ const MODES: {
     label: 'Code',
     Icon: Zap,
     color: 'text-orange-400',
+    activeBg: 'bg-orange-500/10 border-orange-500/25',
     title: 'Code — autonomous agent, full tool access',
   },
 ];
 
-export function ModeSwitcher({ value, onChange }: Props) {
+export function ModeSwitcher({ value, onChange, fullWidth }: Props) {
+  if (fullWidth) {
+    return (
+      <div className="flex w-full rounded-lg overflow-hidden border border-border">
+        {MODES.map((mode, i) => {
+          const active = value === mode.value;
+          return (
+            <button
+              key={mode.value}
+              onClick={() => onChange(mode.value)}
+              title={mode.title}
+              className={[
+                'flex-1 flex items-center justify-center gap-1.5 py-2 text-[11px] font-medium transition-all',
+                i > 0 ? 'border-l border-border' : '',
+                active
+                  ? `${mode.color} ${mode.activeBg}`
+                  : 'text-muted-fg hover:text-fg hover:bg-[#1a1a1a]',
+              ].join(' ')}
+            >
+              <mode.Icon size={12} />
+              {mode.label}
+            </button>
+          );
+        })}
+      </div>
+    );
+  }
+
+  /* Compact inline variant (kept for potential reuse) */
   return (
     <div className="flex items-center bg-[#111] border border-border rounded-lg p-0.5 gap-0.5">
       {MODES.map((mode) => {

--- a/web/src/components/Sidebar.tsx
+++ b/web/src/components/Sidebar.tsx
@@ -1,7 +1,9 @@
 import { useEffect, useState } from 'react';
 import { Plus, Trash2, MessageSquare, ChevronLeft, ChevronRight, Settings2 } from 'lucide-react';
 import { fetchSessions, deleteSession } from '../lib/client.ts';
+import { ModeSwitcher } from './ModeSwitcher.tsx';
 import type { SessionMeta } from '../types.ts';
+import type { AgentMode } from '../types.ts';
 
 function timeAgo(iso: string): string {
   const diff = Date.now() - new Date(iso).getTime();
@@ -19,9 +21,19 @@ type Props = {
   onSelectSession: (id: string) => void;
   onOpenConfig: () => void;
   refreshKey?: number;
+  mode: AgentMode;
+  onModeChange: (m: AgentMode) => void;
 };
 
-export function Sidebar({ currentSessionId, onNewChat, onSelectSession, onOpenConfig, refreshKey }: Props) {
+export function Sidebar({
+  currentSessionId,
+  onNewChat,
+  onSelectSession,
+  onOpenConfig,
+  refreshKey,
+  mode,
+  onModeChange,
+}: Props) {
   const [sessions, setSessions] = useState<SessionMeta[]>([]);
   const [collapsed, setCollapsed] = useState(false);
 
@@ -45,6 +57,7 @@ export function Sidebar({ currentSessionId, onNewChat, onSelectSession, onOpenCo
     if (id === currentSessionId) onNewChat();
   };
 
+  /* ── Collapsed state ─────────────────────────────────────────── */
   if (collapsed) {
     return (
       <div className="flex flex-col items-center w-12 h-full bg-surface border-r border-border py-3 gap-3 flex-shrink-0">
@@ -74,6 +87,7 @@ export function Sidebar({ currentSessionId, onNewChat, onSelectSession, onOpenCo
     );
   }
 
+  /* ── Expanded state ──────────────────────────────────────────── */
   return (
     <div className="flex flex-col w-60 h-full bg-surface border-r border-border flex-shrink-0">
       {/* Header */}
@@ -88,6 +102,11 @@ export function Sidebar({ currentSessionId, onNewChat, onSelectSession, onOpenCo
         >
           <ChevronLeft size={14} />
         </button>
+      </div>
+
+      {/* Mode switcher — top-left, full width */}
+      <div className="px-3 py-2 border-b border-border">
+        <ModeSwitcher value={mode} onChange={onModeChange} fullWidth />
       </div>
 
       {/* New chat button */}
@@ -108,10 +127,13 @@ export function Sidebar({ currentSessionId, onNewChat, onSelectSession, onOpenCo
         ) : (
           <div className="flex flex-col gap-0.5">
             {sessions.map((s) => (
-              <button
+              <div
                 key={s.id}
+                role="button"
+                tabIndex={0}
                 onClick={() => onSelectSession(s.id)}
-                className={`group w-full text-left px-3 py-2 rounded-lg transition-colors flex items-start gap-2 ${
+                onKeyDown={(e) => e.key === 'Enter' && onSelectSession(s.id)}
+                className={`group w-full text-left px-3 py-2 rounded-lg transition-colors flex items-start gap-2 cursor-pointer ${
                   s.id === currentSessionId
                     ? 'bg-accent/10 border border-accent/20 text-fg'
                     : 'hover:bg-[#1a1a1a] text-muted-fg hover:text-fg border border-transparent'
@@ -134,7 +156,7 @@ export function Sidebar({ currentSessionId, onNewChat, onSelectSession, onOpenCo
                 >
                   <Trash2 size={12} />
                 </button>
-              </button>
+              </div>
             ))}
           </div>
         )}

--- a/web/src/hooks/useChat.ts
+++ b/web/src/hooks/useChat.ts
@@ -1,11 +1,12 @@
 import { useState, useCallback, useRef } from 'react';
 import { client, fetchSessionDetail } from '../lib/client.ts';
-import type { ChatMessage, ToolCallEvent, ServerEvent, BackendChatMessage, ApprovalMode, PendingApproval } from '../types.ts';
+import type { ChatMessage, ToolCallEvent, ServerEvent, BackendChatMessage, ApprovalMode, AgentMode, PendingApproval } from '../types.ts';
 
 export type UseChatOptions = {
   sessionId?: string;
   cwd?: string;
   approvalMode?: ApprovalMode;
+  mode?: AgentMode;
 };
 
 export type UsageStats = {
@@ -234,6 +235,7 @@ export function useChat(opts: UseChatOptions = {}) {
           sessionId: currentSessionId,
           cwd: opts.cwd,
           approvalMode: opts.approvalMode,
+          mode: opts.mode,
         });
       } catch (err) {
         setMessages((prev) => [

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -101,3 +101,21 @@ body {
 }
 .prose th { background: #111; color: #aaa; font-weight: 500; }
 .prose hr { border: none; border-top: 1px solid #222; margin: 1em 0; }
+
+/* ── Syntax highlighting (highlight.js dark theme overrides) ── */
+.hljs { background: transparent; color: #e5e5e5; }
+.hljs-comment, .hljs-quote            { color: #6a737d; font-style: italic; }
+.hljs-keyword, .hljs-selector-tag,
+.hljs-built_in, .hljs-name            { color: #ff7b72; }
+.hljs-string, .hljs-attr,
+.hljs-selector-attr                   { color: #a5d6ff; }
+.hljs-number, .hljs-literal,
+.hljs-regexp                          { color: #79c0ff; }
+.hljs-title, .hljs-section,
+.hljs-type                            { color: #d2a8ff; }
+.hljs-variable, .hljs-template-variable { color: #ffa657; }
+.hljs-meta                            { color: #e3b341; }
+.hljs-addition                        { color: #aff5b4; background: #033a16; }
+.hljs-deletion                        { color: #ffdcd7; background: #67060c; }
+.hljs-emphasis                        { font-style: italic; }
+.hljs-strong                          { font-weight: bold; }

--- a/web/src/lib/client.ts
+++ b/web/src/lib/client.ts
@@ -1,4 +1,4 @@
-import type { ServerEvent, SessionMeta, AppConfig, BackendChatMessage, ApprovalMode } from '../types.ts';
+import type { ServerEvent, SessionMeta, AppConfig, BackendChatMessage, ApprovalMode, AgentMode } from '../types.ts';
 
 const WS_URL = `${location.protocol === 'https:' ? 'wss' : 'ws'}://${location.host}/ws`;
 
@@ -7,6 +7,7 @@ export type SendOptions = {
   sessionId?: string;
   cwd?: string;
   approvalMode?: ApprovalMode;
+  mode?: AgentMode;
   provider?: string;
 };
 
@@ -63,7 +64,8 @@ export class DvalinClient {
         content: opts.content,
         sessionId: opts.sessionId,
         cwd: opts.cwd,
-        approvalMode: opts.approvalMode ?? 'readonly',
+        approvalMode: opts.approvalMode,
+        mode: opts.mode ?? 'code',
         provider: opts.provider,
       }),
     );
@@ -132,4 +134,10 @@ export async function fetchSessionDetail(id: string): Promise<SessionDetail> {
   const res = await fetch(`/api/sessions/${id}`);
   if (!res.ok) throw new Error(`HTTP ${res.status}`);
   return res.json() as Promise<SessionDetail>;
+}
+
+export async function fetchFiles(cwd: string): Promise<string[]> {
+  const res = await fetch(`/api/files?cwd=${encodeURIComponent(cwd)}`);
+  if (!res.ok) return [];
+  return res.json() as Promise<string[]>;
 }

--- a/web/src/lib/client.ts
+++ b/web/src/lib/client.ts
@@ -141,3 +141,15 @@ export async function fetchFiles(cwd: string): Promise<string[]> {
   if (!res.ok) return [];
   return res.json() as Promise<string[]>;
 }
+
+export type GitInfo = { branch: string | null; lastCommit: string | null };
+
+export async function fetchGitInfo(cwd: string): Promise<GitInfo> {
+  try {
+    const res = await fetch(`/api/git?cwd=${encodeURIComponent(cwd)}`);
+    if (!res.ok) return { branch: null, lastCommit: null };
+    return res.json() as Promise<GitInfo>;
+  } catch {
+    return { branch: null, lastCommit: null };
+  }
+}

--- a/web/src/lib/pricing.ts
+++ b/web/src/lib/pricing.ts
@@ -1,0 +1,51 @@
+/** Token pricing in USD per 1M tokens. */
+type ModelPricing = { input: number; output: number };
+
+/** Hardcoded defaults for common providers/models. */
+const PRICING_TABLE: Record<string, ModelPricing> = {
+  // DeepSeek
+  'deepseek-chat':     { input: 0.14,  output: 0.28  },
+  'deepseek-coder':    { input: 0.14,  output: 0.28  },
+  'deepseek-reasoner': { input: 0.55,  output: 2.19  },
+
+  // OpenAI
+  'gpt-4o':            { input: 2.50,  output: 10.00 },
+  'gpt-4o-mini':       { input: 0.15,  output: 0.60  },
+  'o1':                { input: 15.00, output: 60.00 },
+  'o3-mini':           { input: 1.10,  output: 4.40  },
+
+  // Groq (free tier, show $0)
+  'llama-3.3-70b-versatile': { input: 0.00, output: 0.00 },
+  'llama-3.1-8b-instant':    { input: 0.00, output: 0.00 },
+  'mixtral-8x7b-32768':      { input: 0.00, output: 0.00 },
+
+  // OpenRouter (approximate)
+  'anthropic/claude-3.5-sonnet': { input: 3.00,  output: 15.00 },
+  'google/gemini-2.0-flash-001': { input: 0.10,  output: 0.40  },
+};
+
+/** Fallback for unknown models — conservative estimate. */
+const DEFAULT_PRICING: ModelPricing = { input: 1.00, output: 3.00 };
+
+export function getPricing(model: string): ModelPricing {
+  if (PRICING_TABLE[model]) return PRICING_TABLE[model];
+  // Partial match — e.g. "deepseek-chat-v3" → use "deepseek-chat" pricing
+  const key = Object.keys(PRICING_TABLE).find((k) => model.startsWith(k) || k.startsWith(model));
+  return key ? PRICING_TABLE[key] : DEFAULT_PRICING;
+}
+
+export function estimateCost(
+  inputTokens: number,
+  outputTokens: number,
+  model: string,
+): number {
+  const p = getPricing(model);
+  return (inputTokens * p.input + outputTokens * p.output) / 1_000_000;
+}
+
+export function formatCost(usd: number): string {
+  if (usd === 0) return '$0';
+  if (usd < 0.0001) return '<$0.0001';
+  if (usd < 0.01)   return `$${usd.toFixed(4)}`;
+  return `$${usd.toFixed(3)}`;
+}

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -49,6 +49,9 @@ export type ChatMessage =
     };
 
 export type ApprovalMode = 'readonly' | 'auto-edit' | 'full-auto';
+export type AgentMode = 'chat' | 'cowork' | 'code';
+
+export type DiffLine = { type: 'add' | 'remove' | 'keep'; content: string };
 
 export type PendingApproval = {
   id: string;

--- a/web/tailwind.config.js
+++ b/web/tailwind.config.js
@@ -25,12 +25,17 @@ export default {
           '0%, 80%, 100%': { transform: 'scale(0.6)', opacity: '0.4' },
           '40%': { transform: 'scale(1)', opacity: '1' },
         },
+        'slide-up': {
+          from: { opacity: '0', transform: 'translateY(12px)' },
+          to: { opacity: '1', transform: 'translateY(0)' },
+        },
       },
       animation: {
         'fade-in': 'fade-in 0.15s ease-out',
         'dot-1': 'dot-bounce 1.2s infinite 0ms',
         'dot-2': 'dot-bounce 1.2s infinite 150ms',
         'dot-3': 'dot-bounce 1.2s infinite 300ms',
+        'slide-up': 'slide-up 0.2s ease-out',
       },
     },
   },

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -5,10 +5,11 @@ export default defineConfig({
   plugins: [react()],
   server: {
     port: 5173,
+    open: true,
     proxy: {
-      '/api': 'http://localhost:3000',
+      '/api': 'http://localhost:3001',
       '/ws': {
-        target: 'ws://localhost:3000',
+        target: 'ws://localhost:3001',
         ws: true,
       },
     },

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -3,6 +3,17 @@ import react from '@vitejs/plugin-react';
 
 export default defineConfig({
   plugins: [react()],
+  build: {
+    rollupOptions: {
+      output: {
+        manualChunks: {
+          'vendor-react': ['react', 'react-dom'],
+          'vendor-highlight': ['highlight.js'],
+          'vendor-markdown': ['react-markdown', 'remark-gfm', 'rehype-highlight'],
+        },
+      },
+    },
+  },
   server: {
     port: 5173,
     open: true,


### PR DESCRIPTION
## 完整功能列表（4 个 Sprint）

### Sprint 1 — 基础三功能
| # | 功能 | 说明 |
|---|---|---|
| 1 | **Mode Switcher** | Chat/Cowork/Code 三模式，后端工具集过滤 + 专属系统 prompt |
| 2 | **Diff Viewer** | write/edit_file 结果显示红绿高亮 diff，默认折叠 |
| 3 | **@ 文件引用** | Composer 输入 @ 触发文件下拉，后端展开为 \`<file>\` 内容 |

### Sprint 2 — Code 模式增强
| # | 功能 | 说明 |
|---|---|---|
| 4 | **代码高亮** | rehype-highlight 语法高亮；主 bundle 530KB→50KB（分包） |
| 5 | **Git 感知** | git_status 工具 + /api/git + 顶栏分支显示 + 系统 prompt 注入 |
| 6 | **AGENTS.md 项目记忆** | 每次对话前读取 AGENTS.md 并注入系统 prompt |

### Sprint 3 — UX 打磨
| # | 功能 | 说明 |
|---|---|---|
| 7 | **ModeSwitcher 左上角** | 侧边栏全宽分段 tab；修复 button-in-button 嵌套警告 |
| 8 | **斜杠命令** | `/clear` `/compact` `/git` `/plan` `/help` `/undo`；输入 / 触发下拉 |
| 9 | **Token 费用估算** | 按模型单价实时计算，顶栏显示 `1,234 tok · $0.003` |

### Sprint 4 — 全量剩余需求
| # | 功能 | 说明 |
|---|---|---|
| 10 | **Plan 模式** | Cowork 模式下自动检测计划，渲染 PlanCard + "Proceed" 按钮 |
| 11 | **审批对话框升级** | edit_file 显示 diff；write_file 内容预览；delete 红色警告；shell 终端格式 |
| 12 | **LLM 上下文压缩** | /compact 真正调 LLM 生成结构化摘要（Goal/Completed/Decisions/Pending） |
| 13 | **/undo 命令** | 持久化 undoStack 跨轮次；/undo N 撤销最近 N 个工具调用 |
| 14 | **Shell 沙箱** | macOS sandbox-exec 内联 profile：拒绝网络，仅允许 cwd+/tmp 写入 |
| 15 | **多 Profile 配置** | LLMConfigModal 内 Profile 管理：保存/应用/删除；/api/config/profiles CRUD |
| 16 | **.dvalincodeignore** | 类 .gitignore 的敏感文件排除；listFiles/searchText/readFile 全部尊重 |
| 17 | **任务进度追踪** | 顶栏实时显示当前 session 已调用工具数 |

---

## 测试结果

```
Test Files  9 passed (9)
Tests      47 passed (47)
```

TypeScript: ✅ backend clean · ✅ frontend clean  
Build: ✅ vite production build 成功

---

## 关键变更文件

| 类别 | 文件 |
|---|---|
| Agent 核心 | loop.ts, runner.ts, types.ts |
| 工具集 | shell.ts, listFiles.ts, readFile.ts, searchText.ts, gitStatus.ts |
| 服务端路由 | config.ts, files.ts, git.ts |
| 配置存储 | configStore.ts |
| 前端组件 | ModeSwitcher, DiffViewer, PlanCard, ApprovalDialog, MessageBubble, ChatThread, Composer, Sidebar, LLMConfigModal |
| 前端状态 | App.tsx, useChat.ts, client.ts, pricing.ts, types.ts |
| 新增文件 | ignorefile.ts, PlanCard.tsx, DiffViewer.tsx, ModeSwitcher.tsx, gitStatus.ts, files.ts, git.ts, pricing.ts |

## Test Plan
- [ ] Chat/Cowork/Code 切换，顶栏工具数、费用更新
- [ ] Chat 模式无法调用 write_file / shell
- [ ] Cowork 模式文件写入前弹出审批 → 显示 diff
- [ ] Cowork 模式 ≥3 步数字列表 → 显示 PlanCard + Proceed 按钮
- [ ] Code 模式 edit_file → AgentActivity 显示 DiffViewer
- [ ] 输入 @ → 文件下拉；输入 / → 命令下拉
- [ ] /undo 撤销最近工具调用；/compact 调 LLM 压缩对话
- [ ] 在 cwd 放 AGENTS.md → system prompt 包含内容
- [ ] 在 cwd 放 .dvalincodeignore → agent 无法读取被忽略的文件
- [ ] LLMConfigModal → 保存 profile → 应用 profile → 主配置更新
- [ ] `npm run dev:all` 一键启动前后端（http://localhost:5173）

🤖 Generated with [Claude Code](https://claude.com/claude-code)