### PR TITLE
docs: README core goal + 2026-06 release intel, requirements & dev plans

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@
 </p>
 
 <p align="center">
-  <b>A local-first, provider-neutral AI coding agent with three modes —</b><br>
-  <b>Chat for questions, Cowork for plan-then-execute, Code for autonomous work.</b>
+  <b>A local-first coding agent: any model, safe by default, small enough to audit, open enough to embed.</b><br>
+  <b>Three modes — Chat for questions, Cowork for plan-then-execute, Code for autonomous work.</b>
 </p>
 
 <p align="center">
@@ -32,6 +32,21 @@
 <tr><td><b>🪶 Zero-dependency binary</b></td><td>Single ~25MB executable per platform. No Node, no Python, no Docker. Auto-opens your browser on launch.</td></tr>
 <tr><td><b>🔐 Local-first</b></td><td>Sessions, config, and profiles live in <code>~/.dvalincode/</code>. <code>.dvalincodeignore</code> blocks the agent from reading sensitive files. <code>AGENTS.md</code> in your repo becomes persistent project instructions.</td></tr>
 </table>
+
+---
+
+## 🎯 Core Goal
+
+> **A local-first coding agent: any model, safe by default, small enough to audit, open enough to embed.**
+
+DvalinCode is built as an **agent runtime**, not just another agent app:
+
+- **Any model** — every OpenAI-compatible endpoint is a first-class citizen, local models included. Your workflow should never be hostage to one vendor's pricing, rate limits, or quality swings.
+- **Safe by default** — three-tier approvals with diff preview, an undo stack, and sandboxed shell execution. An agent you can trust on full-auto.
+- **Small enough to audit** — one ~25MB binary, a handful of runtime dependencies, a codebase you can read in a weekend. Trust through inspection, not promises.
+- **Open enough to embed** — the agent core speaks a clean REST + WebSocket API, ready to be wired into your own product, CI, or internal tools.
+
+The bundled **web GUI is the runtime's reference implementation and showcase** — the first consumer of that public API, demonstrating everything the runtime can do.
 
 ---
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -14,8 +14,8 @@
 </p>
 
 <p align="center">
-  <b>本地优先、模型无关的 AI 编码助手 —— 三种工作模式：</b><br>
-  <b>Chat 提问、Cowork 协作规划、Code 自主执行。</b>
+  <b>模型自由、默认安全、小到可审计、开放到可嵌入的本地编码代理。</b><br>
+  <b>三种工作模式 —— Chat 提问、Cowork 协作规划、Code 自主执行。</b>
 </p>
 
 <p align="center">
@@ -32,6 +32,21 @@
 <tr><td><b>🪶 零依赖二进制</b></td><td>每平台单文件可执行程序 ~25MB。无需 Node、Python、Docker。启动后自动打开浏览器。</td></tr>
 <tr><td><b>🔐 本地优先</b></td><td>Session、配置、Profile 均保存在 <code>~/.dvalincode/</code>。<code>.dvalincodeignore</code> 阻止 Agent 访问敏感文件。仓库根目录的 <code>AGENTS.md</code> 作为项目级持久指令自动加载。</td></tr>
 </table>
+
+---
+
+## 🎯 核心目标
+
+> **模型自由、默认安全、小到可审计、开放到可嵌入的本地编码代理。**
+
+DvalinCode 的定位是 **Agent 运行时（runtime）**，而不只是又一个 Agent 应用：
+
+- **模型自由** —— 任何 OpenAI 兼容端点都是一等公民，包括本地模型。你的工作流不应被任何一家厂商的定价、限流或质量波动绑架。
+- **默认安全** —— 三档审批 + diff 预审、撤销栈、沙箱化 shell 执行。一个敢放心开全自动的 Agent。
+- **小到可审计** —— 单个 ~25MB 二进制、个位数运行时依赖、一个周末就能读完的代码库。信任来自可检查，而非口头承诺。
+- **开放到可嵌入** —— Agent 核心通过干净的 REST + WebSocket API 暴露，可直接接入你自己的产品、CI 或内部工具。
+
+自带的 **Web GUI 是这个运行时的参考实现与展示窗** —— 它是这套公开 API 的第一个消费者，演示运行时的全部能力。
 
 ---
 

--- a/requirements/FEATURE_GAP.md
+++ b/requirements/FEATURE_GAP.md
@@ -2,6 +2,8 @@
 
 > 基于 OpenAI Codex CLI（v0.129–v0.133）与 DvalinCode 现状的对比分析。
 > 优先级：🔴 P0（必须有）· 🟠 P1（强烈建议）· 🟡 P2（锦上添花）
+>
+> **2026-06-10 复核：** 已对照 v0.3.0 实际代码逐项审计，标记 ✅ 已交付 / 🟡 部分交付 / ❌ 未实现。各节「需求」列表保留为当时的规格说明。
 
 ---
 
@@ -10,27 +12,32 @@
 | 维度 | DvalinCode 现有 | Codex |
 |---|---|---|
 | 核心 Agent 循环 | ✅ 8 状态机 | ✅ |
-| 工具集 | ✅ 7 个 (read/write/edit/delete/list/search/shell) | ✅ 更丰富 |
+| 工具集 | ✅ 8 个 (read/write/edit/delete/list/search/shell/git_status) | ✅ 更丰富 |
 | Session 持久化 | ✅ JSON 文件 | ✅ JSONL |
 | 多 Provider 支持 | ✅ OpenAI 兼容 | ✅ |
 | Web GUI | ✅（自研） | ❌ 仅 TUI |
 | Undo/Rollback | ✅ undoStack | ✅ |
-| 流式输出 | ❌ | ✅ SSE |
-| 沙箱隔离 | ❌ | ✅ seatbelt/bwrap |
-| 审批流 | ❌ | ✅ 三档模式 |
-| 项目记忆 | ❌ | ✅ AGENTS.md + SQLite |
-| Token 统计 | ❌ | ✅ |
-| Git 感知 | ❌ | ✅ |
+| 流式输出 | ✅ SSE + token_delta | ✅ SSE |
+| 沙箱隔离 | 🟡 仅 macOS sandbox-exec | ✅ seatbelt/bwrap |
+| 审批流 | ✅ 三档模式 + 审批握手 | ✅ 三档模式 |
+| 项目记忆 | ✅ AGENTS.md | ✅ AGENTS.md + SQLite |
+| Token 统计 | ✅ 用量 + 费用估算 | ✅ |
+| Git 感知 | ✅ 工具 + 提示注入 | ✅ |
 | MCP 支持 | ❌ | ✅ |
-| 中断/取消 | ❌ | ✅ |
+| 中断/取消 | ✅ AbortController | ✅ |
 
 ---
 
 ## 🔴 P0 — 必须实现（影响基本可用性）
 
-### P0-1｜流式输出（Streaming Response）
+### P0-1｜流式输出（Streaming Response）✅
 
