### PR TITLE
Add terminal agent (TUI) and `serve` command on a shared turn-runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <p align="center">
   <a href="https://github.com/arthurpanhku/dvalincode/releases/latest"><img src="https://img.shields.io/github/v/release/arthurpanhku/dvalincode?style=for-the-badge&color=818cf8&label=Release" alt="Release"></a>
   <a href="https://github.com/arthurpanhku/dvalincode/releases"><img src="https://img.shields.io/github/downloads/arthurpanhku/dvalincode/total?style=for-the-badge&color=blue&label=Downloads" alt="Downloads"></a>
-  <a href="#-tests"><img src="https://img.shields.io/badge/Tests-65%20%2F%2065%20%E2%9C%93-success?style=for-the-badge" alt="Tests"></a>
+  <a href="#-tests"><img src="https://img.shields.io/badge/Tests-81%20%2F%2081%20%E2%9C%93-success?style=for-the-badge" alt="Tests"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-green?style=for-the-badge" alt="License"></a>
   <a href="#-quick-install"><img src="https://img.shields.io/badge/Platforms-macOS%20·%20Windows%20·%20Linux-blue?style=for-the-badge" alt="Platforms"></a>
   <a href="#-providers"><img src="https://img.shields.io/badge/LLM-OpenAI%20·%20Claude%20·%20DeepSeek%20·%20Ollama%20·%20Groq-7C3AED?style=for-the-badge" alt="LLM Support"></a>
@@ -29,7 +29,8 @@
 <tr><td><b>⚡ Code mode</b></td><td>Autonomous agent with full tool access. Run tests, type-check, build, lint — one click via the <b>Routines</b> panel. macOS shell calls run inside a <code>sandbox-exec</code> profile with network denied.</td></tr>
 <tr><td><b>🛡️ Audit trail</b></td><td>Every run emits a tamper-evident, hash-chained JSONL log — every file read/written, every command, every approval. A Run Report renders it as Markdown; <code>dvalincode report verify</code> proves the chain is intact. <a href="docs/AUDIT-TRAIL.md">Threat model →</a></td></tr>
 <tr><td><b>🖥️ First-class GUI</b></td><td>Modern web UI with code highlighting, file <code>@</code>-references, <code>/</code> slash commands, Git branch indicator, live token + cost counter, multi-profile LLM config, and a dark / light / system theme switcher.</td></tr>
-<tr><td><b>🪶 Zero-dependency binary</b></td><td>Single ~25MB executable per platform. No Node, no Python, no Docker. Auto-opens your browser on launch.</td></tr>
+<tr><td><b>🖥️ Terminal or web — one binary</b></td><td>Run it bare for an interactive <b>terminal agent</b> (like Claude Code — streaming, inline approvals, red/green diffs), or <code>dvalincode serve</code> to host the <b>web GUI</b> for browser/remote use. Both frontends drive the same agent core.</td></tr>
+<tr><td><b>🪶 Zero-dependency binary</b></td><td>Single ~25MB executable per platform. No Node, no Python, no Docker.</td></tr>
 <tr><td><b>🔐 Local-first</b></td><td>Sessions, config, profiles, and audit logs live in <code>~/.dvalincode/</code>. <code>.dvalincodeignore</code> blocks the agent from reading sensitive files. <code>AGENTS.md</code> in your repo becomes persistent project instructions.</td></tr>
 </table>
 
@@ -126,7 +127,9 @@ Detects your OS + arch, downloads the right binary, installs to `~/.dvalincode/`
 
 ```sh
 source ~/.zshrc    # or ~/.bashrc
-dvalincode         # starts the server, opens your browser
+dvalincode                       # interactive terminal agent (like Claude Code)
+dvalincode serve                 # start the web GUI, open the browser
+dvalincode serve --host 0.0.0.0 --no-open   # host it on a server for remote/browser use
 ```
 
 ### Windows
@@ -153,14 +156,16 @@ Verify against `SHA256SUMS.txt` (included in each release).
 
 ## 🎬 First-time setup
 
-After install, run `dvalincode` and:
+**Terminal (default):** run `dvalincode`. On first launch it walks you through a one-time provider setup (pick a provider, paste your API key, choose a model) and saves it to `~/.dvalincode/config.json`. Then you're at the prompt — type to chat, `/mode` to switch between Chat / Cowork / Code, `/help` for commands.
+
+**Web GUI:** run `dvalincode serve` and:
 
 1. The server starts on `http://localhost:3000` and your browser opens automatically.
 2. Click **LLM Configuration** in the sidebar (bottom-left).
 3. Pick a provider, paste your API key, choose a model, hit **Save**.
 4. Optional: save the current config as a named profile (e.g. `fast`, `cheap`, `local-ollama`) to switch quickly later.
 
-That's it — start chatting in the composer at the bottom.
+Both share the same config and sessions in `~/.dvalincode/`.
 
 ---
 
@@ -210,17 +215,22 @@ That's it — start chatting in the composer at the bottom.
 ## 🛠️ Architecture
 
 ```
-┌─────────────────────────────────────────────────────────┐
-│  Browser GUI (React + TypeScript + Tailwind, Vite)      │
-│  ChatThread · Composer · DiffViewer · PlanCard · …      │
-└──────────────────────────┬──────────────────────────────┘
-                  HTTP / WebSocket
-┌──────────────────────────▼──────────────────────────────┐
-│  Express + ws server (single binary via Bun --compile)  │
-│  /api/sessions · /api/config · /api/files · /api/git    │
-└──────────────────────────┬──────────────────────────────┘
-                           │
-┌──────────────────────────▼──────────────────────────────┐
+┌───────────────────────────┐   ┌─────────────────────────┐
+│  Terminal UI (readline)   │   │  Browser GUI (React/Vite)│
+│  streaming · approvals    │   │  ChatThread · DiffViewer │
+└─────────────┬─────────────┘   └────────────┬────────────┘
+              │ in-process          HTTP / WebSocket
+              │                ┌───────────────▼─────────────┐
+              │                │  Express + ws server         │
+              │                │  /api/* · `dvalincode serve` │
+              │                └───────────────┬─────────────┘
+              └──────────────┬─────────────────┘
+┌────────────────────────────▼────────────────────────────┐
+│  runAgentTurn — shared turn-runner (src/agent/session)   │
+│  provider · prompt (mode · git · AGENTS.md) · session    │
+└────────────────────────────┬────────────────────────────┘
+                             │
+┌────────────────────────────▼────────────────────────────┐
 │                    Agent Engine                          │
 │  AgentLoop (8-state machine) → AgentRunner              │
 │  Streaming · Interrupt · Undo stack · LLM compaction    │
@@ -258,7 +268,7 @@ RESTORE → COMPACT → COMMAND → BUILD → RUN → SAVE → RESPOND → DONE
 npm test
 ```
 
-**65 tests · 12 files · all green.**
+**81 tests · 14 files · all green.**
 
 ---
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -5,7 +5,7 @@
 <p align="center">
   <a href="https://github.com/arthurpanhku/dvalincode/releases/latest"><img src="https://img.shields.io/github/v/release/arthurpanhku/dvalincode?style=for-the-badge&color=818cf8&label=Release" alt="Release"></a>
   <a href="https://github.com/arthurpanhku/dvalincode/releases"><img src="https://img.shields.io/github/downloads/arthurpanhku/dvalincode/total?style=for-the-badge&color=blue&label=Downloads" alt="Downloads"></a>
-  <a href="#-测试"><img src="https://img.shields.io/badge/Tests-65%20%2F%2065%20%E2%9C%93-success?style=for-the-badge" alt="Tests"></a>
+  <a href="#-测试"><img src="https://img.shields.io/badge/Tests-81%20%2F%2081%20%E2%9C%93-success?style=for-the-badge" alt="Tests"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-green?style=for-the-badge" alt="License"></a>
   <a href="#-一行安装"><img src="https://img.shields.io/badge/Platforms-macOS%20·%20Windows%20·%20Linux-blue?style=for-the-badge" alt="Platforms"></a>
   <a href="#-providers"><img src="https://img.shields.io/badge/LLM-OpenAI%20·%20Claude%20·%20DeepSeek%20·%20Ollama%20·%20Groq-7C3AED?style=for-the-badge" alt="LLM Support"></a>
@@ -29,7 +29,8 @@
 <tr><td><b>⚡ Code 模式</b></td><td>自主代理，全工具权限。一键运行测试、类型检查、构建、Lint（侧栏 <b>Routines</b> 面板）。macOS shell 调用在 <code>sandbox-exec</code> 沙箱内执行，网络被禁用。</td></tr>
 <tr><td><b>🛡️ 审计日志</b></td><td>每次运行都生成防篡改、哈希链式的 JSONL 日志 —— 每次文件读写、每条命令、每次审批都被记录。Run Report 将其渲染为 Markdown；<code>dvalincode report verify</code> 可验证链条完好。<a href="docs/AUDIT-TRAIL.md">威胁模型 →</a></td></tr>
 <tr><td><b>🖥️ 一流的 GUI</b></td><td>现代化 Web UI，包含代码语法高亮、<code>@</code> 文件引用、<code>/</code> 斜杠命令、Git 分支显示、实时 Token 与费用统计、多 LLM Profile，以及暗色 / 浅色 / 跟随系统的主题切换。</td></tr>
