### PR TITLE
feat(requirements): Gemini analysis → /compact plan + dvalin.json tea…

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,17 @@ The bundled **web GUI is the runtime's reference implementation and showcase** �
 
 ---
 
+## 🆚 When to choose DvalinCode
+
+| If you're frustrated by… | DvalinCode's answer |
+|---|---|
+| **Cline / Cursor** — IDE-locked, huge install, privacy concerns | Zero-dep binary (~25 MB). Runs anywhere, no IDE required. macOS shell is sandboxed by default — network denied, writes capped to `cwd`. |
+| **Claude Code / Aider** — pure terminal, diff output is a wall of text, env setup is painful | CLI start → auto-opens a modern Web UI with code highlighting and red/green diff approval. One install command, nothing else needed. |
+| **Any cloud agent** — vendor lock-in, rate limits, can't use a local model | Every OpenAI-compatible endpoint is a first-class citizen. Run Ollama with Qwen2.5-Coder: no key, no internet, no per-token cost. |
+| **Any agent** — new teammate can't reproduce your AI setup, routines are stuck in your IDE | `AGENTS.md` committed to the repo ships AI context to every clone. `dvalin.json` (coming in v0.4) ships the team's automation commands the same way. |
+
+---
+
 ## 🚀 Quick Install
 
 ### macOS / Linux (one-liner)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -79,6 +79,17 @@ DvalinCode 的定位是 **Agent 运行时（runtime）**，而不只是又一个
 
 ---
 
+## 🆚 什么时候选择 DvalinCode
+
+| 如果你厌倦了… | DvalinCode 的解法 |
+|---|---|
+| **Cline / Cursor** — 绑定 IDE、安装包庞大、代码上传到云端让人不安 | 单二进制 (~25 MB)，无需任何 IDE。macOS shell 调用默认运行在 `sandbox-exec` 沙箱中——拒绝网络访问，写入范围限制在 `cwd`。 |
+| **Claude Code / Aider** — 纯命令行看 Diff 太痛苦，环境配置繁琐 | CLI 启动后自动打开现代 Web UI，支持代码高亮和红绿 Diff 逐文件审批。一行安装命令，无需其他依赖。 |
+| **任何云端 Agent** — 厂商锁定、频繁限速、无法使用本地模型 | 所有 OpenAI Compatible 端点均为一等公民。用 Ollama 跑 Qwen2.5-Coder：无需 API Key，无需联网，零 Token 费用。 |
+| **任何 Agent** — 新队友无法复现你的 AI 配置，Routines 被锁在你的 IDE 里 | `AGENTS.md` 提交到仓库，随 `git clone` 把 AI 上下文同步给所有人。`dvalin.json`（v0.4 计划）以同样方式共享团队自动化命令集。 |
+
+---
+
 ## 🚀 一行安装
 
 ### macOS / Linux

--- a/requirements/REQUIREMENTS.md
+++ b/requirements/REQUIREMENTS.md
@@ -191,6 +191,74 @@ Every feature is scored on 5 dimensions (1-5):
 
 ---
 