-**现状：** `AgentRunner.runTurn()` 等待 LLM 完整响应后才返回，用户无实时反馈。  
+**状态（2026-06-10 复核）：✅ 已交付。**
+- SSE 流式解析、`onDelta` 逐块回调、`stream_options.include_usage`、AbortSignal 透传：`src/providers/openaiCompatible.ts`（`chatStreaming`）
+- WebSocket `token_delta` 事件推送：`src/server/wsHandler.ts`
+- 前端逐块追加渲染：`web/src/hooks/useChat.ts`（`token_delta` 分支）
+
+**原现状（2026-05-22）：** `AgentRunner.runTurn()` 等待 LLM 完整响应后才返回，用户无实时反馈。  
 **Codex：** SSE 逐 token 推流，TUI 实时渲染，Web 端通过 WebSocket delta 事件更新。
 
 **需求：**
@@ -43,9 +50,14 @@
 
 ---
 
-### P0-2｜操作审批流（Approval Policy）
+### P0-2｜操作审批流（Approval Policy）✅
 
-**现状：** 仅有全局 `allowWrite`/`allowExecute` 布尔开关，写操作无 per-action 确认。  
+**状态（2026-06-10 复核）：✅ 已交付。**
+- 三档审批模式 `readonly` / `auto-edit` / `full-auto` + `requestApproval` 回调：`src/core/context.ts`
+- `approval_request` / `approval_response` 双向握手协议（中断时自动拒绝挂起审批）：`src/server/wsHandler.ts`
+- 前端审批弹窗，含 Diff 预览：`web/src/components/ApprovalDialog.tsx`
+
+**原现状（2026-05-22）：** 仅有全局 `allowWrite`/`allowExecute` 布尔开关，写操作无 per-action 确认。  
 **Codex：** 三档模式 — `suggest`（只读）/ `auto-edit`（文件变更免确认）/ `full-auto`（全自动）。
 
 **需求：**
@@ -61,9 +73,14 @@
 
 ---
 
-### P0-3｜中断 / 取消（Interrupt & Cancel）
+### P0-3｜中断 / 取消（Interrupt & Cancel）✅
 
-**现状：** Agent 一旦开始就无法打断，前端 sending 状态下用户只能等待。  
+**状态（2026-06-10 复核）：✅ 已交付。**
+- 每个 WS 连接维护 `AbortController`，收到 `{ type: 'interrupt' }` 即 abort，新消息自动取消当前 turn：`src/server/wsHandler.ts`
+- `AbortSignal` 贯穿 agent 循环与 LLM fetch：`src/agent/runner.ts`、`src/providers/openaiCompatible.ts`
+- 发送中 Composer 显示停止按钮；中断后保留已生成的部分内容：`web/src/components/Composer.tsx`、`web/src/hooks/useChat.ts`（`interrupted` 分支）
+
+**原现状（2026-05-22）：** Agent 一旦开始就无法打断，前端 sending 状态下用户只能等待。  
 **Codex：** `turn/interrupt` 可随时终止，新消息自动取消当前 turn。
 
 **需求：**
@@ -74,9 +91,13 @@
 
 ---
 
-### P0-4｜Session 完整恢复（Session Restore in UI）
+### P0-4｜Session 完整恢复（Session Restore in UI）✅
 
-**现状：** 侧边栏可列出历史 session，但点击只会新建对话，无法恢复历史消息到 UI。  
+**状态（2026-06-10 复核）：✅ 已交付。**
+- `loadSession(id)` 拉取历史 session 并恢复到 UI，后续对话沿用原 session ID 追加：`web/src/hooks/useChat.ts`
+- 后端消息（含 tool_calls 与 tool 结果配对）映射回前端消息类型：`web/src/hooks/useChat.ts`（`mapBackendMessages`）
+
+**原现状（2026-05-22）：** 侧边栏可列出历史 session，但点击只会新建对话，无法恢复历史消息到 UI。  
 **Codex：** `/resume` 完整恢复历史 thread，包含所有消息和工具调用记录。
 
 **需求：**
@@ -87,9 +108,13 @@
 
 ---
 
-### P0-5｜Shell 沙箱隔离（Sandbox）
+### P0-5｜Shell 沙箱隔离（Sandbox）🟡
 
-**现状：** `shell` 工具直接 `spawn`，无任何隔离，可执行任意系统命令。  
+**状态（2026-06-10 复核）：🟡 部分交付。**
+- 已有：macOS 上 `shell` 工具经 `sandbox-exec` + seatbelt profile 运行，默认禁网络、写入仅限 workspace + /tmp + /var：`src/tools/shell.ts`
+- 缺口：Linux `bwrap` 未实现；`sandboxMode` 配置项与前端沙箱模式选择未实现。后续工作已立项：`requirements/plans/04-execution-safety.md`
+
+**原现状（2026-05-22）：** `shell` 工具直接 `spawn`，无任何隔离，可执行任意系统命令。  
 **Codex：** macOS 用 `seatbelt`，Linux 用 `bwrap + landlock`，网络默认关闭。
 
 **需求：**
@@ -103,9 +128,13 @@
 
 ## 🟠 P1 — 强烈建议（影响日常使用体验）
 
-### P1-1｜项目记忆 / AGENTS.md
+### P1-1｜项目记忆 / AGENTS.md ✅
 
-**现状：** 无项目级指令加载，每次 session 从零开始。  
+**状态（2026-06-10 复核）：✅ 已交付。**
+- 读取 cwd 下的 `AGENTS.md`，注入 system prompt 的 PROJECT INSTRUCTIONS 节：`src/server/wsHandler.ts`
+- 缺口（小）：仅读取 cwd 单层，未沿 git root → cwd 路径链收集；`dvalincode init` 暂不生成模板（`src/commands/init.ts`）
+
+**原现状（2026-05-22）：** 无项目级指令加载，每次 session 从零开始。  
 **Codex：** 从 git root 向下收集所有 `AGENTS.md`，注入 system prompt。
 
 **需求：**
@@ -116,9 +145,15 @@
 
 ---
 
-### P1-2｜Token 用量追踪
+### P1-2｜Token 用量追踪 ✅
 
-**现状：** 无任何 token 计数显示。  
+**状态（2026-06-10 复核）：✅ 已交付。**
+- Provider 透传 `usage`，多轮迭代累加：`src/providers/openaiCompatible.ts`、`src/agent/runner.ts`
+- WebSocket `done` 事件携带用量：`src/server/wsHandler.ts`
+- 前端 topbar 显示本轮 token 数（hover 显示输入/输出明细）与 session 累计费用：`web/src/App.tsx`
+- 缺口（小）：未实现 80k 阈值黄色警告
+
+**原现状（2026-05-22）：** 无任何 token 计数显示。  
 **Codex：** `/status` 显示 session token 用量，TUI 状态栏实时更新。
 
 **需求：**
@@ -130,9 +165,13 @@
 
 ---
 
-### P1-3｜真正的上下文压缩（LLM-based Compaction）
+### P1-3｜真正的上下文压缩（LLM-based Compaction）🟡
 
