### PR TITLE
feat: add CLI --profile flag to load a named provider profile

### DIFF
--- a/requirements/FEATURE_GAP.md
+++ b/requirements/FEATURE_GAP.md
@@ -291,11 +291,13 @@
 
 ---
 
-### P2-4｜多 Profile 配置 🟡
+### P2-4｜多 Profile 配置 ✅
 
-**状态（2026-06-10 复核）：🟡 部分交付。**
+**状态（2026-06-12 复核）：✅ 已交付。**
 - 已有：`config.json` 支持命名 `profiles`，LLM Config 页面可保存 / 应用 / 删除 Profile：`src/server/configStore.ts`、`src/server/routes/config.ts`、`web/src/components/LLMConfigModal.tsx`
-- 缺口：CLI `--profile <name>` 参数未实现
+- CLI `--profile <name>` 已实现：`dvalincode chat --profile <name>` 从 `~/.dvalincode/config.json` 读取命名 profile（provider/apiKey/baseUrl/model），优先级高于 `--provider` 与 `DVALINCODE_*` 环境变量；profile 不存在时报错并列出可用名称。逻辑落在可单测的 `ProviderManager.addProfile`：`src/providers/manager.ts`、`src/commands/chat.ts`、`tests/providers.test.ts`
+
+**原状态（2026-06-10）：🟡 部分交付。** 缺口：CLI `--profile <name>` 参数未实现
 
 **需求：**
 - `config.json` 支持 `profiles` 命名配置（不同项目不同 provider/model/permissions）
@@ -339,12 +341,12 @@
 ├── P0-1 流式输出 · P0-2 审批流 · P0-3 中断/取消 · P0-4 Session 恢复
 ├── P1-1 AGENTS.md · P1-2 Token 统计 · P1-4 Git 感知 · P1-5 Diff 预览
 ├── P1-6 @ 文件引用 · P1-7 审批模式 UI（模式切换器形态）
+├── P2-4 多 Profile 配置（后端 + GUI + CLI --profile）
 └── P2-5 计划模式 · P2-6 费用估算
 
 🟡 部分交付（待收尾）
 ├── P0-5 沙箱：已有 macOS sandbox-exec，缺 Linux bwrap + sandboxMode 配置
-├── P1-3 上下文压缩：/compact 已用 LLM 摘要，缺自动触发（compactThreshold 接线）
-└── P2-4 Profile：后端 + GUI 已支持，缺 CLI --profile 参数
+└── P1-3 上下文压缩：/compact 已用 LLM 摘要，缺自动触发（compactThreshold 接线）
 
 ⏭ 下一阶段（详见 requirements/plans/）
 ├── 子代理与后台任务（plans/02-subagent-tasks.md）

--- a/src/commands/chat.ts
+++ b/src/commands/chat.ts
@@ -5,6 +5,7 @@ import { scanProject } from '../core/projectScanner.js';
 import { AgentLoop } from '../agent/loop.js';
 import { createDvalinContext } from '../core/context.js';
 import { createSession, saveSession, loadSession, summarizeSession } from '../sessions/store.js';
