### PR TITLE
feat: Sprint 4 — Plan mode, Approval diff, Undo, LLM compact, Sandbox…

### DIFF
--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -1,4 +1,4 @@
-import { TurnState, type TurnConfig, type LoopResult, type SlashCommand, type AgentEventHandler, DEFAULT_TURN_CONFIG } from './types.js';
+import { TurnState, type TurnConfig, type LoopResult, type SlashCommand, type AgentEventHandler, DEFAULT_TURN_CONFIG, type UndoEntry } from './types.js';
 import { AgentRunner } from './runner.js';
 import type { ChatMessage } from '../providers/types.js';
 import type { ProviderAdapter } from '../providers/types.js';
@@ -21,6 +21,7 @@ export class AgentLoop {
   private systemPrompt: string;
   private config: TurnConfig;
   private slashCommands: Map<string, SlashCommand>;
+  private sharedUndoStack: UndoEntry[] = [];
 
   constructor(options: AgentLoopOptions) {
     this.provider = options.provider;
@@ -37,8 +38,26 @@ export class AgentLoop {
     // Register built-in commands
     this.slashCommands.set('compact', {
       name: 'compact',
-      description: 'Compress conversation context',
-      handler: (_args, messages) => this.handleCompact(messages),
+      description: 'Compress conversation context using LLM summarization',
+      handler: async (_args, messages) => this.handleCompact(messages),
+    });
+    this.slashCommands.set('undo', {
+      name: 'undo',
+      description: 'Undo the last N tool calls (default: 1)',
+      handler: async (args, messages) => {
+        const count = parseInt(args.trim(), 10);
+        const n = Number.isFinite(count) && count > 0 ? count : 1;
+        const runner = new AgentRunner({
+          provider: this.provider,
+          registry: this.registry,
+          context: this.context,
+          config: this.config,
+          systemPrompt: this.systemPrompt,
+          sharedUndoStack: this.sharedUndoStack,
+        });
+        const undoOutput = await runner.undoLast(n);
+        return { messages, output: undoOutput };
+      },
     });
     this.slashCommands.set('help', {
       name: 'help',
@@ -52,6 +71,7 @@ export class AgentLoop {
           '|---------|-------------|',
           '| `/clear` | Clear conversation (client-side) |',
           '| `/compact` | Compress context to save tokens |',
+          '| `/undo [N]` | Undo the last N tool calls (default: 1) |',
           '| `/git` | Show git branch, commits, changed files |',
           '| `/plan` | Plan the task before executing |',
           '| `/help` | Show this help |',
@@ -95,15 +115,8 @@ export class AgentLoop {
         }
 
         case TurnState.COMPACT: {
-          // TODO: implement context compression using LLM summarization
-          // For now, slice older messages if too many
-          if (messages.length > 50) {
-            const keep = messages.slice(-40);
-            messages = [
-              { role: 'system', content: '[Previous context was compacted. Summary: ...]' },
-              ...keep,
-            ];
-          }
+          const compacted = await this.handleCompact(messages);
+          messages = compacted.messages;
           state = TurnState.BUILD;
           break;
         }
@@ -116,7 +129,7 @@ export class AgentLoop {
             const args = spaceIdx === -1 ? '' : userMessage.slice(spaceIdx + 1);
             const cmd = this.slashCommands.get(cmdName);
             if (cmd) {
-              const result = cmd.handler(args, messages);
+              const result = await Promise.resolve(cmd.handler(args, messages));
               messages = result.messages;
               if (result.output) output = result.output;
               state = TurnState.DONE;
@@ -139,6 +152,7 @@ export class AgentLoop {
             context: this.context,
             config: this.config,
             systemPrompt: this.systemPrompt,
+            sharedUndoStack: this.sharedUndoStack,
           });
           const result = await runner.runTurn(userMessage, messages, onEvent, signal);
           messages = result.messages;
@@ -164,17 +178,46 @@ export class AgentLoop {
     return { messages, output, iterationsUsed, usage };
   }
 
-  private handleCompact(messages: ChatMessage[]): { messages: ChatMessage[]; output?: string } {
+  private async handleCompact(messages: ChatMessage[]): Promise<{ messages: ChatMessage[]; output?: string }> {
     if (messages.length <= 10) {
       return { messages, output: 'Context is already small enough.' };
     }
-    // Simple compact: keep system + last N user/assistant exchanges
-    const systemMsg = messages.find(m => m.role === 'system');
-    const recentMessages = messages.filter(m => m.role !== 'system').slice(-20);
-    const kept = systemMsg ? [systemMsg, ...recentMessages] : recentMessages;
-    return {
-      messages: kept,
-      output: `Compacted: reduced from ${messages.length} to ${kept.length} messages.`,
-    };
+
+    const conversationText = messages
+      .filter(m => m.role !== 'system')
+      .map(m => `[${m.role}]: ${m.content}`)
+      .join('\n\n');
+
+    try {
+      const summaryResponse = await this.provider.chat({
+        system: 'You are a session summarizer for an AI coding assistant. Be concise.',
+        messages: [
+          {
+            role: 'user',
+            content: `Summarize this conversation into a structured summary with these sections:\n1. Goal\n2. Completed\n3. Decisions\n4. CurrentState\n5. Pending\n\nConversation:\n${conversationText}`,
+          },
+        ],
+      });
+
+      const systemMsg = messages.find(m => m.role === 'system');
+      const summaryMsg: ChatMessage = {
+        role: 'assistant',
+        content: `[Conversation summary]\n${summaryResponse.content}`,
+      };
+      const kept = systemMsg ? [systemMsg, summaryMsg] : [summaryMsg];
+      return {
+        messages: kept,
+        output: `Compacted: reduced from ${messages.length} to ${kept.length} messages using LLM summarization.`,
+      };
+    } catch {
+      // Fallback: keep last 20 messages
+      const systemMsg = messages.find(m => m.role === 'system');
+      const recentMessages = messages.filter(m => m.role !== 'system').slice(-20);
+      const kept = systemMsg ? [systemMsg, ...recentMessages] : recentMessages;
+      return {
+        messages: kept,
+        output: `Compacted (fallback): reduced from ${messages.length} to ${kept.length} messages.`,
+      };
+    }
   }
 }

--- a/src/agent/runner.ts
+++ b/src/agent/runner.ts
@@ -10,6 +10,7 @@ export type RunnerOptions = {
   context: DvalinContext;
   config: TurnConfig;
   systemPrompt: string;
+  sharedUndoStack?: UndoEntry[];
 };
 
 export class AgentRunner {
@@ -21,7 +22,7 @@ export class AgentRunner {
   private iterationCount: number = 0;
 
   /** Stack of executed tool calls for undo support */
-  private undoStack: UndoEntry[] = [];
+  private undoStack: UndoEntry[];
 
   constructor(options: RunnerOptions) {
     this.provider = options.provider;
@@ -29,6 +30,7 @@ export class AgentRunner {
     this.context = options.context;
     this.config = options.config;
     this.systemPrompt = options.systemPrompt;
+    this.undoStack = options.sharedUndoStack ?? [];
   }
 
   /** Undo the last N tool calls. Returns a description of what was undone. */

--- a/src/agent/types.ts
+++ b/src/agent/types.ts
@@ -37,7 +37,9 @@ export const DEFAULT_TURN_CONFIG: TurnConfig = {
 export type SlashCommand = {
   name: string;
   description: string;
-  handler: (args: string, messages: ChatMessage[]) => { messages: ChatMessage[]; output?: string };
+  handler: (args: string, messages: ChatMessage[]) =>
+    | { messages: ChatMessage[]; output?: string }
+    | Promise<{ messages: ChatMessage[]; output?: string }>;
 };
 
 export type LoopResult = {

--- a/src/core/ignorefile.ts
+++ b/src/core/ignorefile.ts
@@ -1,0 +1,11 @@
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+export async function loadIgnorePatterns(cwd: string): Promise<string[]> {
+  try {
+    const content = await readFile(join(cwd, '.dvalincodeignore'), 'utf8');
+    return content.split('\n').map(l => l.trim()).filter(l => l && !l.startsWith('#'));
+  } catch {
+    return [];
+  }
+}

--- a/src/server/configStore.ts
+++ b/src/server/configStore.ts
@@ -9,8 +9,16 @@ export type LLMConfig = {
   model?: string;
 };
 
+export type Profile = {
+  provider: string;
+  apiKey?: string;
+  baseUrl?: string;
+  model?: string;
+};
+
 export type AppConfig = {
   llm: LLMConfig;
+  profiles?: Record<string, Profile>;
 };
 
 const CONFIG_DIR = join(homedir(), '.dvalincode');
@@ -32,6 +40,7 @@ export async function readConfig(): Promise<AppConfig> {
     // Merge with defaults (env vars are overridden by saved config)
     return {
       llm: { ...DEFAULTS.llm, ...parsed.llm },
+      profiles: parsed.profiles,
     };
   } catch {
     return DEFAULTS;
@@ -45,6 +54,15 @@ export async function writeConfig(config: AppConfig): Promise<void> {
 
 /** Return config safe for the browser (API key masked). */
 export function maskConfig(config: AppConfig): AppConfig & { llm: { apiKeySet: boolean } } {
+  const maskedProfiles: Record<string, Profile> | undefined = config.profiles
+    ? Object.fromEntries(
+        Object.entries(config.profiles).map(([name, profile]) => [
+          name,
+          { ...profile, apiKey: profile.apiKey ? '••••••••' : undefined },
+        ]),
+      )
+    : undefined;
+
   return {
     ...config,
     llm: {
@@ -52,5 +70,6 @@ export function maskConfig(config: AppConfig): AppConfig & { llm: { apiKeySet: b
       apiKey: config.llm.apiKey ? '••••••••' : undefined,
       apiKeySet: !!config.llm.apiKey,
     },
+    profiles: maskedProfiles,
   };
 }

--- a/src/server/routes/config.ts
+++ b/src/server/routes/config.ts
@@ -1,8 +1,80 @@
 import { Router } from 'express';
 import { readConfig, writeConfig, maskConfig } from '../configStore.js';
-import type { LLMConfig } from '../configStore.js';
+import type { LLMConfig, Profile } from '../configStore.js';
 
 export const configRouter = Router();
+
+// Profile routes must be registered before the root route to avoid being shadowed
+
+configRouter.get('/profiles', async (_req, res) => {
+  const config = await readConfig();
+  const profiles = config.profiles ?? {};
+  // Mask apiKey in each profile
+  const masked = Object.fromEntries(
+    Object.entries(profiles).map(([name, profile]) => [
+      name,
+      { ...profile, apiKey: profile.apiKey ? '••••••••' : undefined },
+    ]),
+  );
+  res.json(masked);
+});
+
+configRouter.post('/profiles/:name', async (req, res) => {
+  const { name } = req.params;
+  const body = req.body as Partial<Profile>;
+  if (!body.provider) {
+    res.status(400).json({ error: 'Missing required field: provider' });
+    return;
+  }
+
+  const config = await readConfig();
+  const profiles = config.profiles ?? {};
+  profiles[name] = {
+    provider: body.provider,
+    apiKey: body.apiKey || undefined,
+    baseUrl: body.baseUrl || undefined,
+    model: body.model || undefined,
+  };
+  const updated = { ...config, profiles };
+  await writeConfig(updated);
+  res.json({ name, profile: { ...profiles[name], apiKey: profiles[name].apiKey ? '••••••••' : undefined } });
+});
+
+configRouter.delete('/profiles/:name', async (req, res) => {
+  const { name } = req.params;
+  const config = await readConfig();
+  const profiles = config.profiles ?? {};
+  if (!profiles[name]) {
+    res.status(404).json({ error: `Profile "${name}" not found` });
+    return;
+  }
+  delete profiles[name];
+  const updated = { ...config, profiles };
+  await writeConfig(updated);
+  res.json({ deleted: name });
+});
+
+configRouter.post('/profiles/:name/apply', async (req, res) => {
+  const { name } = req.params;
+  const config = await readConfig();
+  const profiles = config.profiles ?? {};
+  const profile = profiles[name];
+  if (!profile) {
+    res.status(404).json({ error: `Profile "${name}" not found` });
+    return;
+  }
+  const updated = {
+    ...config,
+    llm: {
+      provider: profile.provider,
+      apiKey: profile.apiKey,
+      baseUrl: profile.baseUrl,
+      model: profile.model,
+    },
+  };
+  await writeConfig(updated);
+  res.json(maskConfig(updated));
+});
 
 configRouter.get('/', async (_req, res) => {
   const config = await readConfig();

--- a/src/tools/listFiles.ts
+++ b/src/tools/listFiles.ts
@@ -1,5 +1,6 @@
 import fg from 'fast-glob';
 import { z } from 'zod';
+import { loadIgnorePatterns } from '../core/ignorefile.js';
 import type { Tool } from './types.js';
 
 const inputSchema = z
@@ -18,12 +19,13 @@ export const listFilesTool: Tool<Input> = {
   inputSchema,
   isConcurrencySafe: () => true,
   async run(input, context) {
+    const userIgnore = await loadIgnorePatterns(context.cwd);
     const files = await fg(input.pattern, {
       cwd: context.cwd,
       dot: true,
       onlyFiles: true,
       followSymbolicLinks: false,
-      ignore: ['**/.git/**', '**/node_modules/**', '**/dist/**', '**/coverage/**'],
+      ignore: ['**/.git/**', '**/node_modules/**', '**/dist/**', '**/coverage/**', ...userIgnore],
     });
 
     const selected = files.sort().slice(0, input.limit);

--- a/src/tools/readFile.ts
+++ b/src/tools/readFile.ts
@@ -1,6 +1,7 @@
 import { readFile, stat } from 'node:fs/promises';
 import { z } from 'zod';
 import { resolveInsideWorkspace } from '../core/workspace.js';
+import { loadIgnorePatterns } from '../core/ignorefile.js';
 import type { Tool } from './types.js';
 
 const inputSchema = z
@@ -20,6 +21,18 @@ export const readFileTool: Tool<Input> = {
   inputSchema,
   isConcurrencySafe: () => true,
   async run(input, context) {
+    const ignorePatterns = await loadIgnorePatterns(context.cwd);
+    for (const pattern of ignorePatterns) {
+      if (
+        input.filePath === pattern ||
+        input.filePath.endsWith('/' + pattern) ||
+        input.filePath.includes('/' + pattern + '/') ||
+        input.filePath.startsWith(pattern + '/')
+      ) {
+        throw new Error(`File excluded by .dvalincodeignore: ${input.filePath}`);
+      }
+    }
+
     const resolvedPath = await resolveInsideWorkspace(context.cwd, input.filePath);
     const info = await stat(resolvedPath);
 

--- a/src/tools/searchText.ts
+++ b/src/tools/searchText.ts
@@ -2,6 +2,7 @@ import { readFile } from 'node:fs/promises';
 import fg from 'fast-glob';
 import { z } from 'zod';
 import { resolveInsideWorkspace } from '../core/workspace.js';
+import { loadIgnorePatterns } from '../core/ignorefile.js';
 import type { Tool } from './types.js';
 
 const inputSchema = z
@@ -22,12 +23,13 @@ export const searchTextTool: Tool<Input> = {
   inputSchema,
   isConcurrencySafe: () => true,
   async run(input, context) {
+    const userIgnore = await loadIgnorePatterns(context.cwd);
     const files = await fg(input.pattern, {
       cwd: context.cwd,
       dot: true,
       onlyFiles: true,
       followSymbolicLinks: false,
-      ignore: ['**/.git/**', '**/node_modules/**', '**/dist/**', '**/coverage/**'],
+      ignore: ['**/.git/**', '**/node_modules/**', '**/dist/**', '**/coverage/**', ...userIgnore],
     });
 
     const needle = input.caseSensitive ? input.query : input.query.toLowerCase();

--- a/src/tools/shell.ts
+++ b/src/tools/shell.ts
@@ -19,7 +19,8 @@ export const shellTool: Tool<Input> = {
   inputSchema,
   isConcurrencySafe: () => false,
   async run(input, context) {
-    const result = await runProcess(input.command, input.args, context.cwd, input.timeoutMs);
+    const sandboxEnabled = process.platform === 'darwin';
+    const result = await runProcess(input.command, input.args, context.cwd, input.timeoutMs, sandboxEnabled);
     return {
       title: `Ran ${input.command}`,
       output: result.output || '(no output)',
@@ -36,9 +37,29 @@ function runProcess(
   args: string[],
   cwd: string,
   timeoutMs: number,
+  sandboxEnabled: boolean,
 ): Promise<{ output: string; exitCode: number | null; timedOut: boolean }> {
+  // On macOS, wrap in sandbox-exec to deny network access while allowing file operations
+  let spawnCommand: string;
+  let spawnArgs: string[];
+
+  if (sandboxEnabled) {
+    const profile = [
+      '(version 1)',
+      '(allow default)',
+      '(deny network*)',
+      '(allow file-read*)',
+      `(allow file-write* (subpath "${cwd}")(subpath "/tmp")(subpath "/var"))`,
+    ].join('');
+    spawnCommand = 'sandbox-exec';
+    spawnArgs = ['-p', profile, command, ...args];
+  } else {
+    spawnCommand = command;
+    spawnArgs = args;
+  }
+
   return new Promise(resolve => {
-    const child = spawn(command, args, {
+    const child = spawn(spawnCommand, spawnArgs, {
       cwd,
       shell: false,
       stdio: ['ignore', 'pipe', 'pipe'],
@@ -70,4 +91,3 @@ function runProcess(
     });
   });
 }
-

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -112,6 +112,12 @@ export default function App() {
 
   const usage = chat.lastUsage;
 
+  // Total tool calls in current session (live progress tracking)
+  const totalTools = chat.messages.reduce((sum, msg) => {
+    if (msg.role === 'assistant') return sum + msg.toolCalls.length;
+    return sum;
+  }, 0);
+
   // Accumulate cost whenever a turn finishes
   useEffect(() => {
     if (!usage) return;
@@ -155,6 +161,11 @@ export default function App() {
                 {gitBranch}
               </span>
             )}
+            {totalTools > 0 && (
+              <span className="text-[11px] text-muted-fg/60 font-mono flex-shrink-0">
+                {totalTools} tool{totalTools === 1 ? '' : 's'}
+              </span>
+            )}
             {usage && (
               <span
                 className="text-[11px] text-muted-fg/70 font-mono flex-shrink-0 flex items-center gap-1.5"
@@ -185,7 +196,12 @@ export default function App() {
         </div>
 
         {/* Thread */}
-        <ChatThread messages={chat.messages} connected={chat.connected} />
+        <ChatThread
+          messages={chat.messages}
+          connected={chat.connected}
+          mode={mode}
+          onProceed={handleSend}
+        />
 
         {/* Composer */}
         <Composer

--- a/web/src/components/ApprovalDialog.tsx
+++ b/web/src/components/ApprovalDialog.tsx
@@ -1,56 +1,144 @@
-import { Check, X } from 'lucide-react';
-import type { PendingApproval } from '../types.ts';
+import { Check, X, AlertTriangle, Trash2 } from 'lucide-react';
+import { DiffViewer } from './DiffViewer.tsx';
+import type { PendingApproval, DiffLine } from '../types.ts';
 
 type Props = {
   approval: PendingApproval;
   onRespond: (id: string, approved: boolean) => void;
 };
 
-const TOOL_ICONS: Record<string, string> = {
-  shell: '⚡',
-  write_file: '📝',
-  edit_file: '✏️',
-  delete_file: '🗑️',
-};
-
-function formatInput(toolName: string, input: unknown): string {
-  if (!input || typeof input !== 'object') return String(input);
-  const obj = input as Record<string, unknown>;
-
-  if (toolName === 'shell' && typeof obj.command === 'string') {
-    return obj.command;
+/* ── Client-side diff (same algorithm as backend generateDiff) ─── */
+function computeDiff(oldStr: string, newStr: string): DiffLine[] {
+  const oldLines = oldStr.split('\n');
+  const newLines = newStr.split('\n');
+  const result: DiffLine[] = [];
+  const maxLen = Math.max(oldLines.length, newLines.length);
+  for (let i = 0; i < maxLen; i++) {
+    const o = oldLines[i] ?? '';
+    const n = newLines[i] ?? '';
+    if (o === n) {
+      result.push({ type: 'keep', content: o });
+    } else {
+      if (i < oldLines.length) result.push({ type: 'remove', content: o });
+      if (i < newLines.length) result.push({ type: 'add', content: n });
+    }
   }
-  if ((toolName === 'write_file' || toolName === 'edit_file') && typeof obj.path === 'string') {
-    const lines = [`path: ${obj.path}`];
-    if (typeof obj.old_string === 'string') lines.push(`- ${obj.old_string.slice(0, 120)}`);
-    if (typeof obj.new_string === 'string') lines.push(`+ ${obj.new_string.slice(0, 120)}`);
-    if (typeof obj.content === 'string') lines.push(`content: ${obj.content.length} chars`);
-    return lines.join('\n');
-  }
-  return JSON.stringify(input, null, 2);
+  return result;
 }
 
+/* ── Per-tool content rendering ─────────────────────────────────── */
+function ApprovalContent({ toolName, input }: { toolName: string; input: unknown }) {
+  if (!input || typeof input !== 'object') {
+    return (
+      <pre className="px-4 py-3 text-xs font-mono text-muted-fg bg-[#0a0a0a] overflow-x-auto max-h-48 whitespace-pre-wrap break-all">
+        {String(input)}
+      </pre>
+    );
+  }
+
+  const obj = input as Record<string, unknown>;
+
+  /* edit_file — show unified diff */
+  if (toolName === 'edit_file') {
+    const filePath = typeof obj.filePath === 'string' ? obj.filePath : undefined;
+    const oldStr = typeof obj.oldString === 'string' ? obj.oldString : '';
+    const newStr = typeof obj.newString === 'string' ? obj.newString : '';
+    const diff = computeDiff(oldStr, newStr);
+    return (
+      <div className="px-4 py-3 bg-[#0a0a0a]">
+        <DiffViewer diff={diff} filePath={filePath} />
+      </div>
+    );
+  }
+
+  /* write_file — show path + content preview */
+  if (toolName === 'write_file') {
+    const filePath = typeof obj.filePath === 'string' ? obj.filePath : '?';
+    const content = typeof obj.content === 'string' ? obj.content : '';
+    const lines = content.split('\n');
+    const preview = lines.slice(0, 12).join('\n') + (lines.length > 12 ? `\n… +${lines.length - 12} lines` : '');
+    return (
+      <div className="bg-[#0a0a0a]">
+        <div className="px-4 py-2 border-b border-border text-[11px] font-mono text-muted-fg">
+          {filePath} <span className="text-muted-fg/50">· {lines.length} lines · {content.length} chars</span>
+        </div>
+        <pre className="px-4 py-3 text-xs font-mono text-muted-fg overflow-x-auto max-h-40 whitespace-pre-wrap break-all">
+          {preview}
+        </pre>
+      </div>
+    );
+  }
+
+  /* delete_file — warning */
+  if (toolName === 'delete_file') {
+    const filePath = typeof obj.filePath === 'string' ? obj.filePath : '?';
+    return (
+      <div className="px-4 py-4 bg-[#0a0a0a] flex items-center gap-3">
+        <Trash2 size={16} className="text-red-400 flex-shrink-0" />
+        <div>
+          <div className="text-sm text-red-300 font-medium">{filePath}</div>
+          <div className="text-xs text-muted-fg mt-0.5">This file will be permanently deleted.</div>
+        </div>
+      </div>
+    );
+  }
+
+  /* shell — command with highlighting */
+  if (toolName === 'shell') {
+    const command = typeof obj.command === 'string' ? obj.command : '';
+    const args = Array.isArray(obj.args) ? (obj.args as string[]).join(' ') : '';
+    const full = args ? `${command} ${args}` : command;
+    return (
+      <div className="bg-[#0a0a0a]">
+        <div className="px-4 py-1.5 border-b border-border text-[11px] text-orange-400/60 font-mono">$ shell</div>
+        <pre className="px-4 py-3 text-xs font-mono text-orange-200 overflow-x-auto whitespace-pre-wrap break-all">
+          {full}
+        </pre>
+      </div>
+    );
+  }
+
+  /* fallback */
+  return (
+    <pre className="px-4 py-3 text-xs font-mono text-muted-fg bg-[#0a0a0a] overflow-x-auto max-h-48 whitespace-pre-wrap break-all">
+      {JSON.stringify(input, null, 2)}
+    </pre>
+  );
+}
+
+/* ── Main dialog ─────────────────────────────────────────────────── */
+const TOOL_META: Record<string, { icon: string; label: string; bg: string; badge: string; badgeStyle: string }> = {
+  shell:       { icon: '⚡', label: 'shell',       bg: 'bg-orange-500/5', badge: 'execute',   badgeStyle: 'text-orange-400 bg-orange-500/10 border-orange-500/20' },
+  write_file:  { icon: '📝', label: 'write_file',  bg: 'bg-yellow-500/5', badge: 'write',     badgeStyle: 'text-yellow-400 bg-yellow-500/10 border-yellow-500/20' },
+  edit_file:   { icon: '✏️',  label: 'edit_file',  bg: 'bg-blue-500/5',   badge: 'edit',      badgeStyle: 'text-blue-400 bg-blue-500/10 border-blue-500/20' },
+  delete_file: { icon: '🗑️', label: 'delete_file', bg: 'bg-red-500/5',    badge: 'delete',    badgeStyle: 'text-red-400 bg-red-500/10 border-red-500/20' },
+};
+
 export function ApprovalDialog({ approval, onRespond }: Props) {
-  const icon = TOOL_ICONS[approval.toolName] ?? '🔧';
-  const isShell = approval.toolName === 'shell';
-  const preview = formatInput(approval.toolName, approval.input);
+  const meta = TOOL_META[approval.toolName] ?? {
+    icon: '🔧', label: approval.toolName, bg: 'bg-yellow-500/5',
+    badge: 'confirm', badgeStyle: 'text-yellow-400 bg-yellow-500/10 border-yellow-500/20',
+  };
+
+  const isDelete = approval.toolName === 'delete_file';
 
   return (
     <div className="fixed inset-0 z-50 flex items-end justify-center pb-24 px-4 pointer-events-none">
       <div className="pointer-events-auto w-full max-w-xl bg-surface border border-border rounded-xl shadow-2xl overflow-hidden animate-slide-up">
         {/* Header */}
-        <div className={`flex items-center gap-2 px-4 py-3 border-b border-border ${isShell ? 'bg-orange-500/5' : 'bg-yellow-500/5'}`}>
-          <span className="text-base">{icon}</span>
-          <span className="text-sm font-medium text-fg">{approval.toolName}</span>
-          <span className={`ml-auto text-[11px] px-2 py-0.5 rounded font-mono ${isShell ? 'text-orange-400 bg-orange-500/10 border border-orange-500/20' : 'text-yellow-400 bg-yellow-500/10 border border-yellow-500/20'}`}>
-            {isShell ? 'execute' : 'write'}
+        <div className={`flex items-center gap-2 px-4 py-3 border-b border-border ${meta.bg}`}>
+          <span className="text-base">{meta.icon}</span>
+          <span className="text-sm font-medium text-fg">{meta.label}</span>
+          {isDelete && (
+            <AlertTriangle size={13} className="text-red-400 ml-0.5" />
+          )}
+          <span className={`ml-auto text-[11px] px-2 py-0.5 rounded font-mono border ${meta.badgeStyle}`}>
+            {meta.badge}
           </span>
         </div>
 
-        {/* Preview */}
-        <pre className="px-4 py-3 text-xs font-mono text-muted-fg bg-[#0a0a0a] overflow-x-auto max-h-32 whitespace-pre-wrap break-all">
-          {preview}
-        </pre>
+        {/* Content */}
+        <ApprovalContent toolName={approval.toolName} input={approval.input} />
 
         {/* Actions */}
         <div className="flex items-center justify-end gap-2 px-4 py-3 border-t border-border">
@@ -63,10 +151,14 @@ export function ApprovalDialog({ approval, onRespond }: Props) {
           </button>
           <button
             onClick={() => onRespond(approval.id, true)}
-            className="flex items-center gap-1.5 px-3 py-1.5 text-xs text-emerald-400 hover:text-emerald-300 bg-emerald-500/10 hover:bg-emerald-500/15 border border-emerald-500/20 rounded-lg transition-colors"
+            className={`flex items-center gap-1.5 px-3 py-1.5 text-xs border rounded-lg transition-colors ${
+              isDelete
+                ? 'text-red-400 hover:text-red-300 bg-red-500/10 hover:bg-red-500/15 border-red-500/20'
+                : 'text-emerald-400 hover:text-emerald-300 bg-emerald-500/10 hover:bg-emerald-500/15 border-emerald-500/20'
+            }`}
           >
             <Check size={12} />
-            Allow
+            {isDelete ? 'Delete' : 'Allow'}
           </button>
         </div>
       </div>

--- a/web/src/components/ChatThread.tsx
+++ b/web/src/components/ChatThread.tsx
@@ -1,13 +1,15 @@
 import { useEffect, useRef } from 'react';
 import { MessageBubble } from './MessageBubble.tsx';
-import type { ChatMessage } from '../types.ts';
+import type { ChatMessage, AgentMode } from '../types.ts';
 
 type Props = {
   messages: ChatMessage[];
   connected: boolean;
+  mode?: AgentMode;
+  onProceed?: (text: string) => void;
 };
 
-export function ChatThread({ messages, connected }: Props) {
+export function ChatThread({ messages, connected, mode, onProceed }: Props) {
   const bottomRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -37,7 +39,12 @@ export function ChatThread({ messages, connected }: Props) {
     <div className="flex-1 overflow-y-auto px-6 py-6">
       <div className="max-w-2xl mx-auto">
         {messages.map((msg, i) => (
-          <MessageBubble key={i} message={msg} />
+          <MessageBubble
+            key={i}
+            message={msg}
+            mode={mode}
+            onProceed={onProceed}
+          />
         ))}
         <div ref={bottomRef} />
       </div>

--- a/web/src/components/LLMConfigModal.tsx
+++ b/web/src/components/LLMConfigModal.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useState } from 'react';
-import { X, Eye, EyeOff, Check, Loader, AlertTriangle, ChevronRight } from 'lucide-react';
-import { fetchConfig, saveConfig } from '../lib/client.ts';
+import { X, Eye, EyeOff, Check, Loader, AlertTriangle, ChevronRight, BookMarked, Trash2, Plus } from 'lucide-react';
+import { fetchConfig, saveConfig, fetchProfiles, saveProfile, deleteProfile, applyProfile } from '../lib/client.ts';
 import type { LLMConfig } from '../types.ts';
+import type { Profile } from '../lib/client.ts';
 
 // ── Provider presets ──────────────────────────────────────────────────────────
 
@@ -167,22 +168,26 @@ export function LLMConfigModal({ onClose }: Props) {
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(true);
 
+  // Profiles state
+  const [profiles, setProfiles] = useState<Record<string, Profile>>({});
+  const [newProfileName, setNewProfileName] = useState('');
+  const [savingProfile, setSavingProfile] = useState(false);
+
   const activeProvider = PROVIDERS.find((p) => p.id === draft.provider) ?? PROVIDERS[PROVIDERS.length - 1];
 
-  // Load existing config on mount
+  // Load existing config + profiles on mount
   useEffect(() => {
-    fetchConfig()
-      .then((cfg) => {
+    Promise.all([fetchConfig(), fetchProfiles()])
+      .then(([cfg, profs]) => {
         setDraft({
           provider: cfg.llm.provider,
           apiKey: cfg.llm.apiKeySet ? '••••••••' : '',
           baseUrl: cfg.llm.baseUrl ?? activeProvider.baseUrl,
           model: cfg.llm.model ?? activeProvider.models[0]?.model ?? '',
         });
+        setProfiles(profs);
       })
-      .catch(() => {
-        // backend not running — use defaults
-      })
+      .catch(() => {})
       .finally(() => setLoading(false));
   }, []);
 
@@ -198,6 +203,44 @@ export function LLMConfigModal({ onClose }: Props) {
   };
 
   const selectModel = (model: string) => setDraft((d) => ({ ...d, model }));
+
+  const handleSaveProfile = async () => {
+    const name = newProfileName.trim();
+    if (!name) return;
+    setSavingProfile(true);
+    try {
+      const profile: Profile = {
+        provider: draft.provider,
+        apiKey: draft.apiKey?.startsWith('••') ? undefined : draft.apiKey || undefined,
+        baseUrl: draft.baseUrl || undefined,
+        model: draft.model || undefined,
+      };
+      await saveProfile(name, profile);
+      setProfiles((p) => ({ ...p, [name]: profile }));
+      setNewProfileName('');
+    } catch { /* ignore */ } finally { setSavingProfile(false); }
+  };
+
+  const handleApplyProfile = async (name: string) => {
+    try {
+      await applyProfile(name);
+      const p = profiles[name];
+      if (!p) return;
+      setDraft({
+        provider: p.provider,
+        apiKey: p.apiKey ?? '',
+        baseUrl: p.baseUrl ?? '',
+        model: p.model ?? '',
+      });
+    } catch { /* ignore */ }
+  };
+
+  const handleDeleteProfile = async (name: string) => {
+    try {
+      await deleteProfile(name);
+      setProfiles((p) => { const n = { ...p }; delete n[name]; return n; });
+    } catch { /* ignore */ }
+  };
 
   const handleSave = async () => {
     if (!(draft.model ?? '').trim()) { setError('Model name is required'); return; }
@@ -346,6 +389,63 @@ export function LLMConfigModal({ onClose }: Props) {
                   </div>
                 )}
               </section>
+
+            {/* ── Profiles ── */}
+            <section className="flex flex-col gap-3 pt-2 border-t border-[#1e1e1e]">
+              <h3 className="text-xs font-semibold text-muted-fg uppercase tracking-wider flex items-center gap-1.5">
+                <BookMarked size={11} />
+                Saved Profiles
+              </h3>
+
+              {Object.keys(profiles).length === 0 ? (
+                <p className="text-xs text-muted-fg/60 italic">No profiles saved yet.</p>
+              ) : (
+                <div className="flex flex-col gap-1.5">
+                  {Object.entries(profiles).map(([name, p]) => (
+                    <div key={name} className="flex items-center gap-2 bg-[#0f0f0f] border border-[#222] rounded-lg px-3 py-2">
+                      <ProviderIcon id={p.provider} size="sm" />
+                      <div className="flex-1 min-w-0">
+                        <div className="text-xs font-semibold text-fg truncate">{name}</div>
+                        <div className="text-[11px] text-muted-fg font-mono truncate">
+                          {p.provider} · {p.model ?? '—'}
+                        </div>
+                      </div>
+                      <button
+                        onClick={() => void handleApplyProfile(name)}
+                        className="text-[11px] px-2 py-1 rounded border border-accent/30 text-accent hover:bg-accent/10 transition-colors"
+                      >
+                        Apply
+                      </button>
+                      <button
+                        onClick={() => void handleDeleteProfile(name)}
+                        className="p-1 text-muted-fg hover:text-red-400 transition-colors"
+                      >
+                        <Trash2 size={12} />
+                      </button>
+                    </div>
+                  ))}
+                </div>
+              )}
+
+              {/* Save current as profile */}
+              <div className="flex items-center gap-2">
+                <input
+                  value={newProfileName}
+                  onChange={(e) => setNewProfileName(e.target.value)}
+                  onKeyDown={(e) => { if (e.key === 'Enter') void handleSaveProfile(); }}
+                  placeholder="Profile name…"
+                  className="flex-1 bg-[#0a0a0a] border border-[#222] rounded-lg px-3 py-1.5 text-xs text-fg placeholder-muted-fg outline-none focus:border-accent/40"
+                />
+                <button
+                  onClick={() => void handleSaveProfile()}
+                  disabled={!newProfileName.trim() || savingProfile}
+                  className="flex items-center gap-1 px-3 py-1.5 text-xs rounded-lg border border-[#333] text-muted-fg hover:text-fg hover:border-accent/40 disabled:opacity-40 transition-colors"
+                >
+                  {savingProfile ? <Loader size={11} className="animate-spin" /> : <Plus size={11} />}
+                  Save
+                </button>
+              </div>
+            </section>
 
             </div>
           )}

--- a/web/src/components/MessageBubble.tsx
+++ b/web/src/components/MessageBubble.tsx
@@ -2,7 +2,9 @@ import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import rehypeHighlight from 'rehype-highlight';
 import { AgentActivity } from './AgentActivity.tsx';
+import { PlanCard, extractPlanSteps } from './PlanCard.tsx';
 import type { ChatMessage } from '../types.ts';
+import type { AgentMode } from '../types.ts';
 
 function ThinkingDots() {
   return (
@@ -14,11 +16,17 @@ function ThinkingDots() {
   );
 }
 
-export function MessageBubble({ message }: { message: ChatMessage }) {
+type Props = {
+  message: ChatMessage;
+  mode?: AgentMode;
+  onProceed?: (text: string) => void;
+};
+
+export function MessageBubble({ message, mode, onProceed }: Props) {
   if (message.role === 'user') {
     return (
       <div className="flex justify-end mb-4 animate-fade-in">
-        <div className="max-w-[75%] bg-[#1a1a2e] border border-[#2a2a4e] rounded-2xl rounded-tr-sm px-4 py-2.5 text-fg text-sm leading-relaxed">
+        <div className="max-w-[75%] bg-[#1a1a2e] border border-[#2a2a4e] rounded-2xl rounded-tr-sm px-4 py-2.5 text-fg text-sm leading-relaxed whitespace-pre-wrap">
           {message.content}
         </div>
       </div>
@@ -29,14 +37,18 @@ export function MessageBubble({ message }: { message: ChatMessage }) {
   const { content, toolCalls, pending } = message;
   const showDots = pending && toolCalls.length === 0 && !content;
 
+  // Detect plan in Cowork mode: ≥3 numbered steps, no tool calls, message done
+  const planSteps =
+    !pending && mode === 'cowork' && toolCalls.length === 0 && content
+      ? extractPlanSteps(content)
+      : null;
+
   return (
     <div className="mb-6 animate-fade-in">
       <div className="flex items-center gap-2 mb-2">
         <img src="/logo.svg" alt="DvalinCode" className="w-5 h-5 rounded-full object-cover flex-shrink-0" />
         <span className="text-xs text-muted-fg font-medium">DvalinCode</span>
-        {pending && (
-          <span className="text-xs text-accent/60 animate-pulse">thinking…</span>
-        )}
+        {pending && <span className="text-xs text-accent/60 animate-pulse">thinking…</span>}
       </div>
 
       {/* Agent tool activity */}
@@ -50,6 +62,9 @@ export function MessageBubble({ message }: { message: ChatMessage }) {
       <div className="ml-7">
         {showDots ? (
           <ThinkingDots />
+        ) : planSteps ? (
+          /* Cowork Plan mode: show visual plan card */
+          <PlanCard steps={planSteps} onProceed={onProceed} />
         ) : content ? (
           <div className="prose text-sm">
             <ReactMarkdown

--- a/web/src/components/PlanCard.tsx
+++ b/web/src/components/PlanCard.tsx
@@ -1,0 +1,97 @@
+import { useState } from 'react';
+import { ClipboardList, ChevronDown, ChevronUp, PlayCircle } from 'lucide-react';
+
+type Props = {
+  steps: string[];
+  onProceed?: (message: string) => void;
+};
+
+export function PlanCard({ steps, onProceed }: Props) {
+  const [collapsed, setCollapsed] = useState(false);
+  const [done, setDone] = useState<Set<number>>(new Set());
+
+  const toggle = (i: number) =>
+    setDone((prev) => {
+      const next = new Set(prev);
+      next.has(i) ? next.delete(i) : next.add(i);
+      return next;
+    });
+
+  return (
+    <div className="my-3 border border-violet-500/25 rounded-xl overflow-hidden bg-violet-500/5">
+      {/* Header */}
+      <div className="flex items-center gap-2 px-4 py-2.5 bg-violet-500/10 border-b border-violet-500/20">
+        <ClipboardList size={13} className="text-violet-400 flex-shrink-0" />
+        <span className="text-xs font-semibold text-violet-300">Plan · {steps.length} steps</span>
+        <button
+          onClick={() => setCollapsed((v) => !v)}
+          className="ml-auto text-violet-400/60 hover:text-violet-300 transition-colors"
+        >
+          {collapsed ? <ChevronDown size={13} /> : <ChevronUp size={13} />}
+        </button>
+      </div>
+
+      {!collapsed && (
+        <>
+          {/* Steps */}
+          <ol className="px-4 py-3 flex flex-col gap-1.5">
+            {steps.map((step, i) => (
+              <li
+                key={i}
+                className="flex items-start gap-2.5 cursor-pointer group"
+                onClick={() => toggle(i)}
+              >
+                {/* Checkbox */}
+                <span
+                  className={`mt-0.5 w-4 h-4 rounded border flex-shrink-0 flex items-center justify-center text-[10px] transition-colors ${
+                    done.has(i)
+                      ? 'bg-violet-500 border-violet-500 text-white'
+                      : 'border-violet-500/40 group-hover:border-violet-400'
+                  }`}
+                >
+                  {done.has(i) ? '✓' : ''}
+                </span>
+                <span
+                  className={`text-xs leading-relaxed transition-colors ${
+                    done.has(i) ? 'text-muted-fg/50 line-through' : 'text-fg/90'
+                  }`}
+                >
+                  <span className="text-violet-400 font-mono mr-1">{i + 1}.</span>
+                  {step}
+                </span>
+              </li>
+            ))}
+          </ol>
+
+          {/* Proceed button */}
+          {onProceed && (
+            <div className="px-4 pb-3">
+              <button
+                onClick={() => onProceed('Proceed with the plan above. Execute each step in order.')}
+                className="flex items-center gap-1.5 px-3 py-1.5 text-xs rounded-lg bg-violet-500/15 hover:bg-violet-500/25 border border-violet-500/30 text-violet-300 hover:text-violet-200 transition-all font-medium"
+              >
+                <PlayCircle size={12} />
+                Proceed with Plan
+              </button>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+
+/** Extract numbered steps from markdown text. Returns null if <3 steps found. */
+export function extractPlanSteps(content: string): string[] | null {
+  const lines = content.split('\n');
+  const steps: string[] = [];
+
+  for (const line of lines) {
+    const m = line.match(/^\s*\d+\.\s+(.+)/);
+    if (m) {
+      steps.push(m[1].trim());
+    }
+  }
+
+  return steps.length >= 3 ? steps : null;
+}

--- a/web/src/lib/client.ts
+++ b/web/src/lib/client.ts
@@ -153,3 +153,40 @@ export async function fetchGitInfo(cwd: string): Promise<GitInfo> {
     return { branch: null, lastCommit: null };
   }
 }
+
+// ── Profiles ─────────────────────────────────────────────────────────────────
+
+export type Profile = {
+  provider: string;
+  apiKey?: string;
+  baseUrl?: string;
+  model?: string;
+};
+
+export async function fetchProfiles(): Promise<Record<string, Profile>> {
+  try {
+    const res = await fetch('/api/config/profiles');
+    if (!res.ok) return {};
+    return res.json() as Promise<Record<string, Profile>>;
+  } catch {
+    return {};
+  }
+}
+
+export async function saveProfile(name: string, profile: Profile): Promise<void> {
+  await fetch(`/api/config/profiles/${encodeURIComponent(name)}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(profile),
+  });
+}
+
+export async function deleteProfile(name: string): Promise<void> {
+  await fetch(`/api/config/profiles/${encodeURIComponent(name)}`, { method: 'DELETE' });
+}
+
+export async function applyProfile(name: string): Promise<AppConfig> {
+  const res = await fetch(`/api/config/profiles/${encodeURIComponent(name)}/apply`, { method: 'POST' });
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  return res.json() as Promise<AppConfig>;
+}


### PR DESCRIPTION
…, Profiles, Ignore

**Plan 模式 (Cowork)**
- New PlanCard component: auto-detects ≥3 numbered steps in Cowork responses
- Visual step list with clickable checkboxes + "Proceed with Plan" button
- Sends follow-up message to trigger execution; collapsed/expanded toggle
- MessageBubble passes mode + onProceed down; ChatThread wires callback from App

**审批对话框升级**
- edit_file: computes client-side diff (same algo as backend) and renders DiffViewer
- write_file: shows file path + first 12 lines of content preview
- delete_file: red warning with Trash icon and permanent-deletion notice
- shell: styled terminal block with orange command text
- Per-tool colour-coded header badges (blue=edit, yellow=write, red=delete, orange=shell)

**LLM 上下文压缩 (真正调 LLM)**
- handleCompact now async; calls provider.chat() with structured summary prompt
- Output: Goal / Completed / Decisions / CurrentState / Pending sections
- Falls back to keeping last 20 messages if LLM call fails
- COMPACT state machine step awaits the async result

**/undo 命令 (持久化 undoStack)**
- AgentLoop maintains sharedUndoStack across turns; passed by reference to every AgentRunner
- /undo [N] slash command creates a temp runner on the shared stack and calls undoLast(N)
- SlashCommand.handler type updated to support async handlers (await Promise.resolve)

**Shell 沙箱 (macOS sandbox-exec)**
- On darwin, wraps every shell invocation in sandbox-exec -p <inline-profile>
- Profile: deny network*, allow file-read*, allow file-write* in cwd + /tmp + /var

**.dvalincodeignore 支持**
- New src/core/ignorefile.ts utility reads .dvalincodeignore from cwd
- list_files, search_text: merge user patterns into fast-glob ignore array
- read_file: blocks access with clear error if path matches any ignore pattern

**多 Profile 配置**
- configStore: Profile type + profiles field in AppConfig; maskConfig masks profile keys
- config routes: GET/POST/DELETE /api/config/profiles/:name + POST .../apply
- LLMConfigModal: Saved Profiles section — list with Apply/Delete; Save-current-as-profile input
- client.ts: fetchProfiles, saveProfile, deleteProfile, applyProfile helpers

**任务进度追踪**
- Topbar shows live "N tools" counter derived from current session messages

## Summary

## Testing

## Notes