-**现状：** `COMPACT` 状态仅做简单切片（保留最后 40 条），注释写着 `TODO`。  
+**状态（2026-06-10 复核）：🟡 部分交付。**
+- 已有：`/compact` 调用 LLM 生成结构化摘要（Goal / Completed / Decisions / CurrentState / Pending），失败时回退保留最近 20 条：`src/agent/loop.ts`（`handleCompact`）
+- 缺口：自动触发未接线 —— `compactThreshold` 已定义（`src/agent/types.ts`）但状态机从不自动进入 COMPACT 态
+
+**原现状（2026-05-22）：** `COMPACT` 状态仅做简单切片（保留最后 40 条），注释写着 `TODO`。  
 **Codex：** 调用 summary 模型生成摘要，替换历史消息，保留关键决策上下文。
 
 **需求：**
@@ -144,9 +183,15 @@
 
 ---
 
-### P1-4｜Git 感知（Git Awareness）
+### P1-4｜Git 感知（Git Awareness）✅
 
-**现状：** 完全不知道 git 状态。  
+**状态（2026-06-10 复核）：✅ 已交付。**
+- System prompt 自动注入当前分支与变更文件数：`src/server/wsHandler.ts`
+- `git_status` 工具（分支 + 最近 5 条 commit + 变更文件，只读）与 `/git` 命令：`src/tools/gitStatus.ts`、`src/agent/loop.ts`
+- 前端 topbar 显示当前分支：`web/src/App.tsx`、`src/server/routes/git.ts`
+- 缺口（小）：`git_diff` 工具未实现
+
+**原现状（2026-05-22）：** 完全不知道 git 状态。  
 **Codex：** 读取 branch、最近 commit、未提交变更，支持 stage/commit。
 
 **需求：**
@@ -158,9 +203,13 @@
 
 ---
 
-### P1-5｜前端 Diff 预览（Diff Viewer in UI）
+### P1-5｜前端 Diff 预览（Diff Viewer in UI）✅
 
-**现状：** 工具调用结果在 AgentActivity 中显示原始文本，`write_file`/`edit_file` 无高亮 diff。  
+**状态（2026-06-10 复核）：✅ 已交付。**
+- `write_file` / `edit_file` 生成结构化 diff，随 `tool_result` 的 metadata 下发：`src/core/diffPreview.ts`、`src/tools/writeFile.ts`、`src/tools/editFile.ts`
+- 前端 DiffViewer 渲染（增删行着色），审批弹窗复用同一组件：`web/src/components/DiffViewer.tsx`、`web/src/components/AgentActivity.tsx`、`web/src/components/ApprovalDialog.tsx`
+
+**原现状（2026-05-22）：** 工具调用结果在 AgentActivity 中显示原始文本，`write_file`/`edit_file` 无高亮 diff。  
 **Codex：** 内置 diff_model 模块，文件变更以 unified diff + 语法高亮展示。
 
 **需求：**
@@ -171,9 +220,13 @@
 
 ---
 
-### P1-6｜@ 文件引用（File Mention）
+### P1-6｜@ 文件引用（File Mention）✅
 
-**现状：** 用户只能用自然语言描述文件路径，无法精确引用。  
+**状态（2026-06-10 复核）：✅ 已交付。**
+- Composer 监听 `@` 弹出文件搜索浮层，支持键盘导航与多文件引用：`web/src/components/Composer.tsx`
+- 后端解析 `@path` 并将文件内容注入 user 消息（限制在 cwd 内）：`src/server/wsHandler.ts`（`expandAtMentions`）
+
+**原现状（2026-05-22）：** 用户只能用自然语言描述文件路径，无法精确引用。  
 **Codex：** TUI 和 API 都支持 `@filename` 语法，自动展开文件内容注入 context。
 
 **需求：**
@@ -184,7 +237,11 @@
 
 ---
 
-### P1-7｜多审批模式 UI（Approval Mode Switcher）
+### P1-7｜多审批模式 UI（Approval Mode Switcher）✅
+
+**状态（2026-06-10 复核）：✅ 已交付（形态不同）。**
+- 以 Chat / Cowork / Code 三模式切换器落地，分别映射 `readonly` / `auto-edit` / `full-auto`：`web/src/components/ModeSwitcher.tsx`（经 Sidebar 渲染）、`src/server/wsHandler.ts`（`MODE_APPROVAL`）
+- 备注：独立的 `web/src/components/ApprovalModeSwitch.tsx` 组件存在但当前未被引用
 
 配合 P0-2，前端需要直观切换审批模式：
 
@@ -198,7 +255,9 @@
 
 ## 🟡 P2 — 锦上添花（差异化竞争力）
 
-### P2-1｜MCP 支持（Model Context Protocol）
+### P2-1｜MCP 支持（Model Context Protocol）❌
+
+**状态（2026-06-10 复核）：❌ 未实现。** 实施方案已立项：`requirements/plans/03-mcp-support.md`。
 
 接入 MCP 生态，让用户自定义工具集（如 Slack、Linear、数据库查询）。
 
@@ -210,7 +269,9 @@
 
 ---
 
-### P2-2｜内置 Web 搜索工具
+### P2-2｜内置 Web 搜索工具 ❌
+
+**状态（2026-06-10 复核）：❌ 未实现。**
 
 **需求：**
 - 新增 `web_search` 工具（access: read）
@@ -219,7 +280,9 @@
 
 ---
 
-### P2-3｜生命周期 Hooks
+### P2-3｜生命周期 Hooks ❌
+
+**状态（2026-06-10 复核）：❌ 未实现。**
 
 **需求：**
 - `config.json` 支持 `hooks.preToolUse` / `hooks.postToolUse` 脚本配置
@@ -228,7 +291,11 @@
 
 ---
 
-### P2-4｜多 Profile 配置
+### P2-4｜多 Profile 配置 🟡
+
+**状态（2026-06-10 复核）：🟡 部分交付。**
+- 已有：`config.json` 支持命名 `profiles`，LLM Config 页面可保存 / 应用 / 删除 Profile：`src/server/configStore.ts`、`src/server/routes/config.ts`、`web/src/components/LLMConfigModal.tsx`
+- 缺口：CLI `--profile <name>` 参数未实现
 
 **需求：**
 - `config.json` 支持 `profiles` 命名配置（不同项目不同 provider/model/permissions）
@@ -237,7 +304,11 @@
 
 ---
 
-### P2-5｜计划模式（Plan Mode）
+### P2-5｜计划模式（Plan Mode）✅
+
+**状态（2026-06-10 复核）：✅ 已交付。**
+- `/plan` 指令进入「只提方案不执行」模式：`src/agent/loop.ts`
+- 前端以 PlanCard 展示步骤列表并支持继续执行：`web/src/components/PlanCard.tsx`、`web/src/components/MessageBubble.tsx`
 
 **需求：**
 - Composer 支持 `/plan` 指令，进入「只提方案不执行」模式
@@ -246,7 +317,11 @@
 
 ---
 
