### PR TITLE
feat: auto-trigger context compaction when history exceeds threshold

### DIFF
--- a/requirements/FEATURE_GAP.md
+++ b/requirements/FEATURE_GAP.md
@@ -165,11 +165,13 @@
 
 ---
 
-### P1-3｜真正的上下文压缩（LLM-based Compaction）🟡
+### P1-3｜真正的上下文压缩（LLM-based Compaction）✅
 
-**状态（2026-06-10 复核）：🟡 部分交付。**
+**状态（2026-06-12 复核）：✅ 已交付。**
 - 已有：`/compact` 调用 LLM 生成结构化摘要（Goal / Completed / Decisions / CurrentState / Pending），失败时回退保留最近 20 条：`src/agent/loop.ts`（`handleCompact`）
-- 缺口：自动触发未接线 —— `compactThreshold` 已定义（`src/agent/types.ts`）但状态机从不自动进入 COMPACT 态
+- 自动触发已接线：`processMessage` 的 `RESTORE` 态在每轮开始估算历史 token，超过 `contextTokenLimit * compactThreshold`（默认 128k × 0.7）时自动进入 `COMPACT` 态再构建本轮：`src/agent/loop.ts`。回归测试覆盖触发/不触发两条路径：`tests/agent.test.ts`
+
+**原状态（2026-06-10）：🟡 部分交付。** 缺口：自动触发未接线 —— `compactThreshold` 已定义（`src/agent/types.ts`）但状态机从不自动进入 COMPACT 态
 
 **原现状（2026-05-22）：** `COMPACT` 状态仅做简单切片（保留最后 40 条），注释写着 `TODO`。  
 **Codex：** 调用 summary 模型生成摘要，替换历史消息，保留关键决策上下文。
@@ -339,11 +341,11 @@
 ├── P0-1 流式输出 · P0-2 审批流 · P0-3 中断/取消 · P0-4 Session 恢复
 ├── P1-1 AGENTS.md · P1-2 Token 统计 · P1-4 Git 感知 · P1-5 Diff 预览
 ├── P1-6 @ 文件引用 · P1-7 审批模式 UI（模式切换器形态）
+├── P1-3 上下文压缩（/compact + compactThreshold 自动触发）
 └── P2-5 计划模式 · P2-6 费用估算
 
 🟡 部分交付（待收尾）
 ├── P0-5 沙箱：已有 macOS sandbox-exec，缺 Linux bwrap + sandboxMode 配置
-├── P1-3 上下文压缩：/compact 已用 LLM 摘要，缺自动触发（compactThreshold 接线）
 └── P2-4 Profile：后端 + GUI 已支持，缺 CLI --profile 参数
 
 ⏭ 下一阶段（详见 requirements/plans/）

--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -1,5 +1,6 @@
 import { TurnState, type TurnConfig, type LoopResult, type SlashCommand, type AgentEventHandler, DEFAULT_TURN_CONFIG, type UndoEntry } from './types.js';
 import { AgentRunner } from './runner.js';
+import { estimateTokens } from './compact.js';
 import type { ChatMessage } from '../providers/types.js';
 import type { ProviderAdapter } from '../providers/types.js';
 import type { ToolRegistry } from '../tools/registry.js';
