### PR TITLE
Release v0.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,9 +51,16 @@ The bundled **web GUI is the runtime's reference implementation and showcase** �
 
 ---
 
-## ⭐ What's New in v0.5.0
+## ⭐ What's New in v0.6.0
 
-> [Full changelog →](https://github.com/arthurpanhku/dvalincode/releases/tag/v0.5.0)
+> [Full changelog →](https://github.com/arthurpanhku/dvalincode/releases/tag/v0.6.0)
+
+- **🖥️ Terminal agent** — run `dvalincode` bare for an interactive terminal coding agent, Claude-Code-style: streaming responses, inline `[y/N]` write approvals with red/green diffs, `/mode` · `/clear` · `/git` · `/plan` · `/compact` · `/undo` · `/help`, Ctrl-C to interrupt, and a guided first-run provider setup. Defaults to read-only **Chat**, switchable live.
+- **🌐 `dvalincode serve`** — the web GUI now lives behind a command, so the *same* binary deploys headless on a server: `dvalincode serve --host 0.0.0.0 --no-open`.
+- **🧩 One engine, two frontends** — the terminal UI and web GUI both drive a shared, transport-agnostic turn-runner (`src/agent/session.ts`), keeping them at feature parity.
+
+<details>
+<summary>v0.5.0 — security-grade audit trail · Run Report · theme switcher</summary>
 
 - **🛡️ Security-grade audit trail** — every Cowork/Code run writes a tamper-evident, hash-chained JSONL log to `~/.dvalincode/audit/` (`run_start`, every `tool_call` / `file_*` / `shell_exec` / `approval`, `run_end`). The hash chain makes any after-the-fact edit detectable. No local coding agent ships verifiable behavior logs. [Format + threat model →](docs/AUDIT-TRAIL.md)
 - **📋 Run Report + `dvalincode report` CLI** — a Markdown summary of each run (files read/changed, commands, decisions, test result), rendered as a collapsible card in the GUI and from the CLI:
@@ -63,6 +70,8 @@ The bundled **web GUI is the runtime's reference implementation and showcase** �
   dvalincode report verify <run-id>  # ✓ chain intact / ✗ broken at seq N
   ```
 - **🎨 Theme switcher** — choose **dark / light / system** in Settings. `system` follows your OS live; the choice persists across sessions.
+
+</details>
 
 <details>
 <summary>v0.4.0 — <code>/compact</code> · <code>dvalin.json</code> team playbook · self-contained binaries</summary>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -51,9 +51,16 @@ DvalinCode 的定位是 **Agent 运行时（runtime）**，而不只是又一个
 
 ---
 
-## ⭐ v0.5.0 新功能
+## ⭐ v0.6.0 新功能
 
-> [完整更新日志 →](https://github.com/arthurpanhku/dvalincode/releases/tag/v0.5.0)
+> [完整更新日志 →](https://github.com/arthurpanhku/dvalincode/releases/tag/v0.6.0)
+
+- **🖥️ 终端代理** —— 直接运行 `dvalincode` 进入交互式终端编码代理（Claude Code 风格）：流式输出、行内 `[y/N]` 写入审批 + 红绿 diff、`/mode` · `/clear` · `/git` · `/plan` · `/compact` · `/undo` · `/help`、Ctrl-C 中断，以及首次启动的引导式 Provider 配置。默认只读 **Chat**，可随时切换。
+- **🌐 `dvalincode serve`** —— Web GUI 现在收归于一个命令，因此*同一个*二进制即可无头部署在服务器上：`dvalincode serve --host 0.0.0.0 --no-open`。
+- **🧩 一套内核，两个前端** —— 终端 UI 与 Web GUI 共同驱动一个传输无关的共享回合执行器（`src/agent/session.ts`），始终保持功能对齐。
+
+<details>
+<summary>v0.5.0 —— 安全级审计日志 · Run Report · 主题切换</summary>
 
 - **🛡️ 安全级审计日志** —— 每次 Cowork/Code 运行都向 `~/.dvalincode/audit/` 写入防篡改、哈希链式的 JSONL 日志（`run_start`、每次 `tool_call` / `file_*` / `shell_exec` / `approval`、`run_end`）。哈希链让任何事后修改都可被检测。本地编码 Agent 中尚无可验证的行为日志。[格式与威胁模型 →](docs/AUDIT-TRAIL.md)
 - **📋 Run Report + `dvalincode report` 命令** —— 每次运行的 Markdown 摘要（读取/变更的文件、执行的命令、决策、测试结果），在 GUI 中以可折叠卡片呈现，也可在命令行查看：
@@ -63,6 +70,8 @@ DvalinCode 的定位是 **Agent 运行时（runtime）**，而不只是又一个
   dvalincode report verify <run-id>  # ✓ 链条完好 / ✗ 在第 N 条断裂
   ```
 - **🎨 主题切换** —— 在设置中选择 **暗色 / 浅色 / 跟随系统**。`跟随系统` 会实时跟随操作系统主题；选择会持久保存。
+
+</details>
 
 <details>
 <summary>v0.4.0 —— <code>/compact</code> · <code>dvalin.json</code> 团队 playbook · 自包含二进制</summary>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dvalincode",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "A local-first, provider-neutral CLI foundation for agentic coding workflows.",
   "type": "module",
   "license": "MIT",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -17,7 +17,7 @@ export function buildProgram(): Command {
   program
     .name('dvalincode')
     .description('Local-first coding agent — terminal UI by default, `serve` for the web GUI')
-    .version('0.5.0');
+    .version('0.6.0');
 
   registerScanCommand(program);
   registerToolsCommand(program, registry);


### PR DESCRIPTION
## Summary

Bump version to **0.6.0** for the terminal-agent + `serve` release (the feature landed in #21), and update the README changelog (EN + zh) with a "What's New in v0.6.0" section.

- `package.json` · `src/cli.ts` → `0.6.0`
- README EN/zh: new v0.6.0 highlights; previous v0.5.0 notes collapsed into a `<details>` (matching the existing pattern)

## Testing

`npm run build` · `npm test` (81/81) · `node dist/index.js --version` → `0.6.0`.

## Notes

Release-only change; no code behavior change. After merge this commit is tagged `v0.6.0` and published as a GitHub release with the cross-compiled binaries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)