-### P2-6｜Token 费用估算
+### P2-6｜Token 费用估算 ✅
+
+**状态（2026-06-10 复核）：✅ 已交付（形态不同）。**
+- 内置各 provider/model 单价表 + 费用计算（含模型名部分匹配回退），topbar 显示 session 累计费用：`web/src/lib/pricing.ts`、`web/src/App.tsx`
+- 备注：单价为内置硬编码表，未做成 LLM Config 可配置项（`price_per_1k_tokens`）
 
 **需求：**
 - 基于 provider 的 token 单价配置，实时计算本 session 费用
@@ -257,28 +332,28 @@
 
 ## 优先级路线图
 
+> 2026-06-10 更新：原 Q1–Q3 计划项已基本全部交付（v0.3.0），路线图改为按实际状态划分。
+
 ```
-Q1（当前冲刺）
-├── P0-1 流式输出
-├── P0-3 中断/取消
-└── P0-4 Session 完整恢复
+✅ 已交付（截至 v0.3.0）
+├── P0-1 流式输出 · P0-2 审批流 · P0-3 中断/取消 · P0-4 Session 恢复
+├── P1-1 AGENTS.md · P1-2 Token 统计 · P1-4 Git 感知 · P1-5 Diff 预览
+├── P1-6 @ 文件引用 · P1-7 审批模式 UI（模式切换器形态）
+└── P2-5 计划模式 · P2-6 费用估算
 
-Q2
-├── P0-2 审批流 + P1-7 审批模式 UI
-├── P1-1 AGENTS.md 项目记忆
-├── P1-2 Token 统计
-└── P1-5 Diff 预览
+🟡 部分交付（待收尾）
+├── P0-5 沙箱：已有 macOS sandbox-exec，缺 Linux bwrap + sandboxMode 配置
+├── P1-3 上下文压缩：/compact 已用 LLM 摘要，缺自动触发（compactThreshold 接线）
+└── P2-4 Profile：后端 + GUI 已支持，缺 CLI --profile 参数
 
-Q3
-├── P0-5 Shell 沙箱
-├── P1-3 LLM 上下文压缩
-├── P1-4 Git 感知
-└── P1-6 @ 文件引用
+⏭ 下一阶段（详见 requirements/plans/）
+├── 子代理与后台任务（plans/02-subagent-tasks.md）
+├── P2-1 MCP 支持（plans/03-mcp-support.md）
+└── P0-5 收尾 + 执行安全加固（plans/04-execution-safety.md）
 
-Q4（差异化）
-├── P2-1 MCP 支持
-├── P2-3 生命周期 Hooks
-└── P2-5 计划模式
+未排期
+├── P2-2 内置 Web 搜索
+└── P2-3 生命周期 Hooks
 ```
 
 ---
@@ -294,4 +369,4 @@ Q4（差异化）
 
 ---
 
-*生成日期：2026-05-22 | 参考版本：Codex v0.133.x*
+*生成日期：2026-05-22 | 参考版本：Codex v0.133.x | 状态复核：2026-06-10，对照 DvalinCode v0.3.0 代码*

--- a/requirements/REQUIREMENTS.md
+++ b/requirements/REQUIREMENTS.md
@@ -158,6 +158,39 @@ Every feature is scored on 5 dimensions (1-5):
 |- **Note**: Interesting case study about structured vibe coding. Could inform guardrails feature. Informational.
 
 
+## Update 2026-06-10 — Release Intelligence (opencode · Claude Code · OpenAI Codex)
+
+> Source data: `data/release_intel_20260610.md` — opencode v1.16.0–v1.17.0 · Claude Code 2.1.157–2.1.170 · Codex rust-v0.134.0–v0.139.0.
+> All three vendors converged on the same three investments this cycle. Development plans: `plans/02-subagent-tasks.md`, `plans/03-mcp-support.md`, `plans/04-execution-safety.md`.
+
+### P1 — New Requirements
+
+#### 14. Subagent & Background Tasks (Score: 13.3)
+- **Pain**: 4/5 · **Align**: 4/5 · **Cost**: 2/5 · **Risk**: 3/5 · **Gap**: 5/5
+- **Signal**: Claude Code dedicated the bulk of 2.1.157–2.1.170 to `claude agents` (dispatch/attach/reply, retire→wake, worktree isolation). opencode v1.16.2 added background subagents. Codex v0.137+ shipped multi-agent v2. Strongest cross-vendor theme of the cycle; DvalinCode has nothing.
+- **What to build**: A `task` tool that spawns a scoped child `AgentRunner` (read-only tool set by default), then a background mode with a task manager, status polling, and WS progress events.
+- **Plan**: `plans/02-subagent-tasks.md`
+
+#### 15. MCP Client Support (Score: 12.5)
+- **Pain**: 4/5 · **Align**: 5/5 · **Cost**: 2/5 · **Risk**: 4/5 · **Gap**: 5/5
+- **Signal**: all three vendors hardened MCP this cycle — opencode v1.17.0 (abort signals, pagination, capability respect), Codex (readOnlyHint concurrency, OAuth, `oneOf`/`allOf` schema fidelity), Claude Code (managed policies, secrets redaction). MCP is now table stakes for an agentic CLI, and it multiplies our provider-neutral, open-ecosystem positioning.
+- **What to build**: zero-dependency stdio JSON-RPC client; map server tools into `ToolRegistry` as `mcp__<server>__<tool>`; reuse the existing approval gates for non-read MCP tools.
+- **Plan**: `plans/03-mcp-support.md`
+
+#### 16. Execution Safety Hardening (Score: 11.1)
+- **Pain**: 5/5 · **Align**: 5/5 · **Cost**: 3/5 · **Risk**: 3/5 · **Gap**: 4/5
+- **Signal**: opencode v1.16.2 now refuses loose edit matches; Claude Code 2.1.160 prompts before writing shell-startup files and build-tool configs that grant code execution; Codex v0.136/v0.139 hardened command safety and sandbox escalation. Continues our #1 community signal (vibe-coding guardrails, ↑7061).
+- **What to build**: unique-match `edit_file` (+ explicit `replaceAll` opt-in), `write_file` overwrite flag, approval-guarded sensitive paths (`.npmrc`, `.git/hooks/`, …), `bwrap` sandbox parity on Linux.
+- **Plan**: `plans/04-execution-safety.md`
+
+### Runner-up (tracked, not planned this cycle)
+- **Session lifecycle v2** — history search, archive, context-overflow recovery (Codex v0.134/v0.136, opencode v1.17.0). Pain 3 · Align 5 · Cost 4 · Risk 4 · Gap 4 → Score 3.8 (P2). Foundation already exists (sessions store + UI restore); revisit next cycle.
+
+### Housekeeping note
+`FEATURE_GAP.md` (2026-05-22) is stale: P0-1 streaming, P0-2 approval flow, P0-3 interrupt/cancel, and P0-4 session restore have all shipped as of v0.3.0.
+
+---
+
 ## Source Log
 
 | Date | Source | Key Signal | Priority |