@@ -110,7 +111,16 @@ export class AgentLoop {
     while (state !== TurnState.DONE) {
       switch (state) {
         case TurnState.RESTORE: {
-          state = TurnState.BUILD;
+          // Auto-compact: if the running history already exceeds the configured
+          // fraction of the context window, summarize it before building the
+          // next turn. Wires up `contextTokenLimit` / `compactThreshold`, which
+          // were defined but previously never consulted by the state machine.
+          const triggerTokens = this.config.contextTokenLimit * this.config.compactThreshold;
+          if (estimateTokens(messages) > triggerTokens) {
+            state = TurnState.COMPACT;
+          } else {
+            state = TurnState.BUILD;
+          }
           break;
         }
 

--- a/tests/agent.test.ts
+++ b/tests/agent.test.ts
@@ -224,6 +224,67 @@ describe('AgentLoop', () => {
     expect(result.messages.length).toBeLessThan(history.length);
   });
 
+  it('auto-compacts history when token estimate exceeds the configured threshold', async () => {
+    const { AgentLoop } = await import('../src/agent/loop.js');
+    // First provider call is the compaction summary; second is the actual turn.
+    const provider = createMockProvider(['STRUCTURED SUMMARY', 'Done, how else can I help?']);
+    const registry = new ToolRegistry();
+    registry.register(createEchoTool());
+
+    const loop = new AgentLoop({
+      provider,
+      registry,
+      context: createDvalinContext(),
+      systemPrompt: 'System prompt',
+      // Tiny window so a modest history trips the 0.5 threshold (> 100 tokens).
+      config: { maxIterations: 3, maxToolCallsPerTurn: 5, contextTokenLimit: 200, compactThreshold: 0.5 },
+    });
+
+    // Long, bulky history (> 10 messages, well over ~100 estimated tokens).
+    const filler = 'x'.repeat(60);
+    const history: ChatMessage[] = [{ role: 'system', content: 'You are helpful.' }];
+    for (let i = 0; i < 15; i++) {
+      history.push({ role: 'user', content: `user message ${i} ${filler}` });
+      history.push({ role: 'assistant', content: `assistant reply ${i} ${filler}` });
+    }
+
+    const result = await loop.processMessage('Continue please', history);
+
+    // The state machine should have entered COMPACT, replacing the bulky history
+    // with a summary message before running the turn.
+    expect(result.messages.some(m => m.content.includes('[Conversation summary]'))).toBe(true);
+    expect(result.messages.length).toBeLessThan(history.length);
+    // The turn still completed after compaction.
+    expect(result.output).toBe('Done, how else can I help?');
+  });
+
+  it('does not auto-compact when history is under the threshold', async () => {
+    const { AgentLoop } = await import('../src/agent/loop.js');
+    const provider = createMockProvider(['Sure, here you go.']);
+    const registry = new ToolRegistry();
+    registry.register(createEchoTool());
+
+    const loop = new AgentLoop({
+      provider,
+      registry,
+      context: createDvalinContext(),
+      systemPrompt: 'System prompt',
+      config: { maxIterations: 3, maxToolCallsPerTurn: 5, contextTokenLimit: 128_000, compactThreshold: 0.7 },
+    });
+
+    const history: ChatMessage[] = [
+      { role: 'system', content: 'You are helpful.' },
+      { role: 'user', content: 'hi' },
+      { role: 'assistant', content: 'hello' },
+    ];
+
+    const result = await loop.processMessage('one more thing', history);
+
+    // No compaction should have happened — no summary message injected.
+    expect(result.messages.some(m => m.content.includes('[Conversation summary]'))).toBe(false);
+    expect(result.output).toBe('Sure, here you go.');
+  });
+
   it('slash command dispatch works', async () => {
     const { AgentLoop } = await import('../src/agent/loop.js');
     const provider = createEchoProvider('dummy');


### PR DESCRIPTION
## Requirement

From `requirements/FEATURE_GAP.md` **P1-3 (上下文压缩 / LLM-based Compaction)**, previously marked 🟡 *部分交付*:

> 缺口：自动触发未接线 —— `compactThreshold` 已定义（`src/agent/types.ts`）但状态机从不自动进入 COMPACT 态。

`DEFAULT_TURN_CONFIG` ships `contextTokenLimit: 128_000` and `compactThreshold: 0.7`, and the `COMPACT` state + `handleCompact()` are fully implemented — but nothing ever transitioned **into** `COMPACT`. The `RESTORE` state went straight to `BUILD`, so compaction only happened via the manual `/compact` command. Long-running sessions would grow unbounded until they hit the model's context limit.

## Change

`processMessage()`'s `RESTORE` state now estimates the running history's token count (`estimateTokens` from `src/agent/compact.ts`) and routes to `COMPACT` when it exceeds `contextTokenLimit * compactThreshold` before building the next turn.

- No infinite-loop risk: `COMPACT → BUILD` (never back to `RESTORE`); the threshold is checked once per turn.
- Compaction behavior itself is unchanged — still LLM summarization with a "keep last 20 messages" fallback. This PR only wires up the **auto-trigger**.

## Tests

Adds two regression tests to `tests/agent.test.ts`:
- **trigger path** — a tiny `contextTokenLimit` + bulky history enters `COMPACT`, replacing history with a summary message, and the turn still completes.
- **no-trigger path** — a short history under the threshold is left untouched (no summary injected).

```
Test Files  9 passed (9)
     Tests  49 passed (49)   # was 47
```

`npm run typecheck` clean.

## Files

- `src/agent/loop.ts` — threshold check in `RESTORE`, import `estimateTokens`
- `tests/agent.test.ts` — +2 tests
- `requirements/FEATURE_GAP.md` — P1-3 marked ✅ delivered

🤖 Generated with [Claude Code](https://claude.com/claude-code)