### PR TITLE
docs: prominent English · 中文 language toggle in both READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 </p>
 
 <p align="center">
+  <b>English</b> · <a href="README.zh-CN.md">中文</a>
+</p>
+
+<p align="center">
   <a href="https://github.com/arthurpanhku/dvalincode/releases/latest"><img src="https://img.shields.io/github/v/release/arthurpanhku/dvalincode?style=for-the-badge&color=818cf8&label=Release" alt="Release"></a>
   <a href="https://github.com/arthurpanhku/dvalincode/releases"><img src="https://img.shields.io/github/downloads/arthurpanhku/dvalincode/total?style=for-the-badge&color=blue&label=Downloads" alt="Downloads"></a>
   <a href="#-tests"><img src="https://img.shields.io/badge/Tests-81%20%2F%2081%20%E2%9C%93-success?style=for-the-badge" alt="Tests"></a>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -3,6 +3,10 @@
 </p>
 
 <p align="center">
+  <a href="README.md">English</a> · <b>中文</b>
+</p>
+
+<p align="center">
   <a href="https://github.com/arthurpanhku/dvalincode/releases/latest"><img src="https://img.shields.io/github/v/release/arthurpanhku/dvalincode?style=for-the-badge&color=818cf8&label=Release" alt="Release"></a>
   <a href="https://github.com/arthurpanhku/dvalincode/releases"><img src="https://img.shields.io/github/downloads/arthurpanhku/dvalincode/total?style=for-the-badge&color=blue&label=Downloads" alt="Downloads"></a>
   <a href="#-测试"><img src="https://img.shields.io/badge/Tests-81%20%2F%2081%20%E2%9C%93-success?style=for-the-badge" alt="Tests"></a>


### PR DESCRIPTION
## Summary

Makes the README language switch obvious. A bilingual README already exists (`README.md` + `README.zh-CN.md`, cross-linked by the `i18n EN · 中文` badge), but the switch was buried in a row of seven badges. This adds a clear toggle line right under the logo in both files:

- `README.md` → **English** · [中文](README.zh-CN.md)
- `README.zh-CN.md` → [English](README.md) · **中文**

Current language is bolded; the other is a one-click link. No content changes — both READMEs are already in sync (incl. the v0.6.0 changelog).

## Testing

Rendered the top of both files; links resolve to the sibling README. GitHub renders relative `.md` links in-repo, so the toggle works from the repo view.

## Notes

Going forward both READMEs are maintained together — any change to one is mirrored in the other in the same change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)