@@ -191,6 +224,10 @@ Every feature is scored on 5 dimensions (1-5):
 || 2026-05-21 | GitHub CodexCLI #16857 | GPU animation usage (↑182) — not DvalinCode-relevant | P3 |
 || 2026-05-21 | GitHub CodexCLI #11023 | Desktop app for Linux (↑674) — incompatible philosophy | P3 |
 
+| 2026-06-10 | opencode v1.16.0–v1.17.0 releases | Background subagents · MCP hardening · loose-edit-match refusal | P1 |
+| 2026-06-10 | Claude Code 2.1.157–2.1.170 changelog | `claude agents` background sessions · guarded config writes · fallback models | P1 |
+| 2026-06-10 | Codex rust-v0.134.0–v0.139.0 releases | Multi-agent v2 · session search/archive · sandbox escalation + permission profiles | P1 |
+
 ## Shipped
 
 | Date | Feature | Requirement |
@@ -198,3 +235,5 @@ Every feature is scored on 5 dimensions (1-5):
 | 2026-05-20 | ProviderAdapter + OpenAI-compatible provider | Provider neutrality (P2-3) |
 | 2026-05-20 | Session persistence + summary memory | Session management (P2-4) |
 | 2026-05-20 | Permission system (read/write/execute) | Execution safety (P2-5) |
+| 2026-06-03 | Streaming · interrupt/cancel · 3-mode approval flow + dialog UI · session restore in web UI · AGENTS.md memory · token usage display (v0.3.0) | FEATURE_GAP P0-1…P0-4, P1-1, P1-2 |
+| 2026-06-03 | Undo stack · `git_status` tool · ignore-file · macOS sandbox-exec shell wrapper (v0.2.0–v0.3.0) | Undo (P1-1) · Git awareness · sensitive-file exclusion (P2-7) |

--- a/requirements/data/release_intel_20260610.md
+++ b/requirements/data/release_intel_20260610.md
@@ -1,0 +1,62 @@
+# Release Intelligence Report
+## Sources: GitHub Releases / Changelogs — opencode · Claude Code · OpenAI Codex
+
+Collected: 2026-06-10
+Window since last analysis (2026-05-22, Codex v0.133):
+- **opencode** v1.16.0 (06-05) · v1.16.2 (06-05) · v1.17.0 (06-10)
+- **Claude Code** 2.1.157 → 2.1.170
+- **OpenAI Codex** rust-v0.134.0 (05-26) → rust-v0.139.0 (06-09)
+
+---
+
+## opencode (v1.16.0 – v1.17.0)
+
+- **Background subagents** — running subagents can be sent to the background so you keep working (v1.16.2)
+- **Workspace/session mobility** — managed workspace cloning that keeps dirty + untracked files; move sessions between workspaces and directories; project copies managed from the TUI (v1.16.0–v1.17.0)
+- **Skill discovery + file-based agent loading** (v1.16.0)
+- `run --replay` interactive session replay; restored full ACP session replay (v1.16.0)
+- **Edit safety** — edit operations now *refuse loose matches* that could overwrite the wrong code or replace an existing file by mistake (v1.16.2)
+- Diff viewer hunk navigation (v1.16.2)
+- **Context-overflow recovery** — sessions recover once from provider context-overflow errors instead of failing (v1.17.0)
+- **MCP hardening** — tool calls receive abort signals; catalogs paginate correctly; servers' advertised capabilities respected; clearer connection-status messages; `mcp add` works non-interactively (v1.17.0)
+- Faster file search across large projects (fff-backed) (v1.17.0)
+- Desktop: WSL-backed support, multi-server, color themes (v1.16.x–v1.17.0)
+
+## Claude Code (2.1.157 – 2.1.170)
+
+- **Background agents (`claude agents`) — the dominant theme, touched in every release**: dispatch/attach/reply flows, retire→wake state preservation (flags, conversation, running background tasks), `--json` output with `id`/`state`/`waitingFor`, worktree isolation for spawned agents, queued replies on delivery failure, daemon/teardown hardening (SIGTERM before SIGKILL)
+- **Skills/plugins ecosystem** — plugins in `.claude/skills` auto-load with no marketplace required; `claude plugin init` scaffolding; `/plugin list`; bundled-skills disable controls (2.1.157, 2.1.163, 2.1.169)
+- **Write-path safety** — prompt before writing shell startup files (`.zshenv`, `.zlogin`, `.bash_login`) and `~/.config/git/`; `acceptEdits` prompts before build-tool configs that grant code execution (`.npmrc`, `.yarnrc*`, `bunfig.toml`, `.bazelrc`, `.pre-commit-config.yaml`, `.devcontainer/`) (2.1.160)
+- **Permission hardening** — glob patterns in deny rules; `$HOME`-aliased deny paths enforced in Bash; Read deny rules hide files from search; MCP secrets redacted in `mcp list/get`; cross-session messages stripped of user authority (2.1.161–2.1.166)
+- **Resilience** — `fallbackModel` setting (up to three, tried in order); automatic one-shot retry on fallback model; restored idle timeouts on stalled streams (2.1.166, 2.1.169)
+- Session ergonomics: `/cd` moves a session's working directory without breaking prompt cache; `--safe-mode` starts with all customizations disabled; Stop/SubagentStop hooks can return `additionalContext`; parallel tool calls fail independently (2.1.161–2.1.169)
+- LSP tool `workspaceSymbol` fixed (2.1.162)
+
+## OpenAI Codex (rust-v0.134.0 – v0.139.0)
+
+- **Session lifecycle** — search across local conversation history with previews (v0.134); `/archive` + `codex archive`/`unarchive` with resume/fork protection (v0.136); `resume`/`fork --last` accept initial prompts (v0.139); forked threads keep renamed titles (v0.138)
+- **Multi-agent v2** — runtime choice kept per thread; cleaner spawn metadata and follow-up defaults; subagent identity in hook inputs; subagent MCP warnings stay in the owning thread (v0.134–v0.139)
+- **MCP/connectors** — per-server env targeting + OAuth for streamable HTTP (v0.134); read-only MCP tools run concurrently when they advertise `readOnlyHint` (v0.134); `oneOf`/`allOf` + `$ref`/`$defs` schema preservation with smarter compaction (v0.134, v0.139)
+- **Safety/sandbox** — `/diff` no longer executes repository-provided git helpers/hooks; PowerShell parser not invoked on non-Windows; deny read rules enforced on safe-command and approval-bypass paths (v0.136); sandbox preserves approved escalation decisions and enforces proxy-only networking (v0.139); named permission profiles via `/permissions` + `--profile` as primary selector (v0.134–v0.135)
+- Plugins: `--json` across marketplace/add/remove commands, cached remote catalogs (v0.137–v0.139)
+- `/goal` workflow refinements; code mode can call standalone web search, including from nested JS tool calls (v0.138–v0.139)
+
+---
+
+## Cross-cutting themes (by signal strength)
+
+| # | Theme | opencode | Claude Code | Codex | DvalinCode today |
+|---|-------|----------|-------------|-------|------------------|
+| 1 | **Subagents & background tasks** | background subagents | `claude agents` (massive, sustained) | multi-agent v2 | ❌ none |
+| 2 | **MCP as core infrastructure** | abort/pagination/capabilities | policy + secrets hardening | readOnlyHint concurrency, OAuth, schema fidelity | ❌ none |
+| 3 | **Write/exec safety hardening** | refuse loose edit matches | guarded config writes | sandbox escalation, command safety | ⚠️ partial (approval modes ✅, macOS sandbox ✅; loose `edit_file`, no Linux sandbox, no guarded paths) |
+| 4 | Session lifecycle v2 (search/archive/replay/recovery) | move/replay/overflow-recovery | retire→wake, `/cd` | history search, archive | ⚠️ partial (store + UI restore ✅) |
+| 5 | Plugins/skills ecosystems | skill discovery | `.claude/skills` auto-load | marketplace JSON | ❌ none |
+
+## DvalinCode reality check (code-verified 2026-06-10)
+
+Already shipped (FEATURE_GAP.md of 2026-05-22 is **stale**): streaming (`openaiCompatible.ts` SSE), interrupt/cancel (`wsHandler.ts` AbortController), three-mode approval flow + `ApprovalDialog`/`ApprovalModeSwitch` UI, session restore in web UI (`useChat.loadSession`), AGENTS.md project memory, token usage surfacing, undo stack, `git_status` tool, ignore-file, macOS `sandbox-exec` shell wrapping.
+
+Confirmed gaps matching themes 1–3: no subagent/task capability; no MCP; `edit_file` silently replaces the first occurrence when `oldString` is ambiguous (`src/tools/editFile.ts`); `write_file` overwrites without a flag; no Linux sandbox (`src/tools/shell.ts` darwin-only); no guarded sensitive-path approvals.
+
+→ Three requirements derived from this report: see `REQUIREMENTS.md` items 14–16 and `plans/02–04`.