-<tr><td><b>🪶 零依赖二进制</b></td><td>每平台单文件可执行程序 ~25MB。无需 Node、Python、Docker。启动后自动打开浏览器。</td></tr>
+<tr><td><b>🖥️ 终端或 Web，同一个二进制</b></td><td>直接运行进入交互式<b>终端代理</b>（像 Claude Code —— 流式输出、行内审批、红绿 diff）；或 <code>dvalincode serve</code> 启动 <b>Web GUI</b> 供浏览器/远程使用。两个前端共用同一套 agent 内核。</td></tr>
+<tr><td><b>🪶 零依赖二进制</b></td><td>每平台单文件可执行程序 ~25MB。无需 Node、Python、Docker。</td></tr>
 <tr><td><b>🔐 本地优先</b></td><td>Session、配置、Profile、审计日志均保存在 <code>~/.dvalincode/</code>。<code>.dvalincodeignore</code> 阻止 Agent 访问敏感文件。仓库根目录的 <code>AGENTS.md</code> 作为项目级持久指令自动加载。</td></tr>
 </table>
 
@@ -126,7 +127,9 @@ curl -fsSL https://raw.githubusercontent.com/arthurpanhku/dvalincode/main/script
 
 ```sh
 source ~/.zshrc    # 或 ~/.bashrc
-dvalincode         # 启动服务并自动打开浏览器
+dvalincode                       # 交互式终端代理（像 Claude Code）
+dvalincode serve                 # 启动 Web GUI 并打开浏览器
+dvalincode serve --host 0.0.0.0 --no-open   # 部署到服务器，供远程/浏览器访问
 ```
 
 ### Windows
@@ -153,14 +156,16 @@ dvalincode         # 启动服务并自动打开浏览器
 
 ## 🎬 首次配置
 
-安装后运行 `dvalincode`：
+**终端（默认）：** 运行 `dvalincode`。首次启动会引导你完成一次性的 Provider 配置（选择 Provider、粘贴 API Key、选择模型），保存到 `~/.dvalincode/config.json`。随后即进入对话提示符 —— 直接输入即可对话，`/mode` 切换 Chat / Cowork / Code，`/help` 查看命令。
+
+**Web GUI：** 运行 `dvalincode serve`：
 
 1. 服务在 `http://localhost:3000` 启动，浏览器自动打开。
 2. 点击侧边栏底部的 **LLM Configuration**。
 3. 选择 Provider、粘贴 API Key、选择模型、保存。
 4. 可选：将当前配置保存为命名 Profile（如 `fast`、`cheap`、`local-ollama`），日后一键切换。
 
-完成 —— 在底部输入框开始对话。
+两种方式共享 `~/.dvalincode/` 下的同一份配置与 Session。
 
 ---
 
@@ -212,17 +217,22 @@ dvalincode         # 启动服务并自动打开浏览器
 ## 🛠️ 架构
 
 ```
-┌─────────────────────────────────────────────────────────┐
-│  浏览器 GUI (React + TypeScript + Tailwind, Vite)        │
-│  ChatThread · Composer · DiffViewer · PlanCard · …      │
-└──────────────────────────┬──────────────────────────────┘
-                  HTTP / WebSocket
-┌──────────────────────────▼──────────────────────────────┐
-│  Express + ws 服务（Bun --compile 单文件二进制）          │
-│  /api/sessions · /api/config · /api/files · /api/git    │
-└──────────────────────────┬──────────────────────────────┘
-                           │
-┌──────────────────────────▼──────────────────────────────┐
+┌───────────────────────────┐   ┌─────────────────────────┐
+│  终端 UI (readline)        │   │  浏览器 GUI (React/Vite) │
+│  流式输出 · 行内审批       │   │  ChatThread · DiffViewer │
+└─────────────┬─────────────┘   └────────────┬────────────┘
+              │ 进程内调用          HTTP / WebSocket
+              │                ┌───────────────▼─────────────┐
+              │                │  Express + ws 服务            │
+              │                │  /api/* · `dvalincode serve` │
+              │                └───────────────┬─────────────┘
+              └──────────────┬─────────────────┘
+┌────────────────────────────▼────────────────────────────┐
+│  runAgentTurn —— 共享回合执行器 (src/agent/session)       │
+│  provider · prompt（mode · git · AGENTS.md）· session     │
+└────────────────────────────┬────────────────────────────┘
+                             │
+┌────────────────────────────▼────────────────────────────┐
 │                  Agent 引擎                              │
 │  AgentLoop（8 状态机） → AgentRunner                     │
 │  流式输出 · 中断 · Undo 栈 · LLM 压缩                    │
@@ -260,7 +270,7 @@ RESTORE → COMPACT → COMMAND → BUILD → RUN → SAVE → RESPOND → DONE
 npm test
 ```
 
-**65 个测试 · 12 个文件 · 全部通过。**
+**81 个测试 · 14 个文件 · 全部通过。**
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
     "build:binaries": "bash scripts/build-binaries.sh",
     "build:binaries:darwin": "bash scripts/build-binaries.sh darwin",
     "build:binaries:linux": "bash scripts/build-binaries.sh linux",
-    "server": "node dist/server/index.js",
-    "server:dev": "tsx src/server/index.ts",
+    "server": "node dist/index.js serve",
+    "server:dev": "tsx src/index.ts serve",
     "web:dev": "cd web && npm run dev",
     "web:build": "cd web && npm run build",
     "dev:all": "concurrently -n backend,frontend -c cyan,magenta \"PORT=3001 npm run server:dev\" \"npm run web:dev\""

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -152,7 +152,9 @@ if [ "$FILTER" = "all" ] || [ "$FILTER" = "darwin" ]; then
 fi
 
 # ── 3. Compile + package each target ──────────────────────────────────
-ENTRY="src/server/index.ts"
+# Unified entry: the binary is the full CLI. Bare `dvalincode` opens the
+# terminal agent (TUI); `dvalincode serve` starts the web server + GUI.
+ENTRY="src/index.ts"
 
 for i in "${!BUN_TARGETS[@]}"; do
   bun_target="${BUN_TARGETS[$i]}"

--- a/src/agent/modes.ts
+++ b/src/agent/modes.ts
@@ -1,0 +1,48 @@
+import type { ApprovalMode } from '../core/context.js';
+
+/** Top-level agent mode (mirrors the GUI's Chat / Cowork / Code switch). */
+export type AgentMode = 'chat' | 'cowork' | 'code';
+
+/** Fine-grained permission within Code mode. */
+export type CodePermissionMode = 'ask' | 'plan' | 'auto' | 'bypass';
+
+/** Tools allowed per mode; `null` means all registered tools. */
+export const MODE_TOOLS: Record<AgentMode, string[] | null> = {
+  chat:   ['read_file', 'list_files', 'search_text'],
+  cowork: null,
+  code:   null,
+};
+
+export const MODE_APPROVAL: Record<AgentMode, ApprovalMode> = {
+  chat:   'readonly',
+  cowork: 'auto-edit',
+  code:   'full-auto',
+};
+
+export const CODE_PERMISSION_APPROVAL: Record<CodePermissionMode, ApprovalMode> = {
+  ask:    'auto-edit',
+  plan:   'readonly',
+  auto:   'full-auto',
+  bypass: 'bypass',
+};
+
+export const MODE_PROMPT: Record<AgentMode, string> = {
+  chat:
+    'You are in Chat mode. Answer questions, explain code, and discuss ideas. Do NOT write, edit, delete files or run shell commands — read-only tools only.',
+  cowork:
+    'You are in Cowork mode. Work collaboratively. Briefly explain your plan before making changes. Prefer focused, surgical edits. File writes and shell commands require user approval.',
+  code:
+    'You are in Code mode. Work autonomously to complete the task efficiently. Use all available tools as needed.',
+};
+
+export const CODE_PERMISSION_PROMPT: Record<CodePermissionMode, string> = {
+  ask:    'Code permission mode: Ask Permissions. Request approval before edits, deletes, or shell commands.',
+  plan:   'Code permission mode: Plan Mode. Create a clear plan only. Do not write files, delete files, or run shell commands.',
+  auto:   'Code permission mode: Auto Mode. Complete the task autonomously with normal tool access.',
+  bypass: 'Code permission mode: Bypass Permissions. Complete the task without approval prompts.',
+};
+
+/** Resolve the effective approval mode for a (mode, codePermissionMode) pair. */
+export function resolveApprovalMode(mode: AgentMode, codePermissionMode: CodePermissionMode): ApprovalMode {
+  return mode === 'code' ? CODE_PERMISSION_APPROVAL[codePermissionMode] : MODE_APPROVAL[mode];
+}

