### PR TITLE
feat: mode-aware sidebar — Chat Templates, Cowork Projects, Code Routines

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -132,6 +132,7 @@ export default function App() {
         onNewChat={handleNewChat}
         onSelectSession={handleSelectSession}
         onOpenConfig={() => setShowLLMConfig(true)}
+        onSend={handleSend}
         refreshKey={sidebarRefresh}
         mode={mode}
         onModeChange={handleModeChange}

--- a/web/src/components/Sidebar.tsx
+++ b/web/src/components/Sidebar.tsx
@@ -1,25 +1,18 @@
 import { useEffect, useState } from 'react';
-import { Plus, Trash2, MessageSquare, ChevronLeft, ChevronRight, Settings2 } from 'lucide-react';
+import { ChevronLeft, ChevronRight, Settings2 } from 'lucide-react';
 import { fetchSessions, deleteSession } from '../lib/client.ts';
 import { ModeSwitcher } from './ModeSwitcher.tsx';
-import type { SessionMeta } from '../types.ts';
-import type { AgentMode } from '../types.ts';
-
-function timeAgo(iso: string): string {
-  const diff = Date.now() - new Date(iso).getTime();
-  const m = Math.floor(diff / 60000);
-  if (m < 1) return 'just now';
-  if (m < 60) return `${m}m ago`;
-  const h = Math.floor(m / 60);
-  if (h < 24) return `${h}h ago`;
-  return `${Math.floor(h / 24)}d ago`;
-}
+import { SidebarChat } from './SidebarChat.tsx';
+import { SidebarCowork } from './SidebarCowork.tsx';
+import { SidebarCode } from './SidebarCode.tsx';
+import type { SessionMeta, AgentMode } from '../types.ts';
 
 type Props = {
   currentSessionId?: string;
   onNewChat: () => void;
   onSelectSession: (id: string) => void;
   onOpenConfig: () => void;
+  onSend: (text: string) => void;
   refreshKey?: number;
   mode: AgentMode;
   onModeChange: (m: AgentMode) => void;
@@ -30,6 +23,7 @@ export function Sidebar({
   onNewChat,
   onSelectSession,
   onOpenConfig,
+  onSend,
   refreshKey,
   mode,
   onModeChange,
@@ -39,8 +33,7 @@ export function Sidebar({
 
   const load = async () => {
     try {
-      const data = await fetchSessions();
-      setSessions(data);
+      setSessions(await fetchSessions());
     } catch {
       // server not available
     }
@@ -68,13 +61,6 @@ export function Sidebar({
         >
           <ChevronRight size={16} />
         </button>
-        <button
-          onClick={onNewChat}
-          className="p-2 rounded-lg hover:bg-[#1a1a1a] text-muted-fg hover:text-fg transition-colors"
-          title="New chat"
-        >
-          <Plus size={16} />
-        </button>
         <div className="flex-1" />
         <button
           onClick={onOpenConfig}
@@ -91,7 +77,7 @@ export function Sidebar({
   return (
     <div className="flex flex-col w-60 h-full bg-surface border-r border-border flex-shrink-0">
       {/* Header */}
-      <div className="flex items-center justify-between px-4 py-3 border-b border-border">
+      <div className="flex items-center justify-between px-4 py-3 border-b border-border flex-shrink-0">
         <div className="flex items-center gap-2">
           <img src="/logo.svg" alt="DvalinCode" className="w-6 h-6 rounded-md object-cover" />
           <span className="font-semibold text-sm text-fg">DvalinCode</span>
@@ -104,66 +90,46 @@ export function Sidebar({
         </button>
       </div>
 
-      {/* Mode switcher — top-left, full width */}
-      <div className="px-3 py-2 border-b border-border">
+      {/* Mode switcher — full width */}
+      <div className="px-3 py-2 border-b border-border flex-shrink-0">
         <ModeSwitcher value={mode} onChange={onModeChange} fullWidth />
       </div>
 
-      {/* New chat button */}
-      <div className="px-3 py-2">
-        <button
-          onClick={onNewChat}
-          className="w-full flex items-center gap-2 px-3 py-2 rounded-lg border border-dashed border-border hover:border-accent/40 hover:bg-accent/5 text-muted-fg hover:text-fg transition-all text-sm"
-        >
-          <Plus size={14} />
-          New chat
-        </button>
-      </div>
-
-      {/* Session list */}
-      <div className="flex-1 overflow-y-auto px-2">
-        {sessions.length === 0 ? (
-          <p className="text-xs text-muted-fg px-3 py-4 text-center">No sessions yet</p>
-        ) : (
-          <div className="flex flex-col gap-0.5">
-            {sessions.map((s) => (
-              <div
-                key={s.id}
-                role="button"
-                tabIndex={0}
-                onClick={() => onSelectSession(s.id)}
-                onKeyDown={(e) => e.key === 'Enter' && onSelectSession(s.id)}
-                className={`group w-full text-left px-3 py-2 rounded-lg transition-colors flex items-start gap-2 cursor-pointer ${
-                  s.id === currentSessionId
-                    ? 'bg-accent/10 border border-accent/20 text-fg'
-                    : 'hover:bg-[#1a1a1a] text-muted-fg hover:text-fg border border-transparent'
-                }`}
-              >
-                <MessageSquare size={13} className="mt-0.5 flex-shrink-0 opacity-60" />
-                <div className="flex-1 min-w-0">
-                  <div className="text-xs font-medium truncate leading-tight">
-                    {s.summary
-                      ? s.summary.replace(/^User wanted: /, '').slice(0, 40)
-                      : s.cwd.split('/').pop() ?? s.id}
-                  </div>
-                  <div className="text-[11px] text-muted-fg mt-0.5">
-                    {timeAgo(s.updatedAt)} · {s.messageCount} msg
-                  </div>
-                </div>
-                <button
-                  onClick={(e) => void handleDelete(e, s.id)}
-                  className="opacity-0 group-hover:opacity-100 p-0.5 rounded hover:text-red-400 transition-all flex-shrink-0"
-                >
-                  <Trash2 size={12} />
-                </button>
-              </div>
-            ))}
-          </div>
+      {/* Mode-specific content — fills remaining height */}
+      <div className="flex flex-col flex-1 min-h-0">
+        {mode === 'chat' && (
+          <SidebarChat
+            sessions={sessions}
+            currentSessionId={currentSessionId}
+            onNewChat={onNewChat}
+            onSelectSession={onSelectSession}
+            onDeleteSession={handleDelete}
+            onSend={onSend}
+          />
+        )}
+        {mode === 'cowork' && (
+          <SidebarCowork
+            sessions={sessions}
+            currentSessionId={currentSessionId}
+            onNewChat={onNewChat}
+            onSelectSession={onSelectSession}
+            onDeleteSession={handleDelete}
+          />
+        )}
+        {mode === 'code' && (
+          <SidebarCode
+            sessions={sessions}
+            currentSessionId={currentSessionId}
+            onNewChat={onNewChat}
+            onSelectSession={onSelectSession}
+            onDeleteSession={handleDelete}
+            onSend={onSend}
+          />
         )}
       </div>
 
       {/* Footer — LLM config */}
-      <div className="border-t border-border px-3 py-2">
+      <div className="border-t border-border px-3 py-2 flex-shrink-0">
         <button
           onClick={onOpenConfig}
           className="w-full flex items-center gap-2 px-3 py-2 rounded-lg hover:bg-[#1a1a1a] text-muted-fg hover:text-fg transition-colors text-sm"

--- a/web/src/components/SidebarChat.tsx
+++ b/web/src/components/SidebarChat.tsx
@@ -1,0 +1,178 @@
+import { useState } from 'react';
+import { Plus, MessageSquare, Trash2, ChevronRight, BookOpen, Search, GitPullRequest, FlaskConical, Sparkles } from 'lucide-react';
+import type { SessionMeta } from '../types.ts';
+
+// ── Templates ────────────────────────────────────────────────────────────────
+
+const TEMPLATES = [
+  {
+    icon: <BookOpen size={12} />,
+    label: 'Explain codebase',
+    prompt:
+      'Give me a high-level overview of this codebase: what it does, how it is structured, and what the main entry points are.',
+  },
+  {
+    icon: <Search size={12} />,
+    label: 'Find TODOs',
+    prompt:
+      'Search the codebase for all TODO, FIXME, HACK, and XXX comments. List them with file paths and line numbers.',
+  },
+  {
+    icon: <GitPullRequest size={12} />,
+    label: 'Review changes',
+    prompt:
+      'Review the recent changes in this project. Check for potential bugs, code quality issues, and suggest improvements.',
+  },
+  {
+    icon: <FlaskConical size={12} />,
+    label: 'Write tests',
+    prompt:
+      'Look at the existing test files and help me write comprehensive tests for the untested parts of the codebase.',
+  },
+  {
+    icon: <Sparkles size={12} />,
+    label: 'Refactor suggestion',
+    prompt:
+      'Analyse the codebase and suggest the three most impactful refactoring opportunities — with clear rationale for each.',
+  },
+];
+
+// ── Session row ───────────────────────────────────────────────────────────────
+
+function timeAgo(iso: string): string {
+  const diff = Date.now() - new Date(iso).getTime();
+  const m = Math.floor(diff / 60000);
+  if (m < 1) return 'just now';
+  if (m < 60) return `${m}m ago`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h}h ago`;
+  return `${Math.floor(h / 24)}d ago`;
+}
+
+function SessionRow({
+  session,
+  active,
+  onSelect,
+  onDelete,
+}: {
+  session: SessionMeta;
+  active: boolean;
+  onSelect: () => void;
+  onDelete: (e: React.MouseEvent) => void;
+}) {
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      onClick={onSelect}
+      onKeyDown={(e) => e.key === 'Enter' && onSelect()}
+      className={`group flex items-start gap-2 px-3 py-2 rounded-lg cursor-pointer transition-colors text-xs border ${
+        active
+          ? 'bg-blue-500/10 border-blue-500/20 text-fg'
+          : 'hover:bg-[#1a1a1a] text-muted-fg hover:text-fg border-transparent'
+      }`}
+    >
+      <MessageSquare size={12} className="mt-0.5 flex-shrink-0 opacity-50" />
+      <div className="flex-1 min-w-0">
+        <div className="font-medium truncate leading-tight">
+          {session.summary
+            ? session.summary.replace(/^User wanted: /, '').slice(0, 38)
+            : session.cwd.split('/').pop() ?? session.id}
+        </div>
+        <div className="text-[10px] text-muted-fg mt-0.5 opacity-70">
+          {timeAgo(session.updatedAt)} · {session.messageCount} msg
+        </div>
+      </div>
+      <button
+        onClick={onDelete}
+        className="opacity-0 group-hover:opacity-100 p-0.5 rounded hover:text-red-400 transition-all flex-shrink-0"
+      >
+        <Trash2 size={11} />
+      </button>
+    </div>
+  );
+}
+
+// ── Main component ────────────────────────────────────────────────────────────
+
+type Props = {
+  sessions: SessionMeta[];
+  currentSessionId?: string;
+  onNewChat: () => void;
+  onSelectSession: (id: string) => void;
+  onDeleteSession: (e: React.MouseEvent, id: string) => void;
+  onSend: (text: string) => void;
+};
+
+export function SidebarChat({
+  sessions,
+  currentSessionId,
+  onNewChat,
+  onSelectSession,
+  onDeleteSession,
+  onSend,
+}: Props) {
+  const [expanded, setExpanded] = useState(false);
+
+  return (
+    <>
+      {/* New chat */}
+      <div className="px-3 py-2">
+        <button
+          onClick={onNewChat}
+          className="w-full flex items-center gap-2 px-3 py-2 rounded-lg border border-dashed border-border hover:border-blue-500/40 hover:bg-blue-500/5 text-muted-fg hover:text-fg transition-all text-xs"
+        >
+          <Plus size={13} />
+          New chat
+          <kbd className="ml-auto text-[10px] opacity-40">⌘N</kbd>
+        </button>
+      </div>
+
+      {/* Templates */}
+      <div className="px-3 pb-2 border-b border-border">
+        <div className="text-[10px] font-semibold text-muted-fg/50 uppercase tracking-wider px-1 mb-1">
+          Templates
+        </div>
+        {TEMPLATES.slice(0, expanded ? TEMPLATES.length : 3).map((t) => (
+          <button
+            key={t.label}
+            onClick={() => onSend(t.prompt)}
+            className="w-full flex items-center gap-2 px-2 py-1.5 rounded-lg text-xs text-muted-fg hover:text-fg hover:bg-[#1a1a1a] transition-colors text-left"
+          >
+            <span className="text-blue-400/70 flex-shrink-0">{t.icon}</span>
+            <span className="flex-1 truncate">{t.label}</span>
+            <ChevronRight size={10} className="opacity-30 flex-shrink-0" />
+          </button>
+        ))}
+        <button
+          onClick={() => setExpanded((v) => !v)}
+          className="w-full text-[11px] text-muted-fg/50 hover:text-muted-fg py-1 transition-colors"
+        >
+          {expanded ? '▲ less' : `+${TEMPLATES.length - 3} more`}
+        </button>
+      </div>
+
+      {/* History */}
+      <div className="flex-1 overflow-y-auto px-2 py-1">
+        <div className="text-[10px] font-semibold text-muted-fg/50 uppercase tracking-wider px-2 py-1.5">
+          History
+        </div>
+        {sessions.length === 0 ? (
+          <p className="text-xs text-muted-fg/50 px-3 py-3 text-center">No conversations yet</p>
+        ) : (
+          <div className="flex flex-col gap-0.5">
+            {sessions.map((s) => (
+              <SessionRow
+                key={s.id}
+                session={s}
+                active={s.id === currentSessionId}
+                onSelect={() => onSelectSession(s.id)}
+                onDelete={(e) => onDeleteSession(e, s.id)}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+    </>
+  );
+}

--- a/web/src/components/SidebarCode.tsx
+++ b/web/src/components/SidebarCode.tsx
@@ -1,0 +1,241 @@
+import { useState } from 'react';
+import {
+  Plus, MessageSquare, Trash2, Zap, ChevronRight, X, Check,
+} from 'lucide-react';
+import type { SessionMeta } from '../types.ts';
+
+// ── Local-storage routines ────────────────────────────────────────────────────
+
+type Routine = { name: string; prompt: string };
+
+const DEFAULT_ROUTINES: Routine[] = [
+  { name: 'Run tests',   prompt: 'Run the test suite and report any failures with details.' },
+  { name: 'Type check',  prompt: 'Run TypeScript type-checking and list all type errors.' },
+  { name: 'Build',       prompt: 'Build the project and report any build errors or warnings.' },
+  { name: 'Git status',  prompt: '/git' },
+  { name: 'Lint',        prompt: 'Run the linter and show any issues that need fixing.' },
+];
+
+function useRoutines(): [Routine[], (r: Routine[]) => void] {
+  const KEY = 'dvalincode-routines-v1';
+  const [routines, setRoutinesState] = useState<Routine[]>(() => {
+    try {
+      const stored = localStorage.getItem(KEY);
+      return stored ? (JSON.parse(stored) as Routine[]) : DEFAULT_ROUTINES;
+    } catch {
+      return DEFAULT_ROUTINES;
+    }
+  });
+  const setRoutines = (r: Routine[]) => {
+    setRoutinesState(r);
+    localStorage.setItem(KEY, JSON.stringify(r));
+  };
+  return [routines, setRoutines];
+}
+
+// ── Session row ───────────────────────────────────────────────────────────────
+
+function timeAgo(iso: string): string {
+  const diff = Date.now() - new Date(iso).getTime();
+  const m = Math.floor(diff / 60000);
+  if (m < 1) return 'just now';
+  if (m < 60) return `${m}m ago`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h}h ago`;
+  return `${Math.floor(h / 24)}d ago`;
+}
+
+function SessionRow({
+  session, active, onSelect, onDelete,
+}: {
+  session: SessionMeta;
+  active: boolean;
+  onSelect: () => void;
+  onDelete: (e: React.MouseEvent) => void;
+}) {
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      onClick={onSelect}
+      onKeyDown={(e) => e.key === 'Enter' && onSelect()}
+      className={`group flex items-start gap-2 px-3 py-2 rounded-lg cursor-pointer transition-colors text-xs border ${
+        active
+          ? 'bg-orange-500/10 border-orange-500/20 text-fg'
+          : 'hover:bg-[#1a1a1a] text-muted-fg hover:text-fg border-transparent'
+      }`}
+    >
+      <MessageSquare size={12} className="mt-0.5 flex-shrink-0 opacity-50" />
+      <div className="flex-1 min-w-0">
+        <div className="font-medium truncate leading-tight">
+          {session.summary
+            ? session.summary.replace(/^User wanted: /, '').slice(0, 38)
+            : session.cwd.split('/').pop() ?? session.id}
+        </div>
+        <div className="text-[10px] text-muted-fg mt-0.5 opacity-70">
+          {timeAgo(session.updatedAt)} · {session.messageCount} msg
+        </div>
+      </div>
+      <button
+        onClick={onDelete}
+        className="opacity-0 group-hover:opacity-100 p-0.5 rounded hover:text-red-400 transition-all flex-shrink-0"
+      >
+        <Trash2 size={11} />
+      </button>
+    </div>
+  );
+}
+
+// ── Add routine form ──────────────────────────────────────────────────────────
+
+function AddRoutineForm({ onAdd }: { onAdd: (r: Routine) => void }) {
+  const [name, setName] = useState('');
+  const [prompt, setPrompt] = useState('');
+
+  const submit = () => {
+    if (!name.trim() || !prompt.trim()) return;
+    onAdd({ name: name.trim(), prompt: prompt.trim() });
+    setName('');
+    setPrompt('');
+  };
+
+  return (
+    <div className="mt-1 flex flex-col gap-1.5 px-1">
+      <input
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+        placeholder="Routine name…"
+        className="w-full bg-[#0f0f0f] border border-border rounded-lg px-2.5 py-1.5 text-xs text-fg placeholder-muted-fg outline-none focus:border-accent/40"
+      />
+      <textarea
+        value={prompt}
+        onChange={(e) => setPrompt(e.target.value)}
+        placeholder="Prompt or /command…"
+        rows={2}
+        className="w-full bg-[#0f0f0f] border border-border rounded-lg px-2.5 py-1.5 text-xs text-fg placeholder-muted-fg outline-none focus:border-accent/40 resize-none"
+      />
+      <div className="flex gap-1.5">
+        <button
+          onClick={submit}
+          disabled={!name.trim() || !prompt.trim()}
+          className="flex-1 flex items-center justify-center gap-1 py-1.5 text-xs rounded-lg bg-orange-500/15 hover:bg-orange-500/25 text-orange-300 border border-orange-500/25 disabled:opacity-40 transition-colors"
+        >
+          <Check size={11} />
+          Save
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// ── Main component ────────────────────────────────────────────────────────────
+
+type Props = {
+  sessions: SessionMeta[];
+  currentSessionId?: string;
+  onNewChat: () => void;
+  onSelectSession: (id: string) => void;
+  onDeleteSession: (e: React.MouseEvent, id: string) => void;
+  onSend: (text: string) => void;
+};
+
+export function SidebarCode({
+  sessions,
+  currentSessionId,
+  onNewChat,
+  onSelectSession,
+  onDeleteSession,
+  onSend,
+}: Props) {
+  const [routines, setRoutines] = useRoutines();
+  const [addingRoutine, setAddingRoutine] = useState(false);
+
+  const removeRoutine = (name: string) =>
+    setRoutines(routines.filter((r) => r.name !== name));
+
+  return (
+    <>
+      {/* New session */}
+      <div className="px-3 py-2">
+        <button
+          onClick={onNewChat}
+          className="w-full flex items-center gap-2 px-3 py-2 rounded-lg border border-dashed border-border hover:border-orange-500/40 hover:bg-orange-500/5 text-muted-fg hover:text-fg transition-all text-xs"
+        >
+          <Plus size={13} />
+          New session
+          <kbd className="ml-auto text-[10px] opacity-40">⌘N</kbd>
+        </button>
+      </div>
+
+      {/* Routines */}
+      <div className="px-3 pb-2 border-b border-border">
+        <div className="flex items-center justify-between px-1 mb-1">
+          <span className="text-[10px] font-semibold text-muted-fg/50 uppercase tracking-wider">
+            Routines
+          </span>
+          <button
+            onClick={() => setAddingRoutine((v) => !v)}
+            className={`text-[10px] transition-colors ${
+              addingRoutine ? 'text-orange-400' : 'text-muted-fg/50 hover:text-muted-fg'
+            }`}
+            title={addingRoutine ? 'Cancel' : 'Add routine'}
+          >
+            {addingRoutine ? <X size={11} /> : <Plus size={11} />}
+          </button>
+        </div>
+
+        <div className="flex flex-col gap-0.5">
+          {routines.map((r) => (
+            <div key={r.name} className="group flex items-center gap-1">
+              <button
+                onClick={() => onSend(r.prompt)}
+                className="flex-1 flex items-center gap-2 px-2 py-1.5 rounded-lg text-xs text-muted-fg hover:text-fg hover:bg-[#1a1a1a] transition-colors text-left"
+              >
+                <Zap size={11} className="text-orange-400/70 flex-shrink-0" />
+                <span className="truncate">{r.name}</span>
+                <ChevronRight size={10} className="ml-auto opacity-30 flex-shrink-0" />
+              </button>
+              <button
+                onClick={() => removeRoutine(r.name)}
+                className="opacity-0 group-hover:opacity-100 p-1 rounded hover:text-red-400 transition-all flex-shrink-0"
+              >
+                <X size={10} />
+              </button>
+            </div>
+          ))}
+        </div>
+
+        {addingRoutine && (
+          <AddRoutineForm
+            onAdd={(r) => {
+              setRoutines([...routines, r]);
+              setAddingRoutine(false);
+            }}
+          />
+        )}
+      </div>
+
+      {/* Sessions */}
+      <div className="flex-1 overflow-y-auto px-2 py-1">
+        <div className="text-[10px] font-semibold text-muted-fg/50 uppercase tracking-wider px-2 py-1.5">
+          Sessions
+        </div>
+        {sessions.length === 0 ? (
+          <p className="text-xs text-muted-fg/50 px-3 py-3 text-center">No sessions yet</p>
+        ) : (
+          <div className="flex flex-col gap-0.5">
+            {sessions.map((s) => (
+              <SessionRow
+                key={s.id}
+                session={s}
+                active={s.id === currentSessionId}
+                onSelect={() => onSelectSession(s.id)}
+                onDelete={(e) => onDeleteSession(e, s.id)}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+    </>
+  );
+}

--- a/web/src/components/SidebarCowork.tsx
+++ b/web/src/components/SidebarCowork.tsx
@@ -1,0 +1,206 @@
+import { useState } from 'react';
+import {
+  Plus, Trash2, FolderOpen, ChevronRight, ClipboardList,
+} from 'lucide-react';
+import type { SessionMeta } from '../types.ts';
+
+function timeAgo(iso: string): string {
+  const diff = Date.now() - new Date(iso).getTime();
+  const m = Math.floor(diff / 60000);
+  if (m < 1) return 'just now';
+  if (m < 60) return `${m}m ago`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h}h ago`;
+  return `${Math.floor(h / 24)}d ago`;
+}
+
+function TaskRow({
+  session,
+  active,
+  onSelect,
+  onDelete,
+}: {
+  session: SessionMeta;
+  active: boolean;
+  onSelect: () => void;
+  onDelete: (e: React.MouseEvent) => void;
+}) {
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      onClick={onSelect}
+      onKeyDown={(e) => e.key === 'Enter' && onSelect()}
+      className={`group flex items-start gap-2 px-3 py-2 rounded-lg cursor-pointer transition-colors text-xs border ${
+        active
+          ? 'bg-violet-500/10 border-violet-500/20 text-fg'
+          : 'hover:bg-[#1a1a1a] text-muted-fg hover:text-fg border-transparent'
+      }`}
+    >
+      <ClipboardList size={12} className="mt-0.5 flex-shrink-0 opacity-50" />
+      <div className="flex-1 min-w-0">
+        <div className="font-medium truncate leading-tight">
+          {session.summary
+            ? session.summary.replace(/^User wanted: /, '').slice(0, 38)
+            : `Task · ${session.cwd.split('/').pop()}`}
+        </div>
+        <div className="text-[10px] text-muted-fg mt-0.5 opacity-70">
+          {timeAgo(session.updatedAt)} · {session.messageCount} msg
+        </div>
+      </div>
+      <button
+        onClick={onDelete}
+        className="opacity-0 group-hover:opacity-100 p-0.5 rounded hover:text-red-400 transition-all flex-shrink-0"
+      >
+        <Trash2 size={11} />
+      </button>
+    </div>
+  );
+}
+
+type Props = {
+  sessions: SessionMeta[];
+  currentSessionId?: string;
+  onNewChat: () => void;
+  onSelectSession: (id: string) => void;
+  onDeleteSession: (e: React.MouseEvent, id: string) => void;
+};
+
+type Project = { name: string; cwd: string; sessions: SessionMeta[] };
+
+export function SidebarCowork({
+  sessions,
+  currentSessionId,
+  onNewChat,
+  onSelectSession,
+  onDeleteSession,
+}: Props) {
+  const [activeProject, setActiveProject] = useState<string | null>(null);
+  const [view, setView] = useState<'projects' | 'all'>('projects');
+
+  // Group by cwd
+  const projectMap = sessions.reduce<Record<string, Project>>((acc, s) => {
+    const key = s.cwd;
+    const name = key.split('/').filter(Boolean).pop() ?? key;
+    if (!acc[key]) acc[key] = { name, cwd: key, sessions: [] };
+    acc[key].sessions.push(s);
+    return acc;
+  }, {});
+  const projects = Object.values(projectMap).sort(
+    (a, b) =>
+      new Date(b.sessions[0]!.updatedAt).getTime() -
+      new Date(a.sessions[0]!.updatedAt).getTime(),
+  );
+
+  const displayedSessions =
+    view === 'all'
+      ? sessions
+      : activeProject
+      ? (projectMap[activeProject]?.sessions ?? [])
+      : sessions;
+
+  return (
+    <>
+      {/* New task */}
+      <div className="px-3 py-2">
+        <button
+          onClick={onNewChat}
+          className="w-full flex items-center gap-2 px-3 py-2 rounded-lg border border-dashed border-border hover:border-violet-500/40 hover:bg-violet-500/5 text-muted-fg hover:text-fg transition-all text-xs"
+        >
+          <Plus size={13} />
+          New task
+          <kbd className="ml-auto text-[10px] opacity-40">⌘N</kbd>
+        </button>
+      </div>
+
+      {/* View toggle */}
+      <div className="px-3 pb-2 flex gap-1">
+        {(['projects', 'all'] as const).map((v) => (
+          <button
+            key={v}
+            onClick={() => setView(v)}
+            className={`flex-1 py-1 text-[11px] rounded-md capitalize transition-colors ${
+              view === v
+                ? 'bg-violet-500/15 text-violet-300 font-medium'
+                : 'text-muted-fg hover:text-fg'
+            }`}
+          >
+            {v === 'projects' ? 'Projects' : 'All tasks'}
+          </button>
+        ))}
+      </div>
+
+      {/* Content */}
+      <div className="flex-1 overflow-y-auto px-2 py-1">
+        {view === 'projects' ? (
+          /* Projects tree */
+          projects.length === 0 ? (
+            <p className="text-xs text-muted-fg/50 px-3 py-3 text-center">No tasks yet</p>
+          ) : (
+            <div className="flex flex-col gap-0.5">
+              {projects.map((p) => (
+                <div key={p.cwd}>
+                  {/* Project header */}
+                  <button
+                    onClick={() =>
+                      setActiveProject(activeProject === p.cwd ? null : p.cwd)
+                    }
+                    className="w-full flex items-center gap-2 px-2 py-2 rounded-lg text-xs hover:bg-[#1a1a1a] text-muted-fg hover:text-fg transition-colors"
+                  >
+                    <FolderOpen size={12} className="text-violet-400/70 flex-shrink-0" />
+                    <span className="flex-1 font-medium truncate text-left">{p.name}</span>
+                    <span className="text-[10px] opacity-50 flex-shrink-0">
+                      {p.sessions.length}
+                    </span>
+                    <ChevronRight
+                      size={11}
+                      className={`opacity-40 flex-shrink-0 transition-transform ${
+                        activeProject === p.cwd ? 'rotate-90' : ''
+                      }`}
+                    />
+                  </button>
+                  {/* Project sessions */}
+                  {activeProject === p.cwd && (
+                    <div className="ml-2 flex flex-col gap-0.5">
+                      {p.sessions.map((s) => (
+                        <TaskRow
+                          key={s.id}
+                          session={s}
+                          active={s.id === currentSessionId}
+                          onSelect={() => onSelectSession(s.id)}
+                          onDelete={(e) => onDeleteSession(e, s.id)}
+                        />
+                      ))}
+                    </div>
+                  )}
+                </div>
+              ))}
+            </div>
+          )
+        ) : (
+          /* All tasks flat list */
+          <>
+            <div className="text-[10px] font-semibold text-muted-fg/50 uppercase tracking-wider px-2 py-1.5">
+              All tasks
+            </div>
+            {displayedSessions.length === 0 ? (
+              <p className="text-xs text-muted-fg/50 px-3 py-3 text-center">No tasks yet</p>
+            ) : (
+              <div className="flex flex-col gap-0.5">
+                {displayedSessions.map((s) => (
+                  <TaskRow
+                    key={s.id}
+                    session={s}
+                    active={s.id === currentSessionId}
+                    onSelect={() => onSelectSession(s.id)}
+                    onDelete={(e) => onDeleteSession(e, s.id)}
+                  />
+                ))}
+              </div>
+            )}
+          </>
+        )}
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
## What changed

Each mode now has a completely different sidebar, similar to how Claude separates Chat / Projects / Artifacts panels.

### Chat mode
- **Templates** — 5 one-click prompt shortcuts (Explain codebase, Find TODOs, Review changes, Write tests, Refactor suggestion). Clicking a template sends it directly to the agent.
- Expandable `+N more / ▲ less` toggle
- **History** — recent conversation list (blue accent)

### Cowork mode
- **Projects / All tasks** toggle tabs
- **Projects view** — sessions grouped by `cwd` directory, expandable folder tree with task count per project
- **All tasks view** — flat chronological task list
- New task button (violet accent)

### Code mode
- **Routines** — 5 default quick-fire commands (Run tests, Type check, Build, Git status, Lint). Click to send, hover to delete.
- **Add routine** form — name + prompt/slash-command, persisted in `localStorage`
- **Sessions** — chronological session history (orange accent)

## Implementation

| File | Change |
|---|---|
| `Sidebar.tsx` | Refactored to thin router; dispatches to mode-specific component |
| `SidebarChat.tsx` | New — Templates + History |
| `SidebarCowork.tsx` | New — Projects tree + All tasks |
| `SidebarCode.tsx` | New — Routines (localStorage) + Sessions |
| `App.tsx` | Passes `onSend` to Sidebar for template/routine click-to-send |

## Test plan
- [ ] Switch to Chat → Templates visible; clicking one sends the prompt
- [ ] Switch to Cowork → Projects tab shows sessions grouped by folder; expand/collapse works
- [ ] Switch to Code → Routines listed; clicking sends; delete (✕) on hover; Add routine saves to localStorage and persists on refresh
- [ ] Collapsed sidebar still works (collapse/expand button)
- [ ] `⌘N` shortcut hint visible on each mode's new-item button

🤖 Generated with [Claude Code](https://claude.com/claude-code)