--- a/requirements/plans/02-subagent-tasks.md
+++ b/requirements/plans/02-subagent-tasks.md
@@ -1,0 +1,84 @@
+# Plan: Subagent & Background Tasks
+
+## Goal
+Add a `task` tool so the agent can delegate scoped work to a child agent, then add background execution so long-running tasks don't block the conversation.
+
+## Why P1?
+- Score: 13.3 (REQUIREMENTS.md #14) — strongest cross-vendor theme of the 2026-06 cycle
+- Claude Code 2.1.157–2.1.170: `claude agents` background sessions dominate every release
+- opencode v1.16.2: "Running subagents can now be sent to the background"
+- Codex rust-v0.137+: multi-agent v2 (per-thread runtime, spawn metadata, subagent identity in hooks)
+- DvalinCode has zero delegation capability today
+
+## Design
+
+### Stage 1 — Synchronous subagent (`task` tool)
+
+A new tool the LLM can call to fan out a focused job (e.g. "find every caller of X", "summarize the auth flow"):
+
+```ts
+// input
+{ prompt: string, tools?: string[] }   // tools defaults to read-only set
+```
+
+- `access: 'read'` — the *tool itself* is safe; the child's own tool calls are
+  individually gated by the child context (below).
+- Builds a **fresh registry** via `createDefaultToolRegistry()` +
+  `setAllowedTools(input.tools ?? READ_ONLY_TOOLS)` where
+  `READ_ONLY_TOOLS = ['read_file', 'list_files', 'search_text', 'git_status']`.
+  Never mutate the parent's registry (`setAllowedTools` is instance-level state).
+- Child context derives from the parent `DvalinContext`:
+  - `agentDepth: (parent.agentDepth ?? 0) + 1` — new field; `task` throws if
+    parent depth ≥ 1 (no recursive subagents)
+  - `allowWrite`/`allowExecute` can only be narrowed, never widened; non-read
+    child tools still flow through the existing `requestApproval` callback in
+    auto-edit mode (free integration with `ApprovalDialog`)
+- Runs a child `AgentRunner` (`RunnerOptions` reuses parent provider + config
+  with a lower `maxIterations`) and returns the child's `finalResponse` as the
+  `ToolResult.output`. Child `usage` goes in `metadata.usage`; parent
+  accumulates it into the turn total in `runner.ts` alongside its own provider
+  usage.
+- Abort: child `runTurn` receives the parent's `AbortSignal` so interrupt
+  (`wsHandler.ts` `currentAbort`) kills the whole tree.
+- Events: child events are forwarded to the parent `AgentEventHandler` wrapped
+  as `{ type: 'task_progress', taskId, inner }` so `AgentActivity` can render a
+  nested timeline.
+- `isConcurrencySafe: () => true` for read-only tool sets — enables future
+  parallel fan-out.
+
+### Stage 2 — Background execution
+
+- `task` input gains `background?: boolean`. When true, the tool registers the
+  run with a new `TaskManager` and immediately returns `Task started: tsk_xxx`.
+- `src/agent/taskManager.ts`: `Map<taskId, { status: 'running'|'done'|'failed', promise, outputBuffer, abort: AbortController, usage }>` — server-process scoped.
+- New read-only tool `task_status` (`{ taskId?: string }`) returns one/all task
+  states + accumulated output, so the model can check back later.
+- WS: new server event `{ type: 'task_update', taskId, status, title }` pushed
+  on state change; web UI badges running tasks in `AgentActivity`.
+- Interrupt semantics: `interrupt` aborts the foreground turn only; background
+  tasks keep running and are listed for explicit cancellation (matches Claude
+  Code/opencode behavior). WS disconnect aborts everything.
+
+### Stage 3 — Future (out of scope here)
+- Parallel fan-out UI, per-task git worktree isolation (opencode workspace
+  cloning, Claude Code worktree agents), cross-session task persistence.
+
+## File Changes
+1. `src/tools/task.ts` — new: `task` tool, child registry/context construction, depth guard
+2. `src/agent/taskManager.ts` — new (stage 2): background task registry
+3. `src/tools/taskStatus.ts` — new (stage 2): `task_status` tool
+4. `src/core/context.ts` — add `agentDepth?: number` to `DvalinContext`
+5. `src/tools/registry.ts` — register new tools in `createDefaultToolRegistry()`; export `READ_ONLY_TOOLS`
+6. `src/agent/runner.ts` — accumulate `metadata.usage` from task results into turn usage
+7. `src/agent/types.ts` — add `task_progress` to `AgentEventHandler` event union
+8. `src/server/wsHandler.ts` — `task_update` server event (stage 2); leave background tasks alive on foreground interrupt
+9. `web/src/components/AgentActivity.tsx` — render nested task progress + running-task badge (stage 2)
+10. `tests/task.test.ts` — new test suite
+
+## Verification
+- Child with default tools cannot write: `task` running a prompt that triggers `write_file` → child throws permission error, parent receives it as tool output (test with mock provider)
+- Depth guard: a child calling `task` fails with a clear error
+- Abort: aborting the parent signal settles the child run promptly
+- Usage: parent turn usage includes child tokens
+- Stage 2: `task(background:true)` returns immediately; `task_status` reflects running → done; WS `task_update` fires
+- `npm run check` passes

--- a/requirements/plans/03-mcp-support.md
+++ b/requirements/plans/03-mcp-support.md
@@ -1,0 +1,88 @@
+# Plan: MCP Client Support
+
+## Goal
+Let users connect MCP (Model Context Protocol) servers so their tools become available to the agent — stdio transport first, zero new dependencies.
+
+## Why P1?
+- Score: 12.5 (REQUIREMENTS.md #15) — all three competitors hardened MCP in the 2026-06 cycle
+- opencode v1.17.0: MCP abort signals, catalog pagination, capability respect, non-interactive `mcp add`
+- Codex rust-v0.134+: per-server env, OAuth for streamable HTTP, concurrent read-only tools via `readOnlyHint`, `oneOf`/`allOf`/`$ref` schema preservation
+- Claude Code 2.1.161+: managed MCP policies, secrets redaction in `mcp list/get`
+- MCP multiplies DvalinCode's provider-neutral, open-REST-API positioning; without it we're locked out of the ecosystem
+
+## Design
+
+### Stage 1 — stdio transport + tool bridging
+
+**Config** (`configStore.ts`, same JSON config the GUI edits):
+```jsonc
+"mcpServers": [
+  { "name": "github", "command": "npx", "args": ["-y", "@modelcontextprotocol/server-github"],
+    "env": { "GITHUB_TOKEN": "..." }, "enabled": true }
+]
+```
+
+**Client** — `src/mcp/client.ts`, no SDK dependency (aligns with the zero-dep
+philosophy). MCP stdio framing is newline-delimited JSON-RPC 2.0:
+- `spawn(command, args, { env })`, write requests to stdin, parse stdout lines
+- Handshake: `initialize` (protocolVersion `2025-03-26`, client info) →
+  `notifications/initialized`
+- Respect advertised capabilities: only call `tools/list` when
+  `capabilities.tools` is present (opencode v1.17.0 fix — bake in from day one)
+- `tools/list` with cursor pagination loop (ditto)
+- `tools/call` with per-call timeout (default 30s); on `AbortSignal` send
+  `notifications/cancelled` and reject (ditto)
+- Server crash → mark server `failed`, surface a clear status message; never
+  take the agent down
+
+**Bridge** — `src/mcp/bridge.ts` maps each MCP tool to our `Tool<unknown>`:
+- Name: `mcp__<server>__<tool>` (collision-proof, recognizable in approval UI)
+- `access`: `annotations.readOnlyHint === true ? 'read' : 'write'` — mirrors
+  Codex; non-read MCP tools then flow through the existing
+  `assertToolPermission` + auto-edit `requestApproval` gates in
+  `ToolRegistry.run()` for free
+- Schema: MCP supplies raw JSON Schema, but `Tool.inputSchema` is zod and
+  `AgentRunner.buildToolDefs()` calls `inputSchema.toJSONSchema?.()`. Add an
+  optional `jsonSchema?: Record<string, unknown>` field to `Tool` that
+  `buildToolDefs()` prefers over the zod conversion; bridge tools use it and
+  set `inputSchema` to a permissive object schema (server-side validation is
+  authoritative). Preserve the schema as-is — no lossy flattening (Codex
+  v0.139 lesson)
+- `isConcurrencySafe: () => access === 'read'`
+- Result: concatenate `content[]` text parts into `ToolResult.output`;
+  non-text parts noted as `[image]`/`[resource]` placeholders
+
+**Manager** — `src/mcp/manager.ts`: reads config, starts enabled servers,
+registers bridged tools into the session's `ToolRegistry`, exposes
+`statuses()`, `dispose()`. Wired up in `wsHandler.ts` (web) and
+`commands/chat.ts` (CLI) at session start.
+
+**CLI** — `src/commands/mcp.ts`: `dvalincode mcp add|list|remove`,
+non-interactive friendly. `list` redacts `env` values (Claude Code 2.1.161
+lesson: never print secrets).
+
+### Stage 2 — later
+- Streamable HTTP transport + OAuth, MCP resources/prompts, server management
+  panel in `SettingsPanel`, per-server tool allowlists.
+
+## File Changes
+1. `src/mcp/client.ts` — new: stdio JSON-RPC client (handshake, list, call, cancel)
+2. `src/mcp/bridge.ts` — new: MCP tool → `Tool<unknown>` mapping
+3. `src/mcp/manager.ts` — new: lifecycle + registration
+4. `src/commands/mcp.ts` — new: `mcp add|list|remove` subcommands; register in `src/index.ts`
+5. `src/server/configStore.ts` — `mcpServers` config section + validation
+6. `src/tools/types.ts` — optional `jsonSchema` field on `Tool`
+7. `src/agent/runner.ts` — `buildToolDefs()` prefers `tool.jsonSchema` when present
+8. `src/server/wsHandler.ts` — start/dispose manager per session; surface server statuses to the UI
+9. `tests/mcp.test.ts` — new: fixture MCP server (small node script speaking stdio JSON-RPC) + client/bridge tests
+
+## Verification
+- Fixture server: handshake completes, tools listed across two pages, `tools/call` round-trips
+- A `readOnlyHint: false` MCP tool in auto-edit mode triggers `requestApproval`; rejection produces "User rejected" without calling the server
+- Abort mid-call sends `notifications/cancelled` and settles the tool promise
+- Killing the fixture server mid-session degrades gracefully (status `failed`, agent keeps working)
+- `dvalincode mcp list` never prints env secret values
+- `npm run check` passes
+
+## Out of scope (v1)
+HTTP/OAuth transports, MCP resources & prompts, sampling, GUI management panel.

--- a/requirements/plans/04-execution-safety.md
+++ b/requirements/plans/04-execution-safety.md
@@ -1,0 +1,90 @@
+# Plan: Execution Safety Hardening
+
+## Goal
+Close the three write/exec safety gaps competitors fixed this cycle: ambiguous edits, silent overwrites/sensitive-config writes, and the missing Linux sandbox.
+
+## Why P1?
+- Score: 11.1 (REQUIREMENTS.md #16) — and it continues our #1 community signal (vibe-coding guardrails, ↑7061)
+- opencode v1.16.2: "Edit operations now refuse loose matches that could overwrite the wrong code or replace an existing file by mistake"
+- Claude Code 2.1.160: prompts before writing shell startup files and build-tool configs that grant code execution
+- Codex rust-v0.136/v0.139: command-safety hardening, sandbox escalation decisions, proxy-only networking
+- "The agent that writes maintainable code" is our stated positioning — safety parity is not optional
+
+## Design
+
+### 4a — Strict edit matching (`edit_file`)
+
+Today `src/tools/editFile.ts` computes `occurrences` but silently replaces the
+first match. Change `run()`:
+- `occurrences > 1` and `replaceAll` not set → throw:
+  `oldString matches N locations in <file>. Add surrounding context to make it unique, or pass replaceAll: true.`
+  (the error text teaches the model the fix — keeps retry cost low)
+- New optional input `replaceAll?: boolean` (default false) → replaces all
+  occurrences (`split().join()`), reports count in output
+- Undo: single-occurrence edits keep the existing string-swap `reverse()`;
+  `replaceAll` edits return `isUndoable: false` (reverse-swap is ambiguous if
+  `newString` already occurred elsewhere)
+
+### 4b — Overwrite + guarded-path approvals
+
+**`write_file` overwrite flag**: if the target exists and input
+`overwrite: true` is absent → throw
+`File exists: <path>. Pass overwrite: true to replace it (a diff will be reported).`
+Backup/diff machinery already exists for undo, so behavior past the gate is unchanged.
+
+**Guarded sensitive paths** — `src/core/guardedPaths.ts`:
+```ts
+const GUARDED = ['.npmrc', '.yarnrc', '.yarnrc.yml', 'bunfig.toml', '.bazelrc',
+  '.pre-commit-config.yaml', '.devcontainer/', '.git/hooks/', '.husky/',
+  '.vscode/tasks.json', '.envrc'];   // files that grant code execution implicitly
+export function isGuardedPath(relPath: string): boolean
+```
+Enforcement in `ToolRegistry.run()` after `inputSchema.parse()`: when
+`tool.access !== 'read'` and the parsed input has a `filePath` hitting the
+guard list, require `context.requestApproval` **even in full-auto mode**
+(approval request carries a `reason: 'guarded-path'` field so
+`ApprovalDialog` can explain *why*). Headless CLI runs without a
+`requestApproval` callback throw with a pointer to the new
+`--allow-guarded` flag (`DvalinContext.allowGuardedPaths`).
+
+### 4c — Linux sandbox parity (`shell` tool)
+
+`src/tools/shell.ts` already wraps commands with `sandbox-exec` on macOS
+(network denied, writes limited to cwd/tmp). Mirror it on Linux when `bwrap`
+is on PATH:
+```
+bwrap --ro-bind / / --bind <cwd> <cwd> --tmpfs /tmp --unshare-net
+      --die-with-parent --proc /proc --dev /dev -- <command> <args...>
+```
+- `DvalinContext.sandboxMode: 'auto' | 'off'` (default `auto`; `off` preserves
+  today's unsandboxed escape hatch for trusted workflows)
+- `ToolResult.metadata.sandbox: 'seatbelt' | 'bwrap' | 'none'` so the UI can
+  badge unsandboxed runs (Windows and bwrap-less Linux report `none`)
+- Sandbox-denied failures (non-zero exit + EPERM/network patterns in output)
+  set `metadata.sandboxDenied: true` so the model understands *why* the
+  command failed and can ask the user instead of flailing
+
+### Stage 2 (not this cycle)
+Escalation memory à la Codex v0.139: an approved "re-run unsandboxed" decision
+is remembered per command per session.
+
+## File Changes
+1. `src/tools/editFile.ts` — uniqueness check, `replaceAll` input, undo rules
+2. `src/tools/writeFile.ts` — `overwrite` input gate
+3. `src/core/guardedPaths.ts` — new: guard list + matcher
+4. `src/tools/registry.ts` — guarded-path approval hook in `run()`
+5. `src/core/context.ts` — `sandboxMode`, `allowGuardedPaths` options
+6. `src/tools/shell.ts` — bwrap wrapper, sandbox metadata, denial detection
+7. `src/server/wsHandler.ts` — pass `reason` through `approval_request`; expose `sandboxMode` from client settings
+8. `web/src/components/ApprovalDialog.tsx` — render guarded-path reason
+9. `tests/editFile.test.ts`, `tests/writeFile.test.ts` — extend; `tests/guardedPaths.test.ts`, `tests/shellSandbox.test.ts` — new (sandbox test skips when bwrap/sandbox-exec unavailable)
+
+## Verification
+- Ambiguous edit (2+ occurrences) fails with the teaching error; `replaceAll: true` replaces all and reports count; unique edit behavior unchanged (existing tests stay green)
+- `write_file` on an existing file fails without `overwrite: true`; undo still restores the backup
+- Writing `.git/hooks/pre-commit` in full-auto triggers an approval request with `reason: 'guarded-path'`; headless run without callback throws mentioning `--allow-guarded`
+- On Linux with bwrap: `curl` from shell tool fails (network unshared), writes outside cwd fail, `metadata.sandbox === 'bwrap'`
+- `npm run check` passes
+
+## Risk note
+Strict matching will surface previously-silent ambiguous edits as errors — expected and desired, but watch the agent-retry rate after rollout; the error messages are written to make self-correction one-shot.


### PR DESCRIPTION
## Summary

**README (EN + zh-CN) — explicit core goal.** New `🎯 Core Goal` section and matching hero tagline:

> A local-first coding agent: **any model, safe by default, small enough to audit, open enough to embed.**

The four pillars are spelled out with the pain points they answer (vendor lock-in, full-auto trust, auditability, integration), and the bundled web GUI is positioned as the runtime's **reference implementation and showcase** — the first consumer of the public REST + WebSocket API.

**2026-06 release-intelligence cycle.** Read the June releases of opencode (v1.16.0–v1.17.0), Claude Code (2.1.157–2.1.170), and OpenAI Codex (rust-v0.134.0–v0.139.0); raw intel in `requirements/data/release_intel_20260610.md`. All three vendors converged on the same three investments, which became scored P1 requirements (`REQUIREMENTS.md` #14–#16) with implementation plans:

| Plan | Requirement | Score |
|---|---|---|
| `plans/02-subagent-tasks.md` | `task` tool spawning scoped child `AgentRunner` → background `TaskManager` | 13.3 |
| `plans/03-mcp-support.md` | zero-dep stdio MCP client bridged into `ToolRegistry` (`mcp__<server>__<tool>`) | 12.5 |
| `plans/04-execution-safety.md` | unique-match `edit_file`, guarded sensitive paths, Linux `bwrap` sandbox | 11.1 |

**FEATURE_GAP.md re-audit** (from the spawned background task): every item checked against v0.3.0 code — P0-1…P0-4 (streaming, approval flow, interrupt, session restore) are shipped and now marked ✅; the roadmap section reflects actual status and links the new plans.

## Testing

Docs-only — no code changes, so no tests to run. All implementation claims in the plans and intel were verified against `src/` (e.g. the approval/interrupt WS protocol in `wsHandler.ts`, `edit_file`'s first-occurrence replacement, the macOS-only `sandbox-exec` wrapper in `shell.ts`), and competitor release notes were pulled from the official GitHub releases/changelogs.

## Notes

- Recommended build order for the plans: **04 → 03 → 02** — safety gates land first, MCP is additive, and subagents then inherit both the gates and any MCP tools.
- Plans are designs only; implementation is the next cycle. Plan numbering continues from the existing `01-undo-system.md`.
- Session-lifecycle v2 (history search / archive / overflow recovery) was the runner-up theme — tracked in REQUIREMENTS.md as P2, not planned this cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)