+## Update 2026-06-11 — Gemini Competitive Analysis
+
+> Source: Gemini review of DvalinCode positioning vs. Cline / Aider / Cursor / Claude Code.
+> Two net-new items surfaced; three pain points confirmed existing direction. Plans: `plans/05-compact-command.md`, `plans/06-team-playbook.md`.
+
+### Assessment: what Gemini confirmed (no new work needed)
+
+| Pain point | DvalinCode answer | Status |
+|---|---|---|
+| 黑盒焦虑 / 权限失控 | 3-mode physical isolation (Chat=read-only, Cowork=plan-then-approve, Code=full-auto) | ✅ Shipped v0.3.0 |
+| 环境依赖重 | Single ~25 MB zero-dep binary, `install.sh` one-liner | ✅ Shipped |
+| LLM 厂商绑定 | `ProviderAdapter` treats DeepSeek / Ollama / OpenAI as first-class | ✅ Shipped |
+| CLI vs. heavy GUI | CLI start → auto-launch Web UI with code highlight + diff view | ✅ Shipped v0.3.0 |
+| 团队 AI 指令无法共享 | `AGENTS.md` committed to repo, shared with whole team | ✅ Shipped v0.3.0 |
+
+### P2 — New Requirements (from Gemini)
+
+#### 17. `/compact` — User-Triggered Context Compression (Score: 8.0) ⬆️ Upgrade from P2 #2
+
+> Replaces / supersedes P2 #2 (Token Efficiency / Cost Awareness). AgentLoop already has a COMPACT state; this turns it into an explicit user command with a structured output format.
+
+- **Pain**: 4/5 · **Align**: 5/5 · **Cost**: 4/5 · **Risk**: 5/5 · **Gap**: 4/5
+- **Score**: (4×5×4) / (4×5) = **8.0** → P2 (was 6.4, upgrading based on local-model framing)
+- **Signal**: Local and cheap model users (DeepSeek, Ollama/Qwen) hit context limits and start hallucinating far sooner than Claude/GPT-4 users. `/compact` is the mechanism that makes a 32k-context local model viable for a full coding session. Gemini specifically called out that no competitor surfaces this as a first-class user command with a structured output.
+- **What to build**:
+  1. `/compact` slash-command in the Web UI chat input
+  2. Backend: call existing `summarizeSession()` → rewrite conversation to a structured summary:
+     ```
+     ## Goal
+     <one-sentence statement of the session's objective>
+     ## Completed
+     - <list of tasks finished, with file paths>
+     ## Key Decisions
+     - <architectural choices, API design, non-obvious picks>
+     ## Pending
+     - <remaining work items>
+     ```
+  3. Replace the full message history with a single `system` message containing this summary + a `user` message with the pending list
+  4. Show a "Context compressed: 12 400 → 800 tokens (−94%)" toast in the UI
+- **Value prop**: Explicitly framed as "the feature that makes local and cheap models viable for long sessions."
+- **Plan**: `plans/05-compact-command.md`
+
+---
+
+#### 18. Team AI Playbook — `dvalin.json` (Score: 4.0)
+
+- **Pain**: 4/5 · **Align**: 5/5 · **Cost**: 4/5 · **Risk**: 5/5 · **Gap**: 4/5
+- **Score**: (4×5×4) / (4×5) = **4.0** → P2
+- **Signal**: Currently, the Routines panel (Run tests / Type check / Build / Git status / Lint) is stored in `localStorage`. When a new teammate clones the repo or you switch machines, all those AI quick-commands are gone. AGENTS.md shares the AI context, but not the runbook of automation commands. Gemini identified this as the next natural extension: commit a `dvalin.json` to the repo and ship everyone the same AI automation playbook.
+- **What to build**:
+  1. On startup, DvalinCode reads `<workspace>/.dvalin.json` (if present) and merges its `routines` list into the Routines panel
+  2. In the Routines panel UI, add an **Export** button: writes current routines to `.dvalin.json` in the workspace root
+  3. Schema (minimal):
+     ```json
+     {
+       "version": 1,
+       "routines": [
+         { "label": "Run tests", "prompt": "Run the full test suite and report failures" },
+         { "label": "Type check", "prompt": "Run tsc --noEmit and list all type errors" }
+       ]
+     }
+     ```
+  4. `.dvalin.json` committed to git → every `git clone` delivers the same AI playbook
+- **DvalinCode differentiator**: No other tool makes "team AI automation commands" a first-class git artifact. AGENTS.md gives context; `dvalin.json` gives commands. Together they form a complete "AI onboarding file" for a project.
+- **Plan**: `plans/06-team-playbook.md`
+
+---
+
 ## Source Log
 
 | Date | Source | Key Signal | Priority |
@@ -227,6 +295,7 @@ Every feature is scored on 5 dimensions (1-5):
 | 2026-06-10 | opencode v1.16.0–v1.17.0 releases | Background subagents · MCP hardening · loose-edit-match refusal | P1 |
 | 2026-06-10 | Claude Code 2.1.157–2.1.170 changelog | `claude agents` background sessions · guarded config writes · fallback models | P1 |
 | 2026-06-10 | Codex rust-v0.134.0–v0.139.0 releases | Multi-agent v2 · session search/archive · sandbox escalation + permission profiles | P1 |