+import { readConfig } from '../server/configStore.js';
 
 export function registerChatCommand(program: Command, registry: ToolRegistry): void {
   program
@@ -14,7 +15,8 @@ export function registerChatCommand(program: Command, registry: ToolRegistry): v
     .option('--session <id>', 'resume an existing session by ID')
     .option('--provider <name>', 'provider name', 'deepseek')
     .option('--model <name>', 'model name')
-    .action(async (messageParts: string[], options: { session?: string; provider: string; model?: string }) => {
+    .option('--profile <name>', 'use a named provider profile from ~/.dvalincode/config.json')
+    .action(async (messageParts: string[], options: { session?: string; provider: string; model?: string; profile?: string }) => {
       const message = messageParts.join(' ');
       const cwd = process.cwd();
 
@@ -31,9 +33,20 @@ export function registerChatCommand(program: Command, registry: ToolRegistry): v
         session = createSession(cwd);
       }
 
-      // Set up provider
+      // Set up provider. A named --profile (from ~/.dvalincode/config.json)
+      // takes precedence over the --provider flag / env defaults.
       const manager = new ProviderManager().loadFromEnv();
-      const provider = manager.get(options.provider);
+      let providerName = options.provider;
+      if (options.profile) {
+        const config = await readConfig();
+        try {
+          providerName = manager.addProfile(config.profiles, options.profile);
+        } catch (err) {
+          console.error(err instanceof Error ? err.message : String(err));
+          process.exit(1);
+        }
+      }
+      const provider = manager.get(providerName);
 
       // Scan workspace for context
       const summary = await scanProject(cwd);

--- a/src/providers/manager.ts
+++ b/src/providers/manager.ts
@@ -7,6 +7,14 @@ export type ConfiguredProvider = {
   adapter: ProviderAdapter;
 };
 
+/** A named provider profile as stored in ~/.dvalincode/config.json. */
+export type ProviderProfile = {
+  provider: string;
+  apiKey?: string;
+  baseUrl?: string;
+  model?: string;
+};
+
 export class ProviderManager {
   private providers = new Map<string, ProviderAdapter>();
 
@@ -35,5 +43,25 @@ export class ProviderManager {
 
     this.addOpenAI(providerName, { apiKey, baseUrl, model });
     return this;
+  }
+
+  /**
+   * Register the provider described by a named profile and return its provider
+   * name (for a subsequent `get`). Throws if the profile is not found, listing
+   * the available profile names.
+   */
+  addProfile(profiles: Record<string, ProviderProfile> | undefined, name: string): string {
+    const profile = profiles?.[name];
+    if (!profile) {
+      const available = Object.keys(profiles ?? {});
+      const hint = available.length ? ` Available: ${available.join(', ')}` : ' No profiles configured.';
+      throw new Error(`Profile not found: ${name}.${hint}`);
+    }
+    this.addOpenAI(profile.provider, {
+      apiKey: profile.apiKey,
+      baseUrl: profile.baseUrl,
+      model: profile.model,
+    });
+    return profile.provider;
   }
 }

--- a/tests/providers.test.ts
+++ b/tests/providers.test.ts
@@ -64,4 +64,29 @@ describe('ProviderManager', () => {
     const mgr = new ProviderManager();
     expect(() => mgr.get('nope')).toThrow('Unknown provider: nope');
   });
+
+  it('addProfile registers the profile provider and returns its name', () => {
+    const mgr = new ProviderManager();
+    const profiles = {
+      work: { provider: 'openai', apiKey: 'sk-work', baseUrl: 'https://api.openai.com/v1', model: 'gpt-4o' },
+      local: { provider: 'ollama', baseUrl: 'http://localhost:11434/v1', model: 'qwen2.5-coder' },
+    };
+
+    const name = mgr.addProfile(profiles, 'work');
+
+    expect(name).toBe('openai');
+    // The provider is now resolvable under the profile's provider name.
+    expect(mgr.get('openai').name).toBe('openai');
+  });
+
+  it('addProfile throws with available names when the profile is missing', () => {
+    const mgr = new ProviderManager();
+    const profiles = { work: { provider: 'openai' } };
+    expect(() => mgr.addProfile(profiles, 'nope')).toThrow('Profile not found: nope. Available: work');
+  });
+
+  it('addProfile throws a clear message when no profiles are configured', () => {
+    const mgr = new ProviderManager();
+    expect(() => mgr.addProfile(undefined, 'work')).toThrow('No profiles configured');
+  });
 });


### PR DESCRIPTION
## Requirement

From `requirements/FEATURE_GAP.md` **P2-4 (多 Profile 配置)**, previously 🟡 *部分交付*:

> 缺口：CLI `--profile <name>` 参数未实现。

Named profiles (`provider` / `apiKey` / `baseUrl` / `model`) can already be saved, applied, and deleted from the Web GUI and are persisted in `~/.dvalincode/config.json`. But the CLI had no way to pick one — your only options were `--provider` and the `DVALINCODE_*` env vars, so per-project / per-model switching from the terminal wasn't possible.

## Change

`dvalincode chat --profile <name>` now reads the named profile from `~/.dvalincode/config.json` and registers it as the active provider. It **takes precedence over** `--provider` and the env defaults. A missing profile exits non-zero with a clear message that lists the available names.

The resolution logic is a new pure method `ProviderManager.addProfile(profiles, name)` — it registers the profile's provider and returns its name, throwing a helpful error when not found. This keeps it unit-testable without filesystem access; `chat.ts` only does the `readConfig()` IO.

## Tests

Adds three tests to `tests/providers.test.ts`:
- registers the profile provider and returns its name
- throws `Profile not found: <name>. Available: …` when the name is missing
- throws `No profiles configured` when there are no profiles

```
Test Files  9 passed (9)
     Tests  50 passed (50)   # was 47
```

`npm run typecheck` clean.

### Manual end-to-end (real DeepSeek endpoint)

- `chat --profile nope` → `Profile not found: nope. No profiles configured.` (exit 1, no network)
- With a `ds` profile saved and **no** `DVALINCODE_*` env set → `chat --profile ds "…"` loaded provider/key/baseURL/model from config and completed a real turn.

## Files

- `src/providers/manager.ts` — `ProviderProfile` type + `addProfile()`
- `src/commands/chat.ts` — `--profile` option, resolves before building the provider
- `tests/providers.test.ts` — +3 tests
- `requirements/FEATURE_GAP.md` — P2-4 marked ✅ delivered

🤖 Generated with [Claude Code](https://claude.com/claude-code)