### PR TITLE
Plan v0.5: security differentiation (audit trail + enforced policy engine)

### DIFF
--- a/requirements/REQUIREMENTS.md
+++ b/requirements/REQUIREMENTS.md
@@ -259,6 +259,82 @@ Every feature is scored on 5 dimensions (1-5):
 
 ---
 
+## Update 2026-06-12 — v0.5 Roadmap: Security Differentiation (user-directed)
+
+> Source: `data/roadmap_v05_20260612.md` — a user-authored strategic brief, not a
+> competitor-intel scrape. Plans: `plans/07-audit-trail.md`,
+> `plans/08-policy-engine.md`, `plans/09-checkpoint-rollback.md`.
+>
+> **Positioning shift:** from *“small enough to audit”* (the code is auditable) to
+> *“every agent action is auditable and policy-enforced.”* Security stops being a
+> mode toggle and becomes the product's moat.
+
+### ⚠️ Scoring caveat — this is a differentiation cycle, not a catch-up cycle
+
+The standard formula `(Pain × Align × Gap) / (Cost × Risk)` measures *catch-up*:
+**Gap = "how far behind are we vs Codex/Claude Code? (5 = way behind)"**. For
+features where **we would be ahead of everyone**, Gap ≈ 1 by definition — which
+drives the score toward zero. That is exactly backwards for a moat play: *nobody
+is ahead of us* is the whole point.
+
+So this cycle ranks by **differentiation value + career signal per hour** (the
+roadmap's stated principle), and the formula scores below are recorded for
+continuity only. **Do not let a future cycle see “1.25” and deprioritize #19** —
+the low number reflects market lead, not low value. Strategic priority (the
+roadmap's P0/P1) governs.
+
+| # | Requirement | Pain | Align | Gap | Cost | Risk | Formula | Strategic |
+|---|-------------|:----:|:-----:|:---:|:----:|:----:|:-------:|:---------:|
+| 19 | Audit Trail + Run Report | 3 | 5 | 1 | 3 | 4 | 1.25 | **P0** |
+| 20 | Enforced Policy Engine | 4 | 5 | 2 | 3 | 3 | 4.4 | **P0** |
+| 21 | Checkpoint / Rollback | 4 | 5 | 3 | 4 | 4 | 3.75 | **P1** |
+
+### P0 (strategic) — New Requirements
+
+#### 19. Audit Trail — security-grade Agent Run Report
+- **Differentiator**: tamper-evident, hash-chained JSONL audit log per run; the Run Report is its rendering layer. No local agent (Claude Code / Cursor / Aider) ships verifiable behavior logs.
+- **Why now**: directly answers the recurring "black-box anxiety / destructive changes without review" signal (Gemini review; vibe-coding aftermath ↑7061) with structure rather than vibes — and it's the literal extension of the founding "small enough to audit" tagline.
+- **What to build**: `~/.dvalincode/audit/run-*.jsonl` event stream (run_start/end, tool_call, file_read/write/delete with diff-stat + content hashes, shell_exec, approval, policy_violation), each event carrying `prev_hash` (SHA-256); a JSONL→Markdown Run Report (collapsible GUI card + export); CLI `report --last | <id> | verify`.
+- **Enforcement-independent**: append-only side channel; a failed event write degrades to a warning and never aborts the run.
+- **Plan**: `plans/07-audit-trail.md`
+
+#### 20. Enforced Policy Engine — `dvalin.json` policies
+- **Differentiator**: behavior constraints enforced at the `ToolRegistry` gating layer (registry.ts:40 `run()`), **before** execution and independent of prompt compliance — vs every competitor's prompt-level "please follow the rules."
+- **Why now**: collapses two long-standing signals (sensitive-file exclusion ↑766/770, vibe-coding guardrails ↑7061) into one structural answer, and lands the AppSec story the THREAT-MODEL.md doc needs.
+- **What to build**: new `policies` block in `dvalin.json` (deny_paths / readonly_paths / shell_allow+denylist / require_approval / max_files_per_run); a policy evaluator invoked in `ToolRegistry.run()`; applies in **all** modes incl. full-auto and Bypass (Bypass skips confirmation, not policy); blocks return a structured error to the agent + write a `policy_violation` audit event. Precedence: repo `dvalin.json` > user `~/.dvalincode/policy.json`, stricter wins. `.dvalincodeignore` documented as the read-dimension analog.
+- **Companion**: `docs/THREAT-MODEL.md` mapped to OWASP LLM Top 10 / agentic risk — a portfolio artifact in its own right.
+- **Plan**: `plans/08-policy-engine.md`
+
+### P1 (strategic) — New Requirements
+
+#### 21. Checkpoint / Rollback — run-level snapshot
+- **What to build**: snapshot before each Cowork/Code run (`git stash create` or a shadow commit — no working-tree pollution); post-run GUI choice **Rollback / Keep / Commit**; CLI `checkpoint list` + `rollback <run-id>`; rollback itself logged to the audit trail. Builds on the existing op-level undo stack (`sharedUndoStack` / `runner.undoLast`).
+- **Genuine gap here (Gap 3)**: Cursor checkpoints / Claude Code rewind exist; we only have operation-level `/undo`. Cheap (git does the work), so ship it — but it's parity, not the headline.
+- **Plan**: `plans/09-checkpoint-rollback.md`
+
+### Non-code deliverable (P1-2)
+- **Design blog post**: *"Why prompt-level rules can't secure coding agents — building enforcement into the tool layer."* Covers #19/#20 design, hash-chain audit log, OWASP agentic mapping, and the *Bypass ≠ bypass policy* trade-off. Repo `docs/` + personal channels; quotable in job materials. Tracked, not a code requirement.
+
+### P2 backlog (only with spare capacity)
+| Requirement | Note | Why deferred |
+|---|---|---|
+| `dvalincode init` → starter AGENTS.md + `dvalin.json` w/ suggested policies | `init`/`scan` commands already exist (generate config) — extend to emit a playbook + policy starter | Table stakes (Claude `/init`, Cursor rules); completeness, not differentiation |
+| PR Assistant (`dvalincode pr`) | PR description / risk / test checklist from audit log + diff | Commodity alone; **depends on #19** — only differentiated as "evidence-backed PR description" |
+| Built-in Routines templates | 5–8 quality routines (Explain repo / Find bugs / Add tests / Review diff / Quality gate) | UX win, not a moat — templates only, no marketplace |
+
+### Explicit non-goals (reaffirmed)
+VS Code extension · plugin system · new model providers · multi-agent collaboration · cloud autonomous agent · routines marketplace. Each conflicts with the local-first / lightweight / safe-by-default identity or is over-architecture at current scale.
+
+### Milestones
+```
+v0.5.0  #19 Audit log + Run Report (incl. verify)
+v0.5.x  #20 Policy Engine + THREAT-MODEL.md
+v0.6.0  #21 Checkpoint/Rollback + blog post
+later   P2 as capacity allows (init → routines templates → PR assistant)
+```
+
+---
+
 ## Source Log
 
 | Date | Source | Key Signal | Priority |
@@ -296,6 +372,7 @@ Every feature is scored on 5 dimensions (1-5):
 | 2026-06-10 | Claude Code 2.1.157–2.1.170 changelog | `claude agents` background sessions · guarded config writes · fallback models | P1 |
 | 2026-06-10 | Codex rust-v0.134.0–v0.139.0 releases | Multi-agent v2 · session search/archive · sandbox escalation + permission profiles | P1 |
 | 2026-06-11 | Gemini competitive review | `/compact` critical for local/cheap models; `dvalin.json` team playbook differentiator | P2 |
+| 2026-06-12 | User strategic brief (v0.5 roadmap) | Audit trail + enforced policy engine as the security moat; differentiation > catch-up | P0 (strategic) |
 
 ## Shipped
 

--- a/requirements/data/roadmap_v05_20260612.md
+++ b/requirements/data/roadmap_v05_20260612.md
@@ -1,0 +1,173 @@
+# v0.5 Roadmap — Security Differentiation (source brief)
+
+> **Provenance:** User-authored strategic direction (2026-06-12), not a competitor
+> release-intelligence scrape. Captured here as the source-of-record for the
+> 2026-06-12 update in `../REQUIREMENTS.md`; scored requirements and per-feature
+> plans derive from this document.
+>
+> **Positioning thesis:** evolve DvalinCode from *“small enough to audit”*
+> (the code is auditable) to *“every agent action is auditable and
+> policy-enforced”* (agent **behavior** is auditable and rules are enforced, not
+> merely requested). Security is the differentiator, not a checkbox.
+>
+> **Sequencing principle (explicit):** rank by differentiation value + career
+> signal per hour invested — **not** functional completeness, and **not** the
+> catch-up scoring formula (which under-scores leadership plays; see the cycle
+> note in REQUIREMENTS.md).
+
+---
+
+## P0-1 — Audit Trail: security-grade Agent Run Report
+
+**Goal:** every agent run emits a tamper-evident structured audit log; the Run
+Report is just its rendering layer. Core differentiator vs Claude Code / Cursor /
+Aider.
+
+### FR-1 Structured event log (foundation)
+- One log file per run: `~/.dvalincode/audit/run-<timestamp>-<id>.jsonl`
+- One event per line (JSONL):
+  - `run_start` / `run_end` (task, mode, provider, model, cwd, git HEAD)
+  - `tool_call` (tool, arg summary, result status, duration)
+  - `file_read` / `file_write` / `file_delete` (path, +N/−M diff stat, before/after content hash)
+  - `shell_exec` (command, exit code, sandboxed?)
+  - `approval` (approve/reject, corresponding diff hash)
+  - `policy_violation` (see P0-2 — the blocked operation)
+- Each event carries `prev_hash` (SHA-256) → hash chain → tamper-evident.
+
+### FR-2 Run Report (rendering layer)
+- After a run, auto-generate Markdown from the JSONL: Task / Files read /
+  Files changed / Commands run / Decisions / Diff summary / Test result.
+- GUI: collapsible card at the end of the session; one-click copy / export.
+
+### FR-3 CLI
+```
+dvalincode report --last
+dvalincode report <run-id> --format markdown|json
+dvalincode report verify <run-id>     # validate the hash chain
+```
+
+### Acceptance
+- After any Cowork/Code run, a complete JSONL exists covering all tool calls.
+- Hand-tamper any line → `report verify` reports the break and its position.
+- Run Report “Files changed” matches the real git diff.
+- Documented threat model: what the log defends (post-hoc forensics, behavior
+  trace) vs not (local root attacker).
+
+### Non-functional
+- Append-only; a single failed event write must NOT abort the run (degrade to warning).
+- Per-run size policy (diffs stored as hash + stat, not full text).
+
+---
+
+## P0-2 — Enforced Policy Engine: `dvalin.json` policies
+
+**Goal:** move behavior constraints from prompt-level (“please follow AGENTS.md”)
+to enforcement-level (intercepted in the ToolRegistry gating layer). The real
+AppSec differentiator — no local agent does this.
+
+### FR-1 Policy schema (new `policies` block in `dvalin.json`)
+```json
+{
+  "policies": {
+    "deny_paths": ["migrations/**", ".env*", "**/*.pem"],
+    "readonly_paths": ["package-lock.json"],
+    "shell_allowlist": ["npm test", "npm run lint", "git status"],
+    "shell_denylist": ["rm -rf", "curl", "wget"],
+    "require_approval": ["delete_file", "shell:git push"],
+    "max_files_per_run": 20
+  }
+}
+```
+
+### FR-2 Enforcement layer
+- Intercept at ToolRegistry permission gating — **before** the operation runs,
+  independent of prompt compliance.
+- Applies in **all** modes, including Code (full-auto) and Bypass. Bypass skips
+  the interactive confirmation, not the policy.
+- On block: return a structured error to the agent (so it can replan) and write a
+  `policy_violation` audit event.
+
+### FR-3 Source & precedence
+- repo `dvalin.json` > user `~/.dvalincode/policy.json`; on conflict, the stricter wins.
+- `.dvalincodeignore` is unchanged; document it as the read-dimension equivalent of `deny_paths`.
+
+### Acceptance
+- `deny_paths` hits block write/edit/delete in every mode; agent gets a clear error.
+- `shell_denylist` hits are blocked in Code full-auto and logged to the audit trail.
+- Writing “allow editing migrations” in AGENTS.md cannot bypass policy (enforcement > prompt).
+- README/docs gain a “Prompt-level rules vs. enforced policies” comparison.
+
+### Companion docs (first-class deliverable)
+- `docs/THREAT-MODEL.md` aligned with OWASP LLM Top 10 / agentic-AI risk:
+  over-permissioned actions, prompt-injection-driven unauthorized writes,
+  sensitive-file exfiltration to the LLM. The doc is itself portfolio material.
+
+---
+
+## P1-1 — Checkpoint / Rollback: run-level snapshot
+
+**Goal:** upgrade operation-level `/undo [N]` to a one-click run-level rollback —
+remove the “the agent changed a pile of things and I can’t cleanly revert” fear.
+Low cost (wraps git); ship it but don’t headline it.
+
+### Functional
+- Before a Cowork/Code run, auto-create a snapshot (`git stash create` or a shadow
+  commit — does not pollute the working tree).
+- After the run, GUI offers three choices: **Rollback this run / Keep changes /
+  Create git commit**.
+- CLI: `dvalincode checkpoint list` · `dvalincode rollback <run-id>`.
+- Rollback itself is written to the audit trail (ties into P0-1).
+
+### Acceptance
+- Non-git directory → degrade to file-level backup or an explicit “unsupported” notice.
+- Files the user hand-edited during the run → rollback warns about conflicts instead of silently overwriting.
+- After rollback, `git status` is clean (or restored to the pre-run state).
+
+---
+
+## P1-2 — Technical blog post (non-code deliverable)
+
+One design-decision article outweighs another routine feature for career signal.
+
+- Working title: *“Why prompt-level rules can’t secure coding agents — building
+  enforcement into the tool layer.”*
+- Covers: P0-1 + P0-2 design motivation, hash-chain audit-log design, mapping to
+  OWASP agentic risks, the “Bypass mode ≠ bypass policy” trade-off.
+- Channels: repo `docs/` + personal blog / LinkedIn; quotable in job materials.
+
+---
+
+## P2 — Lower priority (only with spare capacity)
+
+| Feature | Note | Why not prioritized |
+|---|---|---|
+| `dvalincode init` (scan → AGENTS.md + dvalin.json with suggested policies) | An `init`/`scan` command already exists (generates config) — extend to emit a starter playbook + suggested `policies` | Claude Code `/init`, Cursor rules are table stakes; no differentiation, but its absence looks incomplete — fast completeness item |
+| PR Assistant (`dvalincode pr`) | Generate PR description, risk notes, test checklist from audit log + diff | Commodity on its own; **only** differentiated when fused with P0-1 (“evidence-backed PR description”) — depends on P0-1 landing first |
+| Built-in Routines templates | Ship 5–8 quality routines (Explain repo / Find bugs / Add tests / Review diff / Quality gate) | Improves first-run UX, not a moat; ship templates, not a marketplace |
+
+---
+
+## Explicit non-goals
+
+1. **VS Code extension** — head-on with Cursor/Cline on IDE experience; unwinnable.
+2. **Plugin system** — over-architecture at current scale; routines templates suffice.
+3. **New model providers** — OpenAI-compatible already covers it; zero marginal value.
+4. **Multi-agent collaboration** — adds complexity the target user doesn’t need.
+5. **Cloud autonomous agent** — conflicts with the local-first / safe-by-default identity.
+6. **Routines marketplace / official directory** — castle in the air at this user volume.
+
+---
+
+## Milestones
+
+```
+v0.5.0  P0-1 Audit log + Run Report (incl. verify)
+v0.5.x  P0-2 Policy Engine + THREAT-MODEL.md
+v0.6.0  P1-1 Checkpoint/Rollback + blog post
+later   P2 as capacity allows (init → routines templates → PR assistant)
+```
+
+**Overarching:** after v0.5, the README’s first-line pitch upgrades from
+*“any model, safe by default”* to something like
+*“A local-first coding agent that leaves a tamper-evident audit trail — and
+enforces your repo’s rules instead of asking the model to follow them.”*

--- a/requirements/plans/07-audit-trail.md
+++ b/requirements/plans/07-audit-trail.md
@@ -1,0 +1,129 @@
+# Plan: Audit Trail — Security-Grade Agent Run Report
+
+## Goal
+Every Cowork/Code run emits a tamper-evident, hash-chained JSONL audit log. The
+Run Report (Markdown card + CLI) is a pure rendering layer over that log. This is
+the flagship differentiator: no local agent ships verifiable behavior logs.
+
+## Why P0 (strategic)
+- REQUIREMENTS.md #19. Formula score is 1.25 **by construction** — the catch-up
+  formula scores Gap=1 because nobody is ahead of us here; that's the point, not a
+  reason to deprioritize.
+- Answers the #1 recurring anxiety (black-box behavior / destructive changes
+  without review — vibe-coding aftermath ↑7061) with structure, and is the literal
+  extension of the "small enough to audit" tagline.
+- Prerequisite for two later wins: the rollback audit entry (#21) and the
+  evidence-backed PR assistant (P2).
+
+## Design
+
+### 7a — Event model + hash chain (`src/audit/log.ts`, new)
+Append-only JSONL, one file per run: `~/.dvalincode/audit/run-<ts>-<id>.jsonl`.
+
+```ts
+type AuditEvent =
+  | { type: 'run_start'; task: string; mode: AgentMode; codePermissionMode?: CodePermissionMode;
+      provider: string; model: string; cwd: string; gitHead: string | null }
+  | { type: 'tool_call'; tool: string; argsSummary: string; status: 'ok'|'error'; durationMs: number }
+  | { type: 'file_read';   path: string; sha256: string }
+  | { type: 'file_write';  path: string; added: number; removed: number; beforeHash: string|null; afterHash: string }
+  | { type: 'file_delete'; path: string; beforeHash: string }
+  | { type: 'shell_exec'; command: string; exitCode: number; sandbox: 'seatbelt'|'bwrap'|'none' }
+  | { type: 'approval'; toolName: string; approved: boolean; diffHash?: string }
+  | { type: 'policy_violation'; rule: string; tool: string; target: string }   // from plan 08
+  | { type: 'run_end'; status: 'done'|'interrupted'|'error'; iterations: number;
+      inputTokens?: number; outputTokens?: number };
+
+type AuditRecord = AuditEvent & { seq: number; ts: string; prevHash: string };
+```
+
+`AuditSink` class:
+- `constructor(runId, meta)` opens the file; computes `prevHash` for the genesis
+  event as `sha256(runId)`.
+- `append(event)`: `record = { ...event, seq, ts, prevHash }`; `hash =
+  sha256(canonicalJSON(record))`; write `record` as one line; set `prevHash = hash`
+  for the next event. **canonicalJSON** = stable key order so verification is
+  deterministic.
+- Append is **best-effort**: a write failure is caught, counted, and surfaced as a
+  single `run_end.warnings` note — it must never throw into the agent loop
+  (non-functional requirement).
+- Size policy: file contents are never stored — only `sha256` + `added/removed`
+  line counts. Long `argsSummary`/`command` truncated to 512 chars.
+
+`verifyChain(runId): { ok: boolean; brokenAtSeq?: number }` — re-reads the file,
+recomputes each hash, and checks `record.prevHash === hashOf(previous)`.
+
+### 7b — Wiring the taps (single chokepoint + run boundary)
+The registry is already the one place every tool flows through, and the loop owns
+the run boundary — so taps are minimal and centralized.
+
+- **`src/core/context.ts`** — add optional `audit?: AuditSink` to
+  `DvalinContext`/`DvalinContextOptions`. Plumbed through `createDvalinContext`.
+- **`src/tools/registry.ts` `run()`** — after `tool.run()` resolves, emit
+  `tool_call` (name, status, duration). For write/edit/delete, derive
+  `file_write`/`file_delete` from the result `metadata` that already exists
+  (`writeFile`/`editFile` produce `metadata.diff` + original content; hashes are
+  computed from those). For `read_file`, emit `file_read`. For `shell`, emit
+  `shell_exec` from `metadata.sandbox` + exit code. The `approval` event is emitted
+  where the approval promise resolves (registry.ts:52). All taps are
+  `context.audit?.append(...)` — no-ops when audit is absent (CLI ask/headless).
+- **`src/agent/loop.ts` `processMessage`** — wrap `TurnState.RUN`: emit
+  `run_start` before constructing the runner, `run_end` after, with iteration/usage
+  data already in `LoopResult`. (Keeps the sink lifecycle tied to exactly one user
+  turn = one run.)
+- **`src/server/wsHandler.ts`** — instantiate one `AuditSink` per
+  `loop.processMessage` call (wsHandler.ts:392), inject via the context built at
+  wsHandler.ts:356, and after the run send a new WS event
+  `{ type: 'run_report', runId, markdown }` alongside the existing `done`
+  (wsHandler.ts:90). `gitHead` resolved once from the existing git helper.
+
+### 7c — Run Report renderer (`src/audit/report.ts`, new)
+`renderReport(runId): string` reads the JSONL and produces Markdown:
+`Task` · `Files read` · `Files changed (+N/−M per path)` · `Commands run (exit)` ·
+`Decisions` (extracted from the run's final assistant message / plan steps) ·
+`Diff summary` · `Test result` (heuristic: last `shell_exec` matching a
+test/lint command + its exit code). Pure function over the log → trivially testable.
+
+### 7d — CLI (`src/commands/report.ts`, new; registered in `src/cli.ts`)
+Follows the existing `register*Command(program)` / commander pattern.
+```
+dvalincode report --last
+dvalincode report <run-id> --format markdown|json
+dvalincode report verify <run-id>   # prints ✓ chain intact OR ✗ broken at seq N
+```
+`--last` resolves the newest file in the audit dir.
+
+### 7e — GUI card (`web/src/components/RunReportCard.tsx`, new)
+On the `run_report` WS event, append a collapsible card at the end of the thread
+(rendered by `ChatThread`): summary line collapsed; expanded shows the Markdown
+with Copy / Export buttons. Read-only; styling matches `AgentActivity`/`PlanCard`.
+
+## File Changes
+1. `src/audit/log.ts` — new: event types, `AuditSink` (append + hash chain), `verifyChain`
+2. `src/audit/report.ts` — new: JSONL → Markdown renderer
+3. `src/audit/hash.ts` — new: `sha256`, `canonicalJSON`, file-content hashing helper
+4. `src/core/context.ts` — add `audit?: AuditSink`
+5. `src/tools/registry.ts` — emit tool_call / file_* / shell_exec / approval events in `run()`
+6. `src/agent/loop.ts` — emit run_start / run_end around `TurnState.RUN`
+7. `src/server/wsHandler.ts` — per-run sink; emit `run_report` WS event + report card data
+8. `src/commands/report.ts` + `src/cli.ts` — `report --last|<id>|verify`
+9. `web/src/types.ts` — `run_report` ServerEvent; `web/src/hooks/useChat.ts` — handle it
+10. `web/src/components/RunReportCard.tsx` + `ChatThread.tsx` — render the card
+11. `tests/audit/log.test.ts`, `tests/audit/report.test.ts` — chain integrity, tamper detection, report-vs-diff parity
+12. `docs/AUDIT-TRAIL.md` — format spec + threat model (defends: post-hoc forensics, behavior trace; does **not** defend: local root attacker who can rewrite the whole chain)
+
+## Verification
+- Run any Cowork/Code task → a JSONL exists with `run_start` … `run_end` and a
+  `tool_call` (+ matching `file_*`) for every tool the run made.
+- `report verify <id>` on an untouched log prints ✓; hand-edit one line →
+  prints ✗ with the correct `seq`.
+- Report "Files changed" lines match `git diff --numstat` for the same run.
+- Kill the audit dir's write permission mid-run → run still completes; `run_end`
+  carries a warning; agent output unaffected.
+- `npm run check` passes.
+
+## Risk note
+The hash chain is tamper-**evident**, not tamper-**proof**: a local attacker who can
+rewrite the file can recompute the whole chain. State this plainly in
+`docs/AUDIT-TRAIL.md` — the value is forensic/accountability, not cryptographic
+custody. Don't oversell it.

--- a/requirements/plans/08-policy-engine.md
+++ b/requirements/plans/08-policy-engine.md
@@ -1,0 +1,122 @@
+# Plan: Enforced Policy Engine — `dvalin.json` policies
+
+## Goal
+Move agent behavior constraints from prompt-level ("please follow AGENTS.md") to
+enforcement-level: intercepted in the `ToolRegistry` gating layer, before the
+operation runs, independent of whether the model "agreed." This is the AppSec
+differentiator — no local agent enforces repo-committed policy at the tool layer.
+
+## Why P0 (strategic)
+- REQUIREMENTS.md #20. Collapses two persistent community signals
+  (sensitive-file exclusion ↑766/770, vibe-coding guardrails ↑7061) into one
+  structural mechanism.
+- The proof point for the whole positioning: "enforces your repo's rules instead
+  of asking the model to follow them." Depends on nothing; unlocks
+  `docs/THREAT-MODEL.md`.
+
+## Design
+
+### 8a — Schema (`dvalin.json` gains a `policies` block)
+`dvalin.json` today is `{ version, routines }` (see `src/server/playbookHandler.ts`).
+Add an optional sibling:
+```json
+{
+  "version": 1,
+  "routines": [ ... ],
+  "policies": {
+    "deny_paths":       ["migrations/**", ".env*", "**/*.pem"],
+    "readonly_paths":   ["package-lock.json"],
+    "shell_allowlist":  ["npm test", "npm run lint", "git status"],
+    "shell_denylist":   ["rm -rf", "curl", "wget"],
+    "require_approval":  ["delete_file", "shell:git push"],
+    "max_files_per_run": 20
+  }
+}
+```
+All fields optional. `deny_paths`/`readonly_paths` are glob (reuse the existing
+ignore-file matcher in `src/core/ignorefile.ts`). `shell_*` match against the
+command string (substring for denylist, prefix for allowlist). `require_approval`
+entries are either a tool name or `shell:<prefix>`.
+
+### 8b — Policy module (`src/core/policy.ts`, new)
+```ts
+type Policy = { denyPaths; readonlyPaths; shellAllowlist; shellDenylist; requireApproval; maxFilesPerRun };
+loadPolicy(cwd): Promise<Policy>           // merge repo dvalin.json + ~/.dvalincode/policy.json, stricter wins
+type Decision = { effect: 'allow' } | { effect: 'deny'; rule: string } | { effect: 'approve'; rule: string };
+evaluate(policy, toolName, access, input, runState): Decision
+```
+- **Merge precedence**: repo `dvalin.json.policies` > user `~/.dvalincode/policy.json`.
+  "Stricter wins" = deny/readonly lists are unioned; allowlists are intersected;
+  `max_files_per_run` takes the min; `require_approval` unioned.
+- **Path rules** apply to any tool whose parsed input has a `filePath` and
+  `access !== 'read'`: `deny_paths` hit → deny; `readonly_paths` hit → deny (writes
+  only); read tools are unaffected (that's `.dvalincodeignore`'s job — documented as
+  the read-dimension analog).
+- **Shell rules** apply to the `shell` tool: denylist hit → deny; if `shell_allowlist`
+  is non-empty and the command matches none → deny (default-deny only when an
+  allowlist is declared, so empty config stays permissive).
+- **`require_approval`** → `approve` (force an approval prompt even in full-auto/Bypass).
+- **`max_files_per_run`** → deny once the run's distinct-written-file count would exceed it
+  (count tracked on the context; see 8c).
+
+### 8c — Enforcement point (`src/tools/registry.ts` `run()`)
+The single chokepoint at registry.ts:40. Insert **after** `inputSchema.parse()`
+(so input is typed) and **before** the existing approval block:
+```ts
+const decision = context.policy ? evaluate(context.policy, name, tool.access, input, context.runState) : { effect: 'allow' };
+if (decision.effect === 'deny') {
+  context.audit?.append({ type: 'policy_violation', rule: decision.rule, tool: name, target: targetOf(input) });
+  throw new PolicyError(`Blocked by policy (${decision.rule}): ${name}. This action is not permitted in this workspace.`);
+}
+if (decision.effect === 'approve' && context.requestApproval) { /* force approval regardless of mode */ }
+```
+Key properties:
+- Runs in **every** mode. Bypass/full-auto skip the *interactive confirmation*
+  block below, but the policy `deny` above is unconditional — Bypass ≠ bypass policy.
+- The thrown `PolicyError` is returned to the model as a tool error (existing
+  runner path at runner.ts:155), so the agent **replans** instead of crashing.
+- `targetOf(input)` extracts `filePath` or the shell command for the audit event.
+
+### 8d — Context plumbing (`src/core/context.ts`)
+Add `policy?: Policy` and a mutable `runState: { filesWritten: Set<string> }` to
+`DvalinContext`. `wsHandler.ts` calls `loadPolicy(cwd)` once per run and injects
+both; `filesWritten` is updated by the registry on successful write/delete (also
+feeds `max_files_per_run`).
+
+### 8e — Surfacing (UI + docs)
+- `ApprovalDialog.tsx`: when an approval is policy-forced, show the rule
+  (`reason: 'policy:require_approval'`), reusing the `reason` channel plan 04 added.
+- A blocked action renders as a normal tool-error bubble — the agent's own
+  "I was blocked by policy, trying another approach" makes the enforcement visible.
+- README: new "Prompt-level rules vs. enforced policies" table.
+- `docs/THREAT-MODEL.md`: map to OWASP LLM Top 10 / agentic risks — over-permissioned
+  actions, prompt-injection-driven writes, sensitive-file exfiltration to the LLM —
+  and state what policy does/doesn't defend.
+
+## File Changes
+1. `src/core/policy.ts` — new: schema, `loadPolicy` (merge + stricter-wins), `evaluate`
+2. `src/core/context.ts` — `policy?`, `runState`
+3. `src/tools/registry.ts` — policy gate in `run()` (before approval), `filesWritten` tracking, `PolicyError`
+4. `src/server/wsHandler.ts` — `loadPolicy(cwd)` per run; inject policy + runState
+5. `src/server/playbookHandler.ts` — preserve `policies` on `dvalin.json` save (don't clobber when writing routines)
+6. `web/src/components/ApprovalDialog.tsx` — render policy-forced approval reason
+7. `tests/policy.test.ts` — new: deny_paths in every mode incl. Bypass, shell_denylist in full-auto, allowlist default-deny, merge/stricter-wins, max_files_per_run, AGENTS.md cannot override
+8. `docs/THREAT-MODEL.md` — new (OWASP mapping) · `README.md` — prompt-vs-enforced table
+
+## Verification
+- `deny_paths: ["**/*.pem"]` → `write_file`/`edit_file`/`delete_file` on `key.pem`
+  is blocked in readonly, auto-edit, full-auto, **and** Bypass; the agent receives
+  the `PolicyError` text.
+- `shell_denylist: ["curl"]` → `curl ...` blocked in Code full-auto and a
+  `policy_violation` event lands in the audit log (plan 07).
+- Put "you may modify migrations/" in AGENTS.md with `deny_paths:["migrations/**"]`
+  → write still blocked (proves enforcement > prompt).
+- Empty/absent `policies` → behavior identical to today (no regressions).
+- `npm run check` passes.
+
+## Risk note
+Default-deny is foot-gun territory: an over-broad `deny_paths` or a tight
+`shell_allowlist` can wedge the agent. Mitigations: allowlist is default-deny
+**only when explicitly declared** (absent → permissive); every block returns a
+human-readable rule name so the user immediately sees *why*; ship the README/docs
+examples conservative. Watch the agent-retry rate after rollout, same as plan 04.

--- a/requirements/plans/09-checkpoint-rollback.md
+++ b/requirements/plans/09-checkpoint-rollback.md
@@ -1,0 +1,91 @@
+# Plan: Checkpoint / Rollback — Run-Level Snapshot
+
+## Goal
+Upgrade operation-level `/undo [N]` to a one-click **run-level** rollback: snapshot
+before a run, and after it offer Rollback / Keep / Commit. Removes the "the agent
+changed a pile of files and I can't cleanly revert" fear. Cheap (wraps git) — ship
+it, but it's parity, not the headline.
+
+## Why P1 (strategic)
+- REQUIREMENTS.md #21. Unlike #19/#20 this is a genuine catch-up (Gap 3): Cursor
+  has checkpoints, Claude Code has rewind; we only have op-level undo
+  (`sharedUndoStack` / `runner.undoLast` in `src/agent/runner.ts`).
+- Low cost because git does the heavy lifting; pairs naturally with the audit
+  trail (the rollback is itself an audited event).
+
+## Design
+
+### 9a — Snapshot before a run (`src/core/checkpoint.ts`, new)
+At the start of `TurnState.RUN` (Cowork/Code only — Chat writes nothing), create a
+non-destructive snapshot that does **not** touch the working tree or index:
+- **Git repo**: `git stash create` → returns a dangling commit SHA of the current
+  dirty state (without modifying the working tree). Record
+  `{ runId, kind: 'git', stashCommit, head, ts }`. If the tree is clean,
+  `stash create` returns empty → record `{ kind: 'git', stashCommit: null, head }`
+  (nothing to restore beyond `head`).
+- **Non-git dir**: degrade to a file-level snapshot — copy the files the run is
+  *about* to touch on first write into `~/.dvalincode/checkpoints/<runId>/`
+  (lazy, driven by the registry's write tap), or, if that's too invasive for v1,
+  record `{ kind: 'unsupported' }` and tell the user rollback isn't available here.
+  **Acceptance requires the explicit "unsupported" notice at minimum.**
+- Persist the manifest to `~/.dvalincode/checkpoints/<runId>.json`.
+
+### 9b — Post-run choice (GUI + WS)
+After `run_end`, the server includes checkpoint info in the existing `done`/new
+`run_report` event. The thread renders three actions (next to the Run Report card):
+- **Rollback this run** → `POST /api/checkpoint/rollback { runId }`
+- **Keep changes** → dismiss (default; no-op)
+- **Create git commit** → opens the commit message flow (reuses existing git plumbing)
+
+### 9c — Rollback (`src/core/checkpoint.ts` + route)
+```ts
+rollback(runId): Promise<{ ok: boolean; conflicts?: string[] }>
+```
+- **Git**: compute the set of paths the run wrote (from the audit log's
+  `file_write`/`file_delete` events — plan 07 — or the checkpoint manifest).
+  Detect **post-run user edits**: if a written file's current hash ≠ the run's
+  recorded `afterHash`, the user touched it after the run → add to `conflicts` and
+  **do not** silently overwrite; return conflicts for the UI to confirm.
+  For non-conflicting paths, restore each from the snapshot:
+  `git checkout <head> -- <path>` for files that existed pre-run, and for files the
+  run *created*, `rm` them; apply the stashed dirty state back where relevant.
+  (Scope the restore to run-touched paths so unrelated work is never reverted.)
+- **File-level**: copy back from `~/.dvalincode/checkpoints/<runId>/`, same
+  conflict check via hashes.
+- Emit a `rollback` audit event (extend plan 07's event union) recording runId,
+  restored paths, and any conflicts.
+
+### 9d — CLI (`src/commands/checkpoint.ts`, new; registered in `src/cli.ts`)
+```
+dvalincode checkpoint list            # runId · time · #files · git|file|unsupported
+dvalincode rollback <run-id>          # prompts on conflicts unless --force
+```
+
+## File Changes
+1. `src/core/checkpoint.ts` — new: `snapshot()`, `rollback()`, manifest I/O, conflict detection
+2. `src/agent/loop.ts` — call `snapshot()` at `TurnState.RUN` entry (Cowork/Code)
+3. `src/server/wsHandler.ts` — surface checkpoint info post-run; `POST /api/checkpoint/rollback`, `GET /api/checkpoint/list`
+4. `src/audit/log.ts` — add `rollback` event type (depends on plan 07)
+5. `web/src/components/RunReportCard.tsx` (or a sibling) — Rollback / Keep / Commit actions + conflict confirm dialog
+6. `web/src/lib/client.ts` — `rollbackRun()`, `listCheckpoints()`
+7. `src/commands/checkpoint.ts` + `src/cli.ts` — `checkpoint list`, `rollback <id>`
+8. `tests/checkpoint.test.ts` — new: clean rollback leaves `git status` clean; created-file rollback removes it; post-run user edit → conflict (no silent overwrite); non-git → unsupported notice
+
+## Verification
+- Code-mode run edits 3 files → **Rollback** → `git status` is clean (back to
+  pre-run state); the 3 files match their pre-run content.
+- Run creates `new.ts` → rollback removes it.
+- User hand-edits one of the run's files after the run, then rollback → that file
+  is reported as a conflict and left untouched unless confirmed/`--force`.
+- Non-git directory → run still works; checkpoint reports `unsupported` and the UI
+  hides Rollback (or shows it disabled with a reason).
+- Rollback writes a `rollback` event to the run's audit log.
+- `npm run check` passes.
+
+## Risk note
+`git stash create` + scoped `checkout` is non-destructive, but a careless restore
+could clobber concurrent user edits — hence the mandatory hash-based conflict gate
+(silent overwrite is an explicit acceptance failure). Keep the restore **scoped to
+run-touched paths**; never `git reset --hard` the whole tree. Defer dirty-stash
+re-application edge cases (partial conflicts) behind the conflict prompt rather
+than auto-merging.


### PR DESCRIPTION
## Summary

Adds the **v0.5 security roadmap** to the requirements pipeline (`data → REQUIREMENTS → plans`). No code — planning docs only.

The positioning thesis: evolve DvalinCode from *"small enough to audit"* (the code is auditable) to **"every agent action is auditable and policy-enforced"** (agent *behavior* is auditable and repo rules are *enforced*, not requested). Security becomes the moat.

### What's here
- **`requirements/data/roadmap_v05_20260612.md`** — the source brief (user-authored strategic direction, recorded as source-of-record).
- **`requirements/REQUIREMENTS.md`** — dated `2026-06-12` section with scored requirements **#19–#21** + Source Log entry.
- **`requirements/plans/07-audit-trail.md`** — tamper-evident hash-chained JSONL audit log + Run Report + `report verify`.
- **`requirements/plans/08-policy-engine.md`** — enforced `dvalin.json` policies gated at the tool layer.
- **`requirements/plans/09-checkpoint-rollback.md`** — run-level git snapshot / rollback.

### The three plays
| # | Plan | Differentiator | Strategic priority |
|---|------|----------------|:---:|
| 19 | Audit Trail | hash-chained, verifiable per-run behavior log — no local agent ships this | **P0** |
| 20 | Policy Engine | repo policy *enforced* in `ToolRegistry.run()` before execution, in every mode incl. Bypass — vs everyone's prompt-level "please follow the rules" | **P0** |
| 21 | Checkpoint/Rollback | run-level snapshot atop the existing op-level undo (genuine catch-up: Cursor/Claude have this) | **P1** |

### Reviewer notes
- **Scoring caveat is deliberate and called out in the doc.** The repo's `(Pain×Align×Gap)/(Cost×Risk)` formula measures *catch-up* — `Gap=5` means "way behind." For #19/#20 we'd be *ahead* of everyone, so `Gap≈1` and the formula spits out ~1.25. That's the formula's blind spot for moat plays, not a reason to deprioritize. The section flags this explicitly so a future cycle doesn't see "1.25" and shelve the flagship feature. Ranking follows the roadmap's differentiation-value principle.
- **Plans are grounded against current `src/`**, not the brief's assumptions: enforcement chokepoint confirmed at `src/tools/registry.ts:40` (`run()`), run boundary at `src/agent/loop.ts` `TurnState.RUN` / `wsHandler.ts:392`, write/edit metadata already carries diffs + original content (hashes derivable), and checkpoint builds on the existing `sharedUndoStack` / `runner.undoLast`.
- Continues plan numbering from 06; next cycle starts at 10.

Companion deliverable tracked in the roadmap (not in this PR): `docs/THREAT-MODEL.md` (OWASP LLM Top 10 / agentic mapping) lands with the #20 implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)