+| 2026-06-11 | Gemini competitive review | `/compact` critical for local/cheap models; `dvalin.json` team playbook differentiator | P2 |
 
 ## Shipped
 

--- a/requirements/plans/05-compact-command.md
+++ b/requirements/plans/05-compact-command.md
@@ -1,0 +1,119 @@
+# Plan: `/compact` — User-Triggered Context Compression
+
+## Goal
+
+Turn the existing (but unexposed) `COMPACT` state in `AgentLoop` into a first-class user command with a structured output format. Primary audience: local model users (Ollama/Qwen) and cheap-model users (DeepSeek) who hit context limits mid-session and start hallucinating.
+
+## Why P2?
+
+- Score: 8.0 (REQUIREMENTS.md #17) — upgrade from P2 #2 (Token Efficiency, score 6.4)
+- Gemini analysis: no competitor surfaces context compression as an explicit command with user-visible output
+- Local/cheap models have 8k–32k effective context windows; long coding sessions overflow in 20–40 turns
+- Existing `summarizeSession()` in `AgentLoop` does the heavy lifting — this is mostly a UX/exposure task
+
+## Design
+
+### User flow
+
+1. User types `/compact` in the chat input (or clicks a "Compact" button in the overflow menu)
+2. Frontend sends `{ type: 'compact' }` over WebSocket
+3. Backend calls `summarizeSession(messages)` → receives the summary
+4. Backend replaces the in-memory message history with:
+   - One `system` message: the structured summary (see format below)
+   - One `user` message: "Context was compacted. Continue from the Pending list."
+5. Backend responds with a special `{ type: 'compact_done', before, after }` WS event
+6. Frontend shows a dismissable toast: **"Context compressed: 12 400 → 800 tokens (−94%)"**
+7. Chat scrolls to a visual separator: `── context compacted ──`
+
+### Structured summary format
+
+The LLM prompt passed to `summarizeSession()` should request this exact structure:
+
+```
+## Goal
+<one sentence: what the user is trying to accomplish this session>
+
+## Completed
+- <task or file changed, with file path if applicable>
+- ...
+
+## Key decisions
+- <non-obvious architectural choice or API design decision>
+- ...
+
+## Pending
+- <remaining work items in order of priority>
+- ...
+```
+
+This structure is optimised for re-priming a fresh model context: Goal orients it, Completed prevents re-doing work, Key decisions prevent undoing choices, Pending gives the next action.
+
+### Slash-command registration
+
+DvalinCode already handles `/` commands in `wsHandler.ts` (e.g. `/load`). Add:
+
+```ts
+// src/server/wsHandler.ts
+if (msg.type === 'compact') {
+  const summary = await summarizeSession(session.messages, llmClient);
+  const compactedMessages = buildCompactedHistory(summary);
+  session.messages = compactedMessages;
+  const tokensBefore = estimateTokens(originalMessages);
+  const tokensAfter = estimateTokens(compactedMessages);
+  ws.send(JSON.stringify({
+    type: 'compact_done',
+    summary,
+    tokensBefore,
+    tokensAfter,
+  }));
+  return;
+}
+```
+
+### Frontend: slash-command trigger
+
+In `web/src/`, the chat input already parses `/` commands. Register `/compact`:
+
+```ts
+// web/src/components/ChatInput.tsx (or equivalent)
+if (text === '/compact') {
+  sendWsMessage({ type: 'compact' });
+  return;
+}
+```
+
+Also add a **"Compact context"** entry to the `⋮` (more options) menu in the chat toolbar — one-click for users who don't know the slash command.
+
+### Visual separator
+
+When the frontend receives `compact_done`, insert a divider message in the chat thread:
+
+```
+── context compacted · 12 400 → 800 tokens (−94%) ──
+```
+
+Styled as a muted horizontal rule, not a chat bubble.
+
+## Files to touch
+
+| File | Change |
+|---|---|
+| `src/server/wsHandler.ts` | Handle `type: 'compact'` message |
+| `src/agent/loop.ts` | Export / clean up `summarizeSession()` signature |
+| `src/agent/compact.ts` | New: `buildCompactedHistory(summary)` + structured prompt |
+| `web/src/components/ChatInput.tsx` | Register `/compact` slash command |
+| `web/src/components/ChatThread.tsx` | Render compact-done divider |
+| `web/src/hooks/useWebSocket.ts` | Handle `compact_done` WS event |
+
+## Acceptance criteria
+
+- [ ] `/compact` typed in chat → toast shows token reduction, divider appears in thread
+- [ ] After compact, LLM response references the summary (Goal / Pending) not raw prior messages
+- [ ] Token count in topbar decreases to reflect compacted context
+- [ ] Works with all three providers (DeepSeek, OpenAI, Ollama)
+- [ ] Second `/compact` in same session works (can compact already-compacted history)
+
+## Open questions
+
+- Should `/compact` be auto-triggered when context exceeds a threshold (e.g. 80% of model's `maxTokens`)? Start manual-only; auto-compact in a follow-up.
+- Should the compacted summary be persisted to the session store so restoring the session still works? Yes — store the compacted messages as the session's message list.

--- a/requirements/plans/06-team-playbook.md
+++ b/requirements/plans/06-team-playbook.md
@@ -1,0 +1,151 @@
+# Plan: Team AI Playbook — `dvalin.json`
+
+## Goal
+
+Make the Routines panel (currently stored in `localStorage`, machine-local) into a project-level git artifact. A `dvalin.json` file committed to the repo delivers every team member — and every new clone — the same set of AI automation commands.
+
+## Why P2?
+
+- Score: 4.0 (REQUIREMENTS.md #18)
+- **AGENTS.md** gives the AI context about the project. **`dvalin.json`** gives the AI the runbook — the team's agreed set of quick commands. Together they form a complete "AI onboarding package" for any project.
+- No competitor (Cline, Aider, Claude Code) makes team AI commands a first-class git artifact.
+- The Routines panel already exists in the UI; this is mostly a read/write/merge layer.
+
+## Design
+
+### Schema (`dvalin.json` v1)
+
+Minimal and forwards-compatible:
+
+```json
+{
+  "version": 1,
+  "routines": [
+    {
+      "label": "Run tests",
+      "prompt": "Run the full test suite and report any failures"
+    },
+    {
+      "label": "Type check",
+      "prompt": "Run tsc --noEmit and list all type errors with file paths and line numbers"
+    },
+    {
+      "label": "Build",
+      "prompt": "Build the project and report any build errors"
+    },
+    {
+      "label": "Git status",
+      "prompt": "Show the current git status, staged changes, and recent commits"
+    },
+    {
+      "label": "Lint",
+      "prompt": "Run the linter and auto-fix what's safe; list remaining warnings"
+    }
+  ]
+}
+```
+
+### Behaviour
+
+#### On startup (read)
+
+When DvalinCode starts and the WebSocket handshake delivers `cwd`, the backend checks for `<cwd>/dvalin.json`:
+
+```ts
+// src/server/wsHandler.ts  (or a new src/config/playbook.ts)
+async function loadPlaybook(cwd: string): Promise<Routine[]> {
+  const p = path.join(cwd, 'dvalin.json');
+  try {
+    const raw = await fs.readFile(p, 'utf-8');
+    const data = JSON.parse(raw);
+    if (data.version === 1 && Array.isArray(data.routines)) {
+      return data.routines;               // { label, prompt }[]
+    }
+  } catch { /* file absent or invalid — silent */ }
+  return [];
+}
+```
+
+The routines are sent to the frontend via a new WS event `{ type: 'playbook', routines }` (or piggybacked on the existing session-init payload).
+
+**Merge strategy**: project routines from `dvalin.json` are shown first; any user-added routines (localStorage) that don't share a label with a project routine are appended below a visual separator — "Project routines" vs. "My routines".
+
+#### Export button (write)
+
+In the Routines panel sidebar, add an **Export** button (icon: `ti-download`). Clicking it:
+
+1. POSTs the current routines list to `POST /api/playbook` with `{ cwd, routines }`
+2. Backend writes `<cwd>/dvalin.json` atomically (write to `.dvalin.json.tmp`, then rename)
+3. Frontend shows a toast: **"Saved to dvalin.json — commit it to share with your team"**
+
+#### `GET /api/playbook?cwd=…`
+
+Returns the parsed `dvalin.json` (or `{ routines: [] }` if absent). Frontend calls this once on session load.
+
+### Frontend changes
+
+**Routines panel** (`web/src/components/Sidebar.tsx` or equivalent):
+
+```
+ROUTINES                              [Export ↓]
+──────────────────────────────────────
+▸ Run tests          (from dvalin.json)
+▸ Type check         (from dvalin.json)
+▸ Build              (from dvalin.json)
+──────────────────────────────────────
+▸ My custom routine  (local only)
+                                    [+ Add]
+```
+
+Each project routine shows a small "project" badge so users understand the source.
+
+### API routes (backend)
+
+```ts
+// src/server/index.ts
+app.get('/api/playbook',  playbookHandler.get);   // returns { routines }
+app.post('/api/playbook', playbookHandler.save);  // writes dvalin.json
+```
+
+```ts
+// src/server/playbookHandler.ts
+export async function get(req, res) {
+  const cwd = req.query.cwd as string;
+  res.json({ routines: await loadPlaybook(cwd) });
+}
+
+export async function save(req, res) {
+  const { cwd, routines } = req.body;
+  const out = JSON.stringify({ version: 1, routines }, null, 2);
+  const tmp = path.join(cwd, '.dvalin.json.tmp');
+  const dest = path.join(cwd, 'dvalin.json');
+  await fs.writeFile(tmp, out, 'utf-8');
+  await fs.rename(tmp, dest);
+  res.json({ ok: true });
+}
+```
+
+## Files to touch
+
+| File | Change |
+|---|---|
+| `src/server/index.ts` | Register `GET/POST /api/playbook` |
+| `src/server/playbookHandler.ts` | New: read/write `dvalin.json` |
+| `src/server/wsHandler.ts` | Load playbook on session init, include in session payload |
+| `web/src/components/Sidebar.tsx` | Show project routines with badge, Export button |
+| `web/src/hooks/usePlaybook.ts` | New: fetch + cache playbook, merge with localStorage routines |
+
+## Acceptance criteria
+
+- [ ] Clone a repo with `dvalin.json` → Routines panel shows project routines on first launch
+- [ ] Export button → `dvalin.json` written to workspace root, `git diff` shows expected JSON
+- [ ] Routines from `dvalin.json` and localStorage routines both appear in panel (project first)
+- [ ] Deleting a project routine from the panel does NOT modify `dvalin.json` (local override only)
+- [ ] Missing or malformed `dvalin.json` → silent fallback to localStorage routines only
+- [ ] The default routines (Run tests / Type check / Build / Git status / Lint) remain in localStorage for new projects
+
+## Open questions
+
+- Should routine execution validate that `prompt` is non-empty? Yes — skip empty-prompt routines silently.
+- Should `dvalin.json` support routine categories / groups? Defer — keep v1 flat for simplicity.
+- Should the export include the workspace's existing AGENTS.md content? No — AGENTS.md and `dvalin.json` are separate concerns; keep them independent.


### PR DESCRIPTION
…m playbook

From Gemini's competitive review of DvalinCode vs Cline/Aider/Cursor/Claude Code:

- REQUIREMENTS.md: confirmed 5 existing pain points already addressed; added #17 /compact (upgrade from P2#2, score 6.4→8.0 with local-model framing) and #18 dvalin.json Team AI Playbook (score 4.0, new)
- plans/05-compact-command.md: user-triggered context compression with Goal/Completed/Decisions/Pending structure; critical for Ollama/DeepSeek users
- plans/06-team-playbook.md: export Routines from localStorage to a project-level dvalin.json committable to git; teams share AI commands
- README + README.zh-CN: added "When to choose DvalinCode" comparison table (vs Cline/Cursor, Claude Code/Aider, cloud agents, any agent)

## Summary

## Testing

## Notes