--- a/src/agent/session.ts
+++ b/src/agent/session.ts
@@ -1,0 +1,264 @@
+import { readFile, stat } from 'node:fs/promises';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import path from 'node:path';
+
+import { AgentLoop } from './loop.js';
+import type { AgentEventHandler, LoopResult } from './types.js';
+import {
+  MODE_PROMPT,
+  MODE_TOOLS,
+  CODE_PERMISSION_PROMPT,
+  resolveApprovalMode,
+  type AgentMode,
+  type CodePermissionMode,
+} from './modes.js';
+import { createDvalinContext } from '../core/context.js';
+import { scanProject } from '../core/projectScanner.js';
+import { loadIgnorePatterns } from '../core/ignorefile.js';
+import { resolveInsideWorkspace } from '../core/workspace.js';
+import { createDefaultToolRegistry, type ToolRegistry } from '../tools/registry.js';
+import { ProviderManager } from '../providers/manager.js';
+import { ProviderPool } from '../providers/pool.js';
+import type { ProviderAdapter } from '../providers/types.js';
+import { readConfig } from '../server/configStore.js';
+import { createSession, loadSession, saveSession, summarizeSession } from '../sessions/store.js';
+import { renderReport } from '../audit/report.js';
+
+const execAsync = promisify(execFile);
+
+export type ResolvedProvider = { provider: ProviderAdapter; providerId: string; model: string };
+
+/**
+ * Resolve the active provider from saved config: a provider pool takes priority
+ * when enabled, otherwise the single `llm` config (optionally overridden by name).
+ */
+export async function resolveProvider(override?: string): Promise<ResolvedProvider> {
+  const cfg = await readConfig();
+  if (cfg.pool?.enabled && cfg.pool.entries.some(e => e.enabled)) {
+    const pool = new ProviderPool(cfg.pool.entries, cfg.pool.policy);
+    const picked = pool.next();
+    const model = cfg.pool.entries.find(e => e.id === picked.id)?.model ?? 'unknown';
+    return { provider: picked.adapter, providerId: picked.id, model };
+  }
+  const llm = cfg.llm;
+  const providerName = override ?? llm.provider;
+  const manager = new ProviderManager();
+  manager.addOpenAI(providerName, { apiKey: llm.apiKey, baseUrl: llm.baseUrl, model: llm.model });
+  return { provider: manager.get(providerName), providerId: providerName, model: llm.model ?? 'unknown' };
+}
+
+export type RunTurnInput = {
+  /** The user's message (may contain @file references). */
+  content: string;
+  /** Resume an existing session; omit to start a new one. */
+  sessionId?: string;
+  /** Workspace root — caller is responsible for validating it is allowed. */
+  cwd: string;
+  mode: AgentMode;
+  /** Only meaningful in Code mode (default: `auto`). */
+  codePermissionMode?: CodePermissionMode;
+  /** Override the configured provider by name. */
+  providerOverride?: string;
+  signal?: AbortSignal;
+};
+
+export type RunTurnHooks = {
+  /** Fired once the session id is known (before the LLM runs). */
+  onSessionId?: (sessionId: string) => void;
+  /** Fired once the provider is resolved (before the LLM runs). */
+  onProviderSelected?: (providerId: string, model: string) => void;
+  /** Streams token deltas and tool events as the turn runs. */
+  onEvent?: AgentEventHandler;
+  /** Approval gate for writes/commands in Cowork / Code-Ask mode. */
+  requestApproval?: (id: string, toolName: string, input: unknown) => Promise<boolean>;
+};
+
+export type RunTurnResult = {
+  sessionId: string;
+  result: LoopResult;
+  /** Rendered Run Report Markdown, when an audit run was produced. */
+  reportMarkdown?: string;
+  providerId: string;
+  model: string;
+};
+
+/**
+ * Run one agent turn end-to-end, independent of transport. Both the WebSocket
+ * handler (web GUI) and the terminal UI drive this same function, passing
+ * transport-specific hooks for streaming and approval. Handles session
+ * load/save, provider resolution, prompt assembly (mode + git + AGENTS.md +
+ * @mentions), tool gating, and Run Report rendering.
+ */
+export async function runAgentTurn(input: RunTurnInput, hooks: RunTurnHooks = {}): Promise<RunTurnResult> {
+  const { content, cwd, signal } = input;
+  const mode = input.mode;
+  const codePermissionMode: CodePermissionMode = input.codePermissionMode ?? 'auto';
+  const approvalMode = resolveApprovalMode(mode, codePermissionMode);
+
+  // ── Session ────────────────────────────────────────────────────────────
+  let session;
+  if (input.sessionId) {
+    const loaded = await loadSession(input.sessionId);
+    if (!loaded) throw new Error(`Session not found: ${input.sessionId}`);
+    session = loaded;
+  } else {
+    session = createSession(cwd);
+  }
+  hooks.onSessionId?.(session.id);
+
+  // ── Provider ───────────────────────────────────────────────────────────
+  const { provider, providerId, model } = await resolveProvider(input.providerOverride);
+  hooks.onProviderSelected?.(providerId, model);
+
+  // ── Prompt assembly ──────────────────────────────────────────────────────
+  const userContent = await expandAtMentions(content, cwd);
+
+  const registry = createDefaultToolRegistry();
+  const allowedTools = mode === 'code' && codePermissionMode === 'plan' ? MODE_TOOLS.chat : MODE_TOOLS[mode];
+  registry.setAllowedTools(allowedTools);
+
+  const systemPrompt = await buildSystemPrompt({
+    cwd,
+    mode,
+    codePermissionMode,
+    registry,
+    sessionSummary: session.summary,
+  });
+
+  const turnMessage =
+    mode === 'code' && codePermissionMode === 'plan'
+      ? `Create a detailed step-by-step plan for the following task. Do NOT execute any steps yet.\n\nTask: ${userContent}`
+      : userContent;
+
+  // ── Run ──────────────────────────────────────────────────────────────────
+  const loop = new AgentLoop({
+    provider,
+    registry,
+    context: createDvalinContext({ cwd, approvalMode, requestApproval: hooks.requestApproval }),
+    systemPrompt,
+    audit: { model },
+  });
+
+  const result = await loop.processMessage(turnMessage, session.messages, hooks.onEvent, signal);
+
+  // ── Persist ──────────────────────────────────────────────────────────────
+  session.messages = result.messages;
+  session.updatedAt = new Date().toISOString();
+  session.summary = summarizeSession(session);
+  await saveSession(session);
+
+  // ── Run Report (best-effort) ─────────────────────────────────────────────
+  let reportMarkdown: string | undefined;
+  if (result.runId) {
+    try {
+      reportMarkdown = renderReport(result.runId);
+    } catch {
+      // never block a turn on report rendering
+    }
+  }
+
+  return { sessionId: session.id, result, reportMarkdown, providerId, model };
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────
+
+async function buildSystemPrompt(opts: {
+  cwd: string;
+  mode: AgentMode;
+  codePermissionMode: CodePermissionMode;
+  registry: ToolRegistry;
+  sessionSummary?: string;
+}): Promise<string> {
+  const { cwd, mode, codePermissionMode, registry } = opts;
+  const tools = registry.list();
+  const toolsDesc = tools.map(t => `- ${t.name}: ${t.description} (access: ${t.access})`).join('\n');
+
+  const summary = await scanProject(cwd);
+  const sessionContext = opts.sessionSummary ? `\nPrevious session summary: ${opts.sessionSummary}\n` : '';
+
+  const agentsMd = await readTextFileSafe(path.join(cwd, 'AGENTS.md'));
+  const projectInstructions = agentsMd
+    ? `\n=== PROJECT INSTRUCTIONS (from AGENTS.md) ===\n${agentsMd}\n`
+    : '';
+
+  let gitContext = '';
+  try {
+    const branch = (await execAsync('git', ['branch', '--show-current'], { cwd })).stdout.trim();
+    const status = (await execAsync('git', ['status', '--porcelain'], { cwd })).stdout.trim();
+    const changedCount = status ? status.split('\n').length : 0;
+    gitContext = `\nGit branch: ${branch || '(detached)'}${changedCount > 0 ? ` · ${changedCount} changed file(s)` : ' · clean'}\n`;
+  } catch {
+    // Not a git repo — silently skip
+  }
+
+  return [
+    'You are DvalinCode, an AI coding assistant.',
+    MODE_PROMPT[mode],
+    mode === 'code' ? CODE_PERMISSION_PROMPT[codePermissionMode] : '',
+    '',
+    `Project root: ${summary.root}`,
+    `Files: ${summary.fileCount} files`,
+    `Package manager(s): ${summary.packageManagers.join(', ') || 'none'}`,
+    summary.signals.length > 0 ? `Signals: ${summary.signals.join(', ')}` : '',
+    gitContext,
+    projectInstructions,
+    sessionContext,
+    '',
+    '=== TOOLS ===',
+    `You have ${tools.length} tools available. Use this syntax in your response:`,
+    '',
+    '@tool("tool_name", {"param": "value"})',
+    '',
+    'Available tools:',
+    toolsDesc,
+    '',
+    'RULES:',
+    '- Always read files before modifying them.',
+    '- Prefer focused, surgical changes.',
+  ]
+    .filter(Boolean)
+    .join('\n');
+}
+
+async function readTextFileSafe(filePath: string): Promise<string | null> {
+  try {
+    return await readFile(filePath, 'utf8');
+  } catch {
+    return null;
+  }
+}
+
+function isIgnoredPath(filePath: string, patterns: string[]): boolean {
+  return patterns.some(
+    pattern =>
+      filePath === pattern ||
+      filePath.endsWith('/' + pattern) ||
+      filePath.includes('/' + pattern + '/') ||
+      filePath.startsWith(pattern + '/'),
+  );
+}
+
+/** Expand @filepath references in the user's message by injecting file contents. */
+export async function expandAtMentions(content: string, cwd: string): Promise<string> {
+  const mentionRegex = /@([\w./\-]+)/g;
+  const mentions = [...content.matchAll(mentionRegex)];
+  if (mentions.length === 0) return content;
+
+  const ignorePatterns = await loadIgnorePatterns(cwd);
+  let result = content;
+  for (const match of mentions) {
+    const relPath = match[1];
+    if (isIgnoredPath(relPath, ignorePatterns)) continue;
+    try {
+      const absPath = await resolveInsideWorkspace(cwd, relPath);
+      const info = await stat(absPath);
+      if (info.isDirectory() || info.size > 256_000) continue;
+      const fileContent = await readFile(absPath, 'utf8');
+      result = result.replace(match[0], `<file path="${relPath}">\n\`\`\`\n${fileContent}\n\`\`\`\n</file>`);
+    } catch {
+      // File not found — leave mention as-is
+    }
+  }
+  return result;
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,6 +6,8 @@ import { registerRunToolCommand } from './commands/runTool.js';
 import { registerScanCommand } from './commands/scan.js';
 import { registerToolsCommand } from './commands/tools.js';
 import { registerReportCommand } from './commands/report.js';
+import { registerServeCommand } from './commands/serve.js';
+import { registerTuiCommand } from './commands/tui.js';
 import { createDefaultToolRegistry } from './tools/registry.js';
 
 export function buildProgram(): Command {
@@ -14,7 +16,7 @@ export function buildProgram(): Command {
 
   program
     .name('dvalincode')
-    .description('Local-first CLI foundation for agentic coding workflows')
+    .description('Local-first coding agent — terminal UI by default, `serve` for the web GUI')
     .version('0.5.0');
 
   registerScanCommand(program);
@@ -24,6 +26,19 @@ export function buildProgram(): Command {
   registerChatCommand(program, registry);
   registerInitCommand(program);
   registerReportCommand(program);
+  registerServeCommand(program);
+  registerTuiCommand(program);
+
+  // Bare invocation: launch the terminal agent in an interactive TTY,
+  // otherwise fall back to help (e.g. piped or non-interactive contexts).
+  program.action(async () => {
+    if (process.stdin.isTTY) {
+      const { runTui } = await import('./tui/app.js');
+      await runTui();
+    } else {
+      program.help();
+    }
+  });
 
   return program;
 }

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -1,0 +1,19 @@
+import type { Command } from 'commander';
+import { startServer } from '../server/index.js';
+
+export function registerServeCommand(program: Command): void {
+  program
+    .command('serve')
+    .description('Start the web server + GUI (for server deployment or browser use)')
+    .option('--port <port>', 'port to listen on (default: $PORT or 3000)', (v) => parseInt(v, 10))
+    .option('--host <host>', 'host to bind — use 0.0.0.0 to expose on a network')
+    .option('--open', 'open the browser on start')
+    .option('--no-open', 'do not open the browser on start')
+    .action(async (options: { port?: number; host?: string; open?: boolean }, command: Command) => {
+      // Tri-state: honor an explicit --open/--no-open, otherwise default to
+      // opening only in an interactive terminal (skip it on headless servers).
+      const explicit = command.getOptionValueSource('open') === 'cli';
+      const open = explicit ? options.open : Boolean(process.stdout.isTTY);
+      await startServer({ port: options.port, host: options.host, open });
+    });
+}

--- a/src/commands/tui.ts
+++ b/src/commands/tui.ts
@@ -1,0 +1,15 @@
+import type { Command } from 'commander';
+import type { AgentMode } from '../agent/modes.js';
+
+export function registerTuiCommand(program: Command): void {
+  program
+    .command('tui')
+    .description('Launch the interactive terminal coding agent (default when run bare in a TTY)')
+    .option('--mode <mode>', 'starting mode: chat | cowork | code', 'chat')
+    .option('--cwd <path>', 'workspace directory (defaults to the current directory)')
+    .action(async (options: { mode?: string; cwd?: string }) => {
+      const { runTui } = await import('../tui/app.js');
+      const mode = (['chat', 'cowork', 'code'].includes(options.mode ?? '') ? options.mode : 'chat') as AgentMode;
+      await runTui({ mode, cwd: options.cwd });
+    });
+}

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -71,23 +71,38 @@ wss.on('connection', (ws) => {
   handleWebSocket(ws);
 });
 
-const PORT = parseInt(process.env.PORT ?? '3000', 10);
-const HOST = process.env.HOST ?? '127.0.0.1';
-server.listen(PORT, HOST, () => {
-  const url = `http://localhost:${PORT}`;
-  console.log('');
-  console.log('DvalinCode is running.');
-  console.log(`Open the Web GUI to use the coding assistant: ${url}`);
-  console.log('Keep this terminal window open while you work.');
-  console.log(`Workspace roots: ${process.env.DVALINCODE_WORKSPACE_ROOTS ?? `${process.cwd()} plus ~/.dvalincode/projects`}`);
-  console.log('');
+/**
+ * Start the HTTP + WebSocket server. Exported so the `serve` command (and the
+ * unified binary) can launch it; importing this module no longer binds a port.
+ *
+ * `open` controls the browser auto-open. When left undefined it falls back to
+ * the legacy behavior: open only when running as a compiled binary (not dev)
+ * and `DVALINCODE_NO_OPEN` is unset.
+ */
+export function startServer(
+  opts: { port?: number; host?: string; open?: boolean } = {},
+): Promise<{ url: string; port: number; host: string }> {
+  const port = opts.port ?? parseInt(process.env.PORT ?? '3000', 10);
+  const host = opts.host ?? process.env.HOST ?? '127.0.0.1';
+  return new Promise((resolve) => {
+    server.listen(port, host, () => {
+      const url = `http://localhost:${port}`;
+      console.log('');
+      console.log('DvalinCode is running.');
+      console.log(`Open the Web GUI to use the coding assistant: ${url}`);
+      console.log('Keep this terminal window open while you work.');
+      console.log(`Workspace roots: ${process.env.DVALINCODE_WORKSPACE_ROOTS ?? `${process.cwd()} plus ~/.dvalincode/projects`}`);
+      console.log('');
 
-  // Auto-open browser when running as a compiled release binary
-  if (!isDev && process.env.DVALINCODE_NO_OPEN !== '1') {
-    const cmd =
-      process.platform === 'darwin' ? `open "${url}"` :
-      process.platform === 'win32'  ? `start "" "${url}"` :
-                                       `xdg-open "${url}"`;
-    exec(cmd, () => { /* ignore errors */ });
-  }
-});
+      const shouldOpen = opts.open ?? (!isDev && process.env.DVALINCODE_NO_OPEN !== '1');
+      if (shouldOpen) {
+        const cmd =
+          process.platform === 'darwin' ? `open "${url}"` :
+          process.platform === 'win32'  ? `start "" "${url}"` :
+                                           `xdg-open "${url}"`;
+        exec(cmd, () => { /* ignore errors */ });
+      }
+      resolve({ url, port, host });
+    });
+  });
+}

--- a/src/server/wsHandler.ts
+++ b/src/server/wsHandler.ts
@@ -1,67 +1,10 @@
-import { readFile, stat } from 'node:fs/promises';
-import { execFile } from 'node:child_process';
-import { promisify } from 'node:util';
-import path from 'node:path';
-
-const execAsync = promisify(execFile);
 import type { WebSocket } from 'ws';
-import { ProviderManager } from '../providers/manager.js';
-import { ProviderPool } from '../providers/pool.js';
-import { scanProject } from '../core/projectScanner.js';
-import { AgentLoop } from '../agent/loop.js';
-import { renderReport } from '../audit/report.js';
-import { createDvalinContext } from '../core/context.js';
-import { createDefaultToolRegistry } from '../tools/registry.js';
-import {
-  createSession,
-  saveSession,
-  loadSession,
-  summarizeSession,
-} from '../sessions/store.js';
+import { runAgentTurn, resolveProvider } from '../agent/session.js';
+import { loadSession, saveSession } from '../sessions/store.js';
 import { estimateTokens, summarizeWithLLM, buildCompactedHistory } from '../agent/compact.js';
-import { readConfig } from './configStore.js';
 import type { AgentEvent } from '../agent/types.js';
-import { loadIgnorePatterns } from '../core/ignorefile.js';
-import { resolveInsideWorkspace } from '../core/workspace.js';
+import type { AgentMode, CodePermissionMode } from '../agent/modes.js';
 import { resolveAllowedCwd } from './security.js';
-
-type AgentMode = 'chat' | 'cowork' | 'code';
-type CodePermissionMode = 'ask' | 'plan' | 'auto' | 'bypass';
-
-const MODE_TOOLS: Record<AgentMode, string[] | null> = {
-  chat:   ['read_file', 'list_files', 'search_text'],
-  cowork: null, // all tools
-  code:   null, // all tools
-};
-
-const MODE_APPROVAL: Record<AgentMode, 'readonly' | 'auto-edit' | 'full-auto' | 'bypass'> = {
-  chat:   'readonly',
-  cowork: 'auto-edit',
-  code:   'full-auto',
-};
-
-const CODE_PERMISSION_APPROVAL: Record<CodePermissionMode, 'readonly' | 'auto-edit' | 'full-auto' | 'bypass'> = {
-  ask: 'auto-edit',
-  plan: 'readonly',
-  auto: 'full-auto',
-  bypass: 'bypass',
-};
-
-const MODE_PROMPT: Record<AgentMode, string> = {
-  chat:
-    'You are in Chat mode. Answer questions, explain code, and discuss ideas. Do NOT write, edit, delete files or run shell commands — read-only tools only.',
-  cowork:
-    'You are in Cowork mode. Work collaboratively. Briefly explain your plan before making changes. Prefer focused, surgical edits. File writes and shell commands require user approval.',
-  code:
-    'You are in Code mode. Work autonomously to complete the task efficiently. Use all available tools as needed.',
-};
-
-const CODE_PERMISSION_PROMPT: Record<CodePermissionMode, string> = {
-  ask: 'Code permission mode: Ask Permissions. Request approval before edits, deletes, or shell commands.',
-  plan: 'Code permission mode: Plan Mode. Create a clear plan only. Do not write files, delete files, or run shell commands.',
-  auto: 'Code permission mode: Auto Mode. Complete the task autonomously with normal tool access.',
-  bypass: 'Code permission mode: Bypass Permissions. Complete the task without approval prompts.',
-};
 
 type ClientMessage =
   | {
@@ -99,46 +42,6 @@ function send(ws: WebSocket, msg: ServerMessage): void {
   if (ws.readyState === 1 /* OPEN */) {
     ws.send(JSON.stringify(msg));
   }
-}
-
-async function readTextFileSafe(filePath: string): Promise<string | null> {
-  try { return await readFile(filePath, 'utf8'); } catch { return null; }
-}
-
-function isIgnoredPath(filePath: string, patterns: string[]): boolean {
-  return patterns.some(pattern =>
-    filePath === pattern ||
-    filePath.endsWith('/' + pattern) ||
-    filePath.includes('/' + pattern + '/') ||
-    filePath.startsWith(pattern + '/'),
-  );
-}
-
-/** Expand @filepath references in the user's message by injecting file contents. */
-async function expandAtMentions(content: string, cwd: string): Promise<string> {
-  const mentionRegex = /@([\w./\-]+)/g;
-  const mentions = [...content.matchAll(mentionRegex)];
-  if (mentions.length === 0) return content;
-
-  const ignorePatterns = await loadIgnorePatterns(cwd);
-  let result = content;
-  for (const match of mentions) {
-    const relPath = match[1];
-    if (isIgnoredPath(relPath, ignorePatterns)) continue;
-    try {
-      const absPath = await resolveInsideWorkspace(cwd, relPath);
-      const info = await stat(absPath);
-      if (info.isDirectory() || info.size > 256_000) continue;
-      const fileContent = await readFile(absPath, 'utf8');
-      result = result.replace(
-        match[0],
-        `<file path="${relPath}">\n\`\`\`\n${fileContent}\n\`\`\`\n</file>`,
-      );
-    } catch {
-      // File not found — leave mention as-is
-    }
-  }
-  return result;
 }
 
 export function handleWebSocket(ws: WebSocket): void {
@@ -182,18 +85,7 @@ export function handleWebSocket(ws: WebSocket): void {
       }
       let provider;
       try {
-        const cfg = await readConfig();
-        if (cfg.pool?.enabled && cfg.pool.entries.some(e => e.enabled)) {
-          provider = new ProviderPool(cfg.pool.entries, cfg.pool.policy).next().adapter;
-        } else {
-          const manager = new ProviderManager();
-          manager.addOpenAI(cfg.llm.provider, {
-            apiKey: cfg.llm.apiKey,
-            baseUrl: cfg.llm.baseUrl,
-            model: cfg.llm.model,
-          });
-          provider = manager.get(cfg.llm.provider);
-        }
+        ({ provider } = await resolveProvider());
       } catch (err) {
         send(ws, { type: 'error', message: `Provider error: ${err instanceof Error ? err.message : String(err)}` });
         return;
@@ -222,151 +114,12 @@ export function handleWebSocket(ws: WebSocket): void {
       send(ws, { type: 'error', message: err instanceof Error ? err.message : 'Workspace is not allowed' });
       return;
     }
+
     const mode: AgentMode = msg.mode ?? 'code';
     const codePermissionMode: CodePermissionMode = msg.codePermissionMode ?? 'auto';
-    const approvalMode = msg.approvalMode ?? (mode === 'code' ? CODE_PERMISSION_APPROVAL[codePermissionMode] : MODE_APPROVAL[mode]);
 
-    // Load or create session
-    let session;
-    if (msg.sessionId) {
-      session = await loadSession(msg.sessionId);
-      if (!session) {
-        send(ws, { type: 'error', message: `Session not found: ${msg.sessionId}` });
-        return;
-      }
-    } else {
-      session = createSession(cwd);
-    }
-
-    send(ws, { type: 'session_id', sessionId: session.id });
-
-    // Set up provider (pool takes priority when enabled)
-    let provider;
-    let activeProviderId: string;
-    let activeModel = 'unknown';
-    try {
-      const cfg = await readConfig();
-      if (cfg.pool?.enabled && cfg.pool.entries.some(e => e.enabled)) {
-        const pool = new ProviderPool(cfg.pool.entries, cfg.pool.policy);
-        const picked = pool.next();
-        provider = picked.adapter;
-        activeProviderId = picked.id;
-        activeModel = cfg.pool.entries.find(e => e.id === picked.id)?.model ?? 'unknown';
-      } else {
-        const llm = cfg.llm;
-        const providerName = msg.provider ?? llm.provider;
-        const manager = new ProviderManager();
-        manager.addOpenAI(providerName, {
-          apiKey: llm.apiKey,
-          baseUrl: llm.baseUrl,
-          model: llm.model,
-        });
-        provider = manager.get(providerName);
-        activeProviderId = providerName;
-        activeModel = llm.model ?? 'unknown';
-      }
-    } catch (err) {
-      send(ws, {
-        type: 'error',
-        message: `Provider error: ${err instanceof Error ? err.message : String(err)}`,
-      });
-      return;
-    }
-    send(ws, { type: 'provider_selected', providerId: activeProviderId });
-
-    // Expand @mentions in user message
-    const userContent = await expandAtMentions(msg.content, cwd);
-
-    // Build tool registry filtered by mode
-    const registry = createDefaultToolRegistry();
-    const allowedTools = mode === 'code' && codePermissionMode === 'plan'
-      ? MODE_TOOLS.chat
-      : MODE_TOOLS[mode];
-    registry.setAllowedTools(allowedTools);
-
-    const tools = registry.list();
-    const toolsDesc = tools
-      .map((t) => `- ${t.name}: ${t.description} (access: ${t.access})`)
-      .join('\n');
-
-    const summary = await scanProject(cwd);
-    const sessionContext = session.summary ? `\nPrevious session summary: ${session.summary}\n` : '';
-
-    // ── AGENTS.md project memory ─────────────────────────────────────────────
-    const agentsMd = await readTextFileSafe(path.join(cwd, 'AGENTS.md'));
-    const projectInstructions = agentsMd
-      ? `\n=== PROJECT INSTRUCTIONS (from AGENTS.md) ===\n${agentsMd}\n`
-      : '';
-
-    // ── Git context ──────────────────────────────────────────────────────────
-    let gitContext = '';
-    try {
-      const branch = (await execAsync('git', ['branch', '--show-current'], { cwd })).stdout.trim();
-      const status = (await execAsync('git', ['status', '--porcelain'], { cwd })).stdout.trim();
-      const changedCount = status ? status.split('\n').length : 0;
-      gitContext = `\nGit branch: ${branch || '(detached)'}${changedCount > 0 ? ` · ${changedCount} changed file(s)` : ' · clean'}\n`;
-    } catch {
-      // Not a git repo — silently skip
-    }
-
-    const systemPrompt = [
-      'You are DvalinCode, an AI coding assistant.',
-      MODE_PROMPT[mode],
-      mode === 'code' ? CODE_PERMISSION_PROMPT[codePermissionMode] : '',
-      '',
-      `Project root: ${summary.root}`,
-      `Files: ${summary.fileCount} files`,
-      `Package manager(s): ${summary.packageManagers.join(', ') || 'none'}`,
-      summary.signals.length > 0 ? `Signals: ${summary.signals.join(', ')}` : '',
-      gitContext,
-      projectInstructions,
-      sessionContext,
-      '',
-      '=== TOOLS ===',
-      `You have ${tools.length} tools available. Use this syntax in your response:`,
-      '',
-      '@tool("tool_name", {"param": "value"})',
-      '',
-      'Available tools:',
-      toolsDesc,
-      '',
-      'RULES:',
-      '- Always read files before modifying them.',
-      '- Prefer focused, surgical changes.',
-    ]
-      .filter(Boolean)
-      .join('\n');
-
-    const requestApproval = (id: string, toolName: string, input: unknown): Promise<boolean> => {
-      return new Promise((resolve) => {
-        if (abort.signal.aborted) { resolve(false); return; }
-        pendingApprovals.set(id, resolve);
-        send(ws, { type: 'approval_request', id, toolName, input });
-        abort.signal.addEventListener('abort', () => {
-          if (pendingApprovals.has(id)) {
-            pendingApprovals.delete(id);
-            resolve(false);
-          }
-        }, { once: true });
-      });
-    };
-
-    const turnMessage = mode === 'code' && codePermissionMode === 'plan'
-      ? `Create a detailed step-by-step plan for the following task. Do NOT execute any steps yet.\n\nTask: ${userContent}`
-      : userContent;
-
-    const loop = new AgentLoop({
-      provider,
-      registry,
-      context: createDvalinContext({
-        cwd,
-        approvalMode,
-        requestApproval,
-      }),
-      systemPrompt,
-      audit: { model: activeModel },
-    });
-
+    // Stream agent events to the browser. tool_result strips the large
+    // internal-only `originalContent` field before it goes over the wire.
     const onEvent = (event: AgentEvent): void => {
       if (abort.signal.aborted) return;
       switch (event.type) {
@@ -377,8 +130,9 @@ export function handleWebSocket(ws: WebSocket): void {
           send(ws, { type: 'tool_call', name: event.name, id: event.id, input: event.input });
           break;
         case 'tool_result': {
-          // Strip large/internal-only fields before sending over WebSocket
-          const { originalContent: _omit, ...safeMetadata } = (event.metadata ?? {}) as Record<string, unknown> & { originalContent?: unknown };
+          const { originalContent: _omit, ...safeMetadata } = (event.metadata ?? {}) as Record<string, unknown> & {
+            originalContent?: unknown;
+          };
           send(ws, {
             type: 'tool_result',
             name: event.name,
@@ -394,39 +148,66 @@ export function handleWebSocket(ws: WebSocket): void {
       }
     };
 
+    // Approval round-trip: park the resolver until the browser replies, and
+    // auto-reject if the turn is interrupted.
+    const requestApproval = (id: string, toolName: string, input: unknown): Promise<boolean> => {
+      return new Promise((resolve) => {
+        if (abort.signal.aborted) {
+          resolve(false);
+          return;
+        }
+        pendingApprovals.set(id, resolve);
+        send(ws, { type: 'approval_request', id, toolName, input });
+        abort.signal.addEventListener(
+          'abort',
+          () => {
+            if (pendingApprovals.has(id)) {
+              pendingApprovals.delete(id);
+              resolve(false);
+            }
+          },
+          { once: true },
+        );
+      });
+    };
+
     try {
-      const result = await loop.processMessage(turnMessage, session.messages, onEvent, abort.signal);
+      const turn = await runAgentTurn(
+        {
+          content: msg.content,
+          sessionId: msg.sessionId,
+          cwd,
+          mode,
+          codePermissionMode,
+          providerOverride: msg.provider,
+          signal: abort.signal,
+        },
+        {
+          onSessionId: (sessionId) => send(ws, { type: 'session_id', sessionId }),
+          onProviderSelected: (providerId) => send(ws, { type: 'provider_selected', providerId }),
+          onEvent,
+          requestApproval,
+        },
+      );
 
       if (abort.signal.aborted) return;
 
-      session.messages = result.messages;
-      session.updatedAt = new Date().toISOString();
-      session.summary = summarizeSession(session);
-      await saveSession(session);
-
-      send(ws, { type: 'response', content: result.output });
-      if (result.runId) {
-        try {
-          send(ws, { type: 'run_report', runId: result.runId, markdown: renderReport(result.runId) });
-        } catch {
-          // Report rendering is best-effort; never block the turn on it.
-        }
+      send(ws, { type: 'response', content: turn.result.output });
+      if (turn.reportMarkdown && turn.result.runId) {
+        send(ws, { type: 'run_report', runId: turn.result.runId, markdown: turn.reportMarkdown });
       }
       send(ws, {
         type: 'done',
-        sessionId: session.id,
-        iterations: result.iterationsUsed,
-        usage: result.usage,
+        sessionId: turn.sessionId,
+        iterations: turn.result.iterationsUsed,
+        usage: turn.result.usage,
       });
     } catch (err) {
       if (abort.signal.aborted) {
         send(ws, { type: 'interrupted' });
         return;
       }
-      send(ws, {
-        type: 'error',
-        message: err instanceof Error ? err.message : String(err),
-      });
+      send(ws, { type: 'error', message: err instanceof Error ? err.message : String(err) });
     } finally {
       if (currentAbort === abort) currentAbort = null;
     }

--- a/src/tui/app.ts
+++ b/src/tui/app.ts
@@ -1,0 +1,196 @@
+import readline from 'node:readline';
+import { homedir } from 'node:os';
+import chalk from 'chalk';
+
+import { runAgentTurn, resolveProvider } from '../agent/session.js';
+import type { AgentEvent } from '../agent/types.js';
+import type { AgentMode, CodePermissionMode } from '../agent/modes.js';
+import { readConfig, writeConfig } from '../server/configStore.js';
+import { PROVIDER_PRESETS, findPreset } from './presets.js';
+import * as R from './render.js';
+
+export type TuiOptions = { cwd?: string; mode?: AgentMode };
+
+/** Launch the interactive terminal agent. Drives the same `runAgentTurn` the
+ * web GUI uses, with stdout streaming and stdin approval. */
+export async function runTui(opts: TuiOptions = {}): Promise<void> {
+  const cwd = opts.cwd ?? process.cwd();
+  let mode: AgentMode = opts.mode ?? 'chat';
+  let codePermissionMode: CodePermissionMode = 'ask';
+  let sessionId: string | undefined;
+  let activeAbort: AbortController | null = null;
+
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+  const ask = (query: string): Promise<string> => new Promise(resolve => rl.question(query, resolve));
+
+  process.stdout.write(R.banner());
+
+  await ensureConfigured(rl, ask);
+
+  let providerModel = 'unconfigured';
+  try {
+    const r = await resolveProvider();
+    providerModel = `${r.providerId}/${r.model}`;
+  } catch {
+    // leave as unconfigured; the first turn will surface a clear error
+  }
+  const cwdDisplay = cwd.startsWith(homedir()) ? cwd.replace(homedir(), '~') : cwd;
+
+  // Ctrl-C: interrupt a running turn, or exit at an idle prompt.
+  rl.on('SIGINT', () => {
+    if (activeAbort) {
+      activeAbort.abort();
+    } else {
+      process.stdout.write('\n');
+      rl.close();
+    }
+  });
+  rl.on('close', () => process.exit(0));
+
+  // Approval gate for Cowork / Code-Ask writes and commands.
+  const requestApproval = async (_id: string, toolName: string, input: unknown): Promise<boolean> => {
+    const answer = await ask('\n' + R.approvalLine(toolName, input));
+    return /^y(es)?$/i.test(answer.trim());
+  };
+
+  async function runTurn(content: string): Promise<void> {
+    const abort = new AbortController();
+    activeAbort = abort;
+    let sawToken = false;
+
+    const onEvent = (event: AgentEvent): void => {
+      switch (event.type) {
+        case 'token_delta':
+          process.stdout.write(event.content);
+          sawToken = true;
+          break;
+        case 'tool_call':
+          process.stdout.write('\n' + R.formatToolCall(event.name, event.input) + '\n');
+          break;
+        case 'tool_result':
+          process.stdout.write(R.formatToolResult(event.output) + '\n');
+          break;
+        case 'tool_error':
+          process.stdout.write(R.formatToolError(event.name, event.error) + '\n');
+          break;
+      }
+    };
+
+    try {
+      const turn = await runAgentTurn(
+        { content, sessionId, cwd, mode, codePermissionMode, signal: abort.signal },
+        { onEvent, requestApproval },
+      );
+      sessionId = turn.sessionId;
+      if (!sawToken && turn.result.output) {
+        process.stdout.write(turn.result.output + '\n');
+      } else {
+        process.stdout.write('\n');
+      }
+      if (turn.result.runId) {
+        process.stdout.write(chalk.dim(`  🔒 audit ${turn.result.runId} — dvalincode report --last\n`));
+      }
+    } catch (err) {
+      if (abort.signal.aborted) {
+        process.stdout.write(chalk.yellow('\n  ⏹ interrupted\n'));
+      } else {
+        process.stdout.write(chalk.red(`\n  error: ${err instanceof Error ? err.message : String(err)}\n`));
+      }
+    } finally {
+      activeAbort = null;
+    }
+  }
+
+  function handleMode(arg: string): void {
+    const [m, perm] = arg.split(/\s+/);
+    if (m === 'chat' || m === 'cowork' || m === 'code') {
+      mode = m;
+      if (m === 'code') {
+        codePermissionMode = (['ask', 'plan', 'auto', 'bypass'].includes(perm) ? perm : 'auto') as CodePermissionMode;
+      }
+      process.stdout.write(chalk.dim(`  mode → ${mode}${mode === 'code' ? ` (${codePermissionMode})` : ''}\n`));
+    } else {
+      process.stdout.write(chalk.red('  unknown mode — use: chat | cowork | code\n'));
+    }
+  }
+
+  /** Returns true if handled locally; false to forward to the agent (e.g. /git). */
+  function handleLocal(line: string): boolean {
+    if (!line.startsWith('/')) return false;
+    const sp = line.indexOf(' ');
+    const cmd = sp === -1 ? line.slice(1) : line.slice(1, sp);
+    const arg = sp === -1 ? '' : line.slice(sp + 1).trim();
+    switch (cmd) {
+      case 'exit':
+      case 'quit':
+        rl.close();
+        return true;
+      case 'clear':
+        sessionId = undefined;
+        process.stdout.write(chalk.dim('  ✓ new session\n'));
+        return true;
+      case 'mode':
+        handleMode(arg);
+        return true;
+      case 'help':
+        process.stdout.write(R.helpText() + '\n');
+        return true;
+      default:
+        return false; // /git /plan /compact /undo → handled by the agent loop
+    }
+  }
+
+  // Main REPL loop.
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    process.stdout.write('\n' + R.statusLine(mode, providerModel, cwdDisplay) + '\n');
+    const line = (await ask(chalk.cyan('› '))).trim();
+    if (!line) continue;
+    if (handleLocal(line)) continue;
+    await runTurn(line);
+  }
+}
+
+/** First-run: if no API key is available (and the provider needs one), walk the
+ * user through a minimal provider setup and persist it to config. */
+async function ensureConfigured(
+  rl: readline.Interface,
+  ask: (q: string) => Promise<string>,
+): Promise<void> {
+  const cfg = await readConfig();
+  const preset = findPreset(cfg.llm.provider);
+  const needsKey = preset?.needsKey ?? true;
+  if (cfg.llm.apiKey || !needsKey) return;
+
+  process.stdout.write(chalk.bold("\n  No LLM provider configured. Let's set one up.\n\n"));
+  process.stdout.write('  Providers: ' + PROVIDER_PRESETS.map(p => p.id).join(', ') + '\n');
+
+  const providerId = (await ask('  Provider [deepseek]: ')).trim() || 'deepseek';
+  const chosen = findPreset(providerId) ?? findPreset('deepseek')!;
+
+  let apiKey = '';
+  if (chosen.needsKey) {
+    apiKey = (await askMasked(rl, '  API key: ')).trim();
+  }
+  const model = (await ask(`  Model [${chosen.defaultModel}]: `)).trim() || chosen.defaultModel;
+
+  await writeConfig({
+    llm: { provider: chosen.id, apiKey: apiKey || undefined, baseUrl: chosen.baseUrl, model },
+  });
+  process.stdout.write(chalk.dim('  ✓ saved to ~/.dvalincode/config.json\n'));
+}
+
+/** Ask without echoing the typed characters (for API keys). */
+function askMasked(rl: readline.Interface, query: string): Promise<string> {
+  return new Promise(resolve => {
+    const iface = rl as unknown as { _writeToOutput?: (s: string) => void };
+    const original = iface._writeToOutput;
+    rl.question(query, answer => {
+      iface._writeToOutput = original;
+      process.stdout.write('\n');
+      resolve(answer);
+    });
+    // After the query is printed, suppress echo of subsequent keystrokes.
+    iface._writeToOutput = () => {};
+  });
+}

--- a/src/tui/presets.ts
+++ b/src/tui/presets.ts
@@ -1,0 +1,23 @@
+/** Minimal provider presets for the first-run terminal setup. Mirrors the
+ * built-in presets the web LLM Configuration modal offers. The backend provider
+ * is OpenAI-compatible, so each entry just needs a base URL + a default model. */
+export type ProviderPreset = {
+  id: string;
+  label: string;
+  baseUrl: string;
+  defaultModel: string;
+  /** Local providers (e.g. Ollama) need no API key. */
+  needsKey: boolean;
+};
+
+export const PROVIDER_PRESETS: ProviderPreset[] = [
+  { id: 'deepseek',   label: 'DeepSeek',   baseUrl: 'https://api.deepseek.com/v1',   defaultModel: 'deepseek-chat',                 needsKey: true },
+  { id: 'openai',     label: 'OpenAI',     baseUrl: 'https://api.openai.com/v1',     defaultModel: 'gpt-4o-mini',                   needsKey: true },
+  { id: 'groq',       label: 'Groq',       baseUrl: 'https://api.groq.com/openai/v1', defaultModel: 'llama-3.1-8b-instant',         needsKey: true },
+  { id: 'openrouter', label: 'OpenRouter', baseUrl: 'https://openrouter.ai/api/v1',  defaultModel: 'google/gemini-2.0-flash-001',   needsKey: true },
+  { id: 'ollama',     label: 'Ollama',     baseUrl: 'http://localhost:11434/v1',     defaultModel: 'qwen2.5-coder',                 needsKey: false },
+];
+
+export function findPreset(id: string): ProviderPreset | undefined {
+  return PROVIDER_PRESETS.find(p => p.id === id.toLowerCase());
+}

--- a/src/tui/render.ts
+++ b/src/tui/render.ts
@@ -1,0 +1,95 @@
+import chalk from 'chalk';
+import type { AgentMode } from '../agent/modes.js';
+
+/** Pure terminal formatters for the TUI. No IO — returns strings so they can be
+ * unit-tested. chalk auto-disables color when stdout is not a TTY. */
+
+function clip(s: string, n: number): string {
+  const flat = s.replace(/\s+/g, ' ').trim();
+  return flat.length > n ? flat.slice(0, n) + '…' : flat;
+}
+
+/** A short one-line summary of a tool's arguments for call/approval lines. */
+export function summarizeToolInput(input: unknown): string {
+  if (input && typeof input === 'object') {
+    const o = input as Record<string, unknown>;
+    const key = ['filePath', 'path', 'command', 'pattern', 'query', 'glob'].find(
+      k => k in o && typeof o[k] === 'string',
+    );
+    if (key) return clip(String(o[key]), 80);
+    return clip(JSON.stringify(o), 80);
+  }
+  return clip(String(input ?? ''), 80);
+}
+
+export function formatToolCall(name: string, input: unknown): string {
+  return chalk.cyan(`  ⚙ ${name}`) + chalk.dim(`  ${summarizeToolInput(input)}`);
+}
+
+export function formatToolError(name: string, error: string): string {
+  return chalk.red(`  ✗ ${name}: ${clip(error, 200)}`);
+}
+
+/** Colorize a `+ `/`- `/`  ` diff (as produced by edit_file / write_file output). */
+export function colorizeDiff(text: string): string {
+  return text
+    .split('\n')
+    .map(line => {
+      if (line.startsWith('+ ')) return chalk.green(line);
+      if (line.startsWith('- ')) return chalk.red(line);
+      return chalk.dim(line);
+    })
+    .join('\n');
+}
+
+/** Render a tool result for the terminal: indented and diff-colorized. */
+export function formatToolResult(output: string): string {
+  if (!output.trim()) return chalk.dim('  ✓ done');
+  return colorizeDiff(output)
+    .split('\n')
+    .map(l => '  ' + l)
+    .join('\n');
+}
+
+const MODE_COLOR: Record<AgentMode, (s: string) => string> = {
+  chat: chalk.blue,
+  cowork: chalk.magenta,
+  code: chalk.yellow,
+};
+
+/** The dim context line printed above the input prompt. */
+export function statusLine(mode: AgentMode, providerModel: string, cwdDisplay: string): string {
+  const tag = MODE_COLOR[mode](`[${mode}]`);
+  return `${tag} ${chalk.dim(providerModel)} ${chalk.dim('·')} ${chalk.dim(cwdDisplay)}`;
+}
+
+export function approvalLine(toolName: string, input: unknown): string {
+  return (
+    chalk.yellow('  ⚠ approve ') +
+    chalk.bold(toolName) +
+    chalk.dim(`  ${summarizeToolInput(input)}`) +
+    chalk.yellow('  [y/N] ')
+  );
+}
+
+export function banner(): string {
+  return [
+    '',
+    chalk.bold.cyan('  DvalinCode') + chalk.dim('  — local-first terminal coding agent'),
+    chalk.dim('  /help for commands · /mode to switch · Ctrl-C to interrupt · /exit to quit'),
+    '',
+  ].join('\n');
+}
+
+export function helpText(): string {
+  return [
+    chalk.bold('  Commands'),
+    '  /mode <chat|cowork|code> [perm]  switch mode (perm: ask|plan|auto|bypass for code)',
+    '  /clear                           start a fresh session',
+    '  /git  /plan <task>  /compact  /undo [N]   (handled by the agent)',
+    '  /help                            show this help',
+    '  /exit                            quit',
+    '',
+    chalk.dim('  @path references inline a file · Ctrl-C interrupts a running turn'),
+  ].join('\n');
+}

--- a/tests/agent/session.test.ts
+++ b/tests/agent/session.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, realpathSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import {
+  resolveApprovalMode,
+  MODE_APPROVAL,
+  MODE_TOOLS,
+  CODE_PERMISSION_APPROVAL,
+} from '../../src/agent/modes.js';
+import { expandAtMentions } from '../../src/agent/session.js';
+
+describe('resolveApprovalMode', () => {
+  it('maps non-code modes directly', () => {
+    expect(resolveApprovalMode('chat', 'auto')).toBe('readonly');
+    expect(resolveApprovalMode('cowork', 'auto')).toBe('auto-edit');
+  });
+
+  it('uses the code permission mode within code', () => {
+    expect(resolveApprovalMode('code', 'ask')).toBe('auto-edit');
+    expect(resolveApprovalMode('code', 'plan')).toBe('readonly');
+    expect(resolveApprovalMode('code', 'auto')).toBe('full-auto');
+    expect(resolveApprovalMode('code', 'bypass')).toBe('bypass');
+  });
+
+  it('keeps chat read-only and gives cowork/code write access', () => {
+    expect(MODE_APPROVAL.chat).toBe('readonly');
+    expect(MODE_TOOLS.chat).toEqual(['read_file', 'list_files', 'search_text']);
+    expect(MODE_TOOLS.cowork).toBeNull();
+    expect(CODE_PERMISSION_APPROVAL.plan).toBe('readonly');
+  });
+});
+
+describe('expandAtMentions', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = realpathSync(mkdtempSync(path.join(tmpdir(), 'dvalin-mention-')));
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('inlines the contents of a mentioned file', async () => {
+    writeFileSync(path.join(dir, 'note.txt'), 'hello world', 'utf8');
+    const out = await expandAtMentions('look at @note.txt please', dir);
+    expect(out).toContain('<file path="note.txt">');
+    expect(out).toContain('hello world');
+  });
+
+  it('leaves a mention for a missing file unchanged', async () => {
+    const out = await expandAtMentions('check @nope.txt', dir);
+    expect(out).toBe('check @nope.txt');
+  });
+
+  it('does not inline a directory', async () => {
+    mkdirSync(path.join(dir, 'sub'));
+    const out = await expandAtMentions('see @sub', dir);
+    expect(out).toBe('see @sub');
+  });
+
+  it('returns the message untouched when there are no mentions', async () => {
+    const out = await expandAtMentions('plain message', dir);
+    expect(out).toBe('plain message');
+  });
+});

--- a/tests/tui/render.test.ts
+++ b/tests/tui/render.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import chalk from 'chalk';
+import {
+  summarizeToolInput,
+  formatToolCall,
+  formatToolError,
+  colorizeDiff,
+  formatToolResult,
+  statusLine,
+  approvalLine,
+} from '../../src/tui/render.js';
+
+// Default to no-color so structural assertions are deterministic.
+beforeEach(() => {
+  chalk.level = 0;
+});
+
+describe('summarizeToolInput', () => {
+  it('prefers a meaningful key and truncates long values', () => {
+    expect(summarizeToolInput({ filePath: 'src/index.ts' })).toBe('src/index.ts');
+    expect(summarizeToolInput({ command: 'npm test' })).toBe('npm test');
+    expect(summarizeToolInput({ pattern: 'export class' })).toBe('export class');
+    const long = 'x'.repeat(200);
+    expect(summarizeToolInput({ filePath: long }).length).toBeLessThanOrEqual(81);
+    expect(summarizeToolInput({ filePath: long }).endsWith('…')).toBe(true);
+  });
+
+  it('falls back to JSON for objects without a known key', () => {
+    expect(summarizeToolInput({ foo: 'bar' })).toContain('foo');
+  });
+});
+
+describe('formatToolCall / formatToolError', () => {
+  it('includes the tool name and an arg summary', () => {
+    expect(formatToolCall('read_file', { filePath: 'a.ts' })).toContain('read_file');
+    expect(formatToolCall('read_file', { filePath: 'a.ts' })).toContain('a.ts');
+  });
+
+  it('renders errors with the tool name and message', () => {
+    expect(formatToolError('shell', 'boom')).toContain('shell');
+    expect(formatToolError('shell', 'boom')).toContain('boom');
+  });
+});
+
+describe('colorizeDiff', () => {
+  it('preserves content and line count without color', () => {
+    const input = '+ added\n- removed\n  kept';
+    const out = colorizeDiff(input);
+    expect(out.split('\n')).toHaveLength(3);
+    expect(out).toContain('+ added');
+    expect(out).toContain('- removed');
+  });
+
+  it('wraps add/remove lines in ANSI color when enabled', () => {
+    chalk.level = 1;
+    const out = colorizeDiff('+ added\n- removed');
+    // ESC[ sequences present around the colored lines
+    expect(out).toMatch(/\[/);
+  });
+});
+
+describe('formatToolResult', () => {
+  it('indents output and shows a fallback for empty results', () => {
+    expect(formatToolResult('hello')).toBe('  hello');
+    expect(formatToolResult('   ')).toContain('done');
+  });
+});
+
+describe('statusLine / approvalLine', () => {
+  it('shows the mode, provider, and cwd', () => {
+    const s = statusLine('cowork', 'deepseek/deepseek-chat', '~/proj');
+    expect(s).toContain('[cowork]');
+    expect(s).toContain('deepseek/deepseek-chat');
+    expect(s).toContain('~/proj');
+  });
+
+  it('shows the tool and the y/N affordance', () => {
+    const a = approvalLine('write_file', { filePath: 'x.ts' });
+    expect(a).toContain('write_file');
+    expect(a).toContain('[y/N]');
+  });
+});


### PR DESCRIPTION
## Summary

Makes `dvalincode` a Claude-Code-style **interactive terminal agent** when run bare, while keeping the web GUI available via **`dvalincode serve`** for server/browser deployment. Both frontends now drive one shared, transport-agnostic turn-runner, so they stay at feature parity.

**One binary, two frontends over a shared core:**
- **Unified entry** — bare `dvalincode` in a TTY launches the TUI; `dvalincode serve [--host 0.0.0.0 --no-open]` starts the HTTP/WS server + GUI. Extracted `startServer()` from `server/index.ts` (no more import-time `listen`) and pointed the release build at the CLI entry (`src/index.ts`).
- **Shared turn-runner** — `runAgentTurn` (`src/agent/session.ts`) + mode tables (`src/agent/modes.ts`) extracted from `wsHandler.ts`. The WS handler is now a thin adapter (~440 → ~230 lines) with an unchanged message protocol and event ordering.
- **Terminal UI** (`src/tui/`) — readline REPL with live token streaming, per-write `[y/N]` approval prompts, red/green diffs, `/mode` · `/clear` · `/help` · `/exit` (plus `/git` `/plan` `/compact` `/undo` passed through to the agent), Ctrl-C interrupt, and a guided first-run provider setup. Defaults to **Chat (read-only)**, switchable live via `/mode`.

No new runtime dependencies (`readline` is built-in, `chalk` already present), preserving the "zero-dependency binary" value.

## Testing

- `npm run build` · `npm run typecheck` · `npm test` — clean; **81/81 tests** (was 65; +16 covering the pure render formatters, mode→approval mapping, and `@mention` expansion).
- **TUI end-to-end** (scripted via a child-process driver): Chat-mode question streamed a response; `/mode cowork` → write request → `⚠ approve write_file [y/N]` → `y` → file written. The generated audit log rendered via `report --last` with `✅ approved write_file`, and `report verify` reported the chain intact.
- **Web parity**: restarted the server via the new `serve` path and ran a turn through the WebSocket — identical event order `session_id → provider_selected → token_delta → response → run_report → done`; the workspace-not-allowed error path is also unchanged.
- **First-run setup**: guided prompts → masked key entry → persisted `~/.dvalincode/config.json` with the correct preset `baseUrl`.

## Notes

- The existing one-shot `dvalincode chat "<msg>"` command is left untouched; the new `tui` is the interactive path. Worth considering deprecating `chat` in favor of the TUI in a follow-up.
- Ctrl-C interrupt is wired through the same `AbortController` → signal mechanism the web uses; not driven live in CI (no pty available), but the abort path is shared with the verified web flow.
- `serve` keeps the Bun virtual-path (`webDist`) detection intact so the packaged binary still serves `web/dist`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)