### PR TITLE
Add native desktop GUI app (webview-bun) — experimental, v0.7.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ npm-debug.log*
 
 # Release build artifacts
 release/
+release-gui/

--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 </p>
 
 <p align="center">
+  <b>English</b> · <a href="README.zh-CN.md">中文</a>
+</p>
+
+<p align="center">
   <a href="https://github.com/arthurpanhku/dvalincode/releases/latest"><img src="https://img.shields.io/github/v/release/arthurpanhku/dvalincode?style=for-the-badge&color=818cf8&label=Release" alt="Release"></a>
   <a href="https://github.com/arthurpanhku/dvalincode/releases"><img src="https://img.shields.io/github/downloads/arthurpanhku/dvalincode/total?style=for-the-badge&color=blue&label=Downloads" alt="Downloads"></a>
   <a href="#-tests"><img src="https://img.shields.io/badge/Tests-81%20%2F%2081%20%E2%9C%93-success?style=for-the-badge" alt="Tests"></a>

--- a/README.md
+++ b/README.md
@@ -55,13 +55,20 @@ The bundled **web GUI is the runtime's reference implementation and showcase** �
 
 ---
 
-## ⭐ What's New in v0.6.0
+## ⭐ What's New in v0.7.0 — 🧪 Desktop app (beta)
 
-> [Full changelog →](https://github.com/arthurpanhku/dvalincode/releases/tag/v0.6.0)
+- **🖥️ Native desktop app** — a real application window (not a browser tab) over the same engine: `DvalinCode.app` on macOS, plus Windows/Linux builds. Built with [webview-bun](https://github.com/tr1ckydev/webview-bun) using the OS-native webview (WKWebView / WebView2 / WebKitGTK) — no Electron, stays a small self-contained binary.
+- **🧩 A third frontend, one core** — the desktop app, terminal UI, and web GUI all drive the same shared turn-runner. The current `dvalincode` binary is now positioned purely as the **CLI** (terminal + `serve`).
+- **Status:** the desktop binaries are **experimental / unverified** — grab them from the latest **pre-release** and please report how the window behaves on your OS.
+
+<details>
+<summary>v0.6.0 — terminal agent · <code>serve</code> · shared turn-runner</summary>
 
 - **🖥️ Terminal agent** — run `dvalincode` bare for an interactive terminal coding agent, Claude-Code-style: streaming responses, inline `[y/N]` write approvals with red/green diffs, `/mode` · `/clear` · `/git` · `/plan` · `/compact` · `/undo` · `/help`, Ctrl-C to interrupt, and a guided first-run provider setup. Defaults to read-only **Chat**, switchable live.
 - **🌐 `dvalincode serve`** — the web GUI now lives behind a command, so the *same* binary deploys headless on a server: `dvalincode serve --host 0.0.0.0 --no-open`.
 - **🧩 One engine, two frontends** — the terminal UI and web GUI both drive a shared, transport-agnostic turn-runner (`src/agent/session.ts`), keeping them at feature parity.
+
+</details>
 
 <details>
 <summary>v0.5.0 — security-grade audit trail · Run Report · theme switcher</summary>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -3,6 +3,10 @@
 </p>
 
 <p align="center">
+  <a href="README.md">English</a> · <b>中文</b>
+</p>
+
+<p align="center">
   <a href="https://github.com/arthurpanhku/dvalincode/releases/latest"><img src="https://img.shields.io/github/v/release/arthurpanhku/dvalincode?style=for-the-badge&color=818cf8&label=Release" alt="Release"></a>
   <a href="https://github.com/arthurpanhku/dvalincode/releases"><img src="https://img.shields.io/github/downloads/arthurpanhku/dvalincode/total?style=for-the-badge&color=blue&label=Downloads" alt="Downloads"></a>
   <a href="#-测试"><img src="https://img.shields.io/badge/Tests-81%20%2F%2081%20%E2%9C%93-success?style=for-the-badge" alt="Tests"></a>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -55,13 +55,20 @@ DvalinCode 的定位是 **Agent 运行时（runtime）**，而不只是又一个
 
 ---
 
-## ⭐ v0.6.0 新功能
+## ⭐ v0.7.0 新功能 —— 🧪 桌面应用（beta）
 
-> [完整更新日志 →](https://github.com/arthurpanhku/dvalincode/releases/tag/v0.6.0)
+- **🖥️ 原生桌面应用** —— 一个真正的应用窗口（不是浏览器标签页），跑在同一套内核之上：macOS 的 `DvalinCode.app`，外加 Windows / Linux 版本。基于 [webview-bun](https://github.com/tr1ckydev/webview-bun)，使用系统原生 webview（WKWebView / WebView2 / WebKitGTK）—— 不用 Electron，仍是小巧自包含的二进制。
+- **🧩 第三个前端，同一内核** —— 桌面应用、终端 UI、Web GUI 都驱动同一套共享回合执行器。现有的 `dvalincode` 二进制现在纯粹定位为 **CLI**（终端 + `serve`）。
+- **状态：** 桌面二进制目前**实验性 / 未验证** —— 请从最新的 **pre-release** 下载，并反馈窗口在你系统上的表现。
+
+<details>
+<summary>v0.6.0 —— 终端代理 · <code>serve</code> · 共享回合执行器</summary>
 
 - **🖥️ 终端代理** —— 直接运行 `dvalincode` 进入交互式终端编码代理（Claude Code 风格）：流式输出、行内 `[y/N]` 写入审批 + 红绿 diff、`/mode` · `/clear` · `/git` · `/plan` · `/compact` · `/undo` · `/help`、Ctrl-C 中断，以及首次启动的引导式 Provider 配置。默认只读 **Chat**，可随时切换。
 - **🌐 `dvalincode serve`** —— Web GUI 现在收归于一个命令，因此*同一个*二进制即可无头部署在服务器上：`dvalincode serve --host 0.0.0.0 --no-open`。
 - **🧩 一套内核，两个前端** —— 终端 UI 与 Web GUI 共同驱动一个传输无关的共享回合执行器（`src/agent/session.ts`），始终保持功能对齐。
+
+</details>
 
 <details>
 <summary>v0.5.0 —— 安全级审计日志 · Run Report · 主题切换</summary>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dvalincode",
-  "version": "0.4.3",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dvalincode",
-      "version": "0.4.3",
+      "version": "0.6.0",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.6.2",
@@ -14,6 +14,7 @@
         "cors": "^2.8.5",
         "express": "^4.21.2",
         "fast-glob": "^3.3.3",
+        "webview-bun": "^2.4.0",
         "ws": "^8.18.2",
         "zod": "^4.1.13"
       },
@@ -3277,6 +3278,12 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
+    },
+    "node_modules/webview-bun": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/webview-bun/-/webview-bun-2.4.0.tgz",
+      "integrity": "sha512-0+ugnQlcUHmuW+iLeb+Lzb8rGUJh7WEdXvNsuvaVEXT3EagK380XdD7heVJu0Ek/mNxMY3G2JM142YRQ1hDUGQ==",
+      "license": "MIT"
     },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dvalincode",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "A local-first, provider-neutral CLI foundation for agentic coding workflows.",
   "type": "module",
   "license": "MIT",
@@ -30,7 +30,10 @@
     "server:dev": "tsx src/index.ts serve",
     "web:dev": "cd web && npm run dev",
     "web:build": "cd web && npm run build",
-    "dev:all": "concurrently -n backend,frontend -c cyan,magenta \"PORT=3001 npm run server:dev\" \"npm run web:dev\""
+    "dev:all": "concurrently -n backend,frontend -c cyan,magenta \"PORT=3001 npm run server:dev\" \"npm run web:dev\"",
+    "gui:dev": "bun src/gui/index.ts",
+    "build:gui": "bash scripts/build-gui.sh",
+    "build:gui:darwin": "bash scripts/build-gui.sh darwin"
   },
   "keywords": [
     "cli",
@@ -48,6 +51,7 @@
     "cors": "^2.8.5",
     "express": "^4.21.2",
     "fast-glob": "^3.3.3",
+    "webview-bun": "^2.4.0",
     "ws": "^8.18.2",
     "zod": "^4.1.13"
   },

--- a/scripts/build-gui.sh
+++ b/scripts/build-gui.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+# Build the DvalinCode DESKTOP GUI app (native window via webview-bun):
+#   1. Build the React frontend (web/dist/)
+#   2. Compile the GUI binary (src/gui/index.ts) for each platform via Bun
+#   3. Package: macOS -> DvalinCode.app (dock app); Linux/Windows -> archive
+#   4. Generate SHA256SUMS-gui.txt
+#
+# The GUI opens a native window (WKWebView / WebView2 / WebKitGTK) over the same
+# embedded server as `dvalincode serve`. Separate artifact from the CLI binary.
+#
+# Usage: scripts/build-gui.sh [all|darwin|linux|windows]
+#
+# NOTE: native-webview binaries are most reliable when built on their own OS.
+# Cross-compiling from macOS embeds the per-platform lib but is unverified for
+# Linux/Windows until run on that OS.
+
+set -euo pipefail
+
+if command -v bun >/dev/null 2>&1; then BUN="$(command -v bun)";
+elif [ -x "$HOME/.bun/bin/bun" ]; then BUN="$HOME/.bun/bin/bun";
+else echo "error: bun is not installed." >&2; exit 1; fi
+
+is_windows_host() { [[ "$(uname -s)" == MINGW* || "$(uname -s)" == MSYS* || "$(uname -s)" == CYGWIN* ]]; }
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+FILTER="${1:-all}"
+VERSION="$(node -p "require('./package.json').version" 2>/dev/null || echo "0.0.0")"
+RELEASE_DIR="release-gui"
+ICON_SOURCE="web/public/logo.svg"
+MACOS_ICON="${RELEASE_DIR}/tmp/AppIcon.icns"
+ENTRY="src/gui/index.ts"
+
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "  DvalinCode v${VERSION} — Desktop GUI Build"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo
+
+echo "▶ Building web frontend…"
+(cd web && npm run build)
+echo "  ✓ web/dist/ ready"
+echo
+
+BUN_TARGETS=(); BIN_NAMES=()
+add() {
+  local bun_tgt="$1" bin_name="$2"
+  case "$FILTER" in
+    all) ;;
+    darwin)  [[ "$bun_tgt" == *darwin*  ]] || return 0 ;;
+    linux)   [[ "$bun_tgt" == *linux*   ]] || return 0 ;;
+    windows) [[ "$bun_tgt" == *windows* ]] || return 0 ;;
+    *) echo "error: unknown filter '$FILTER'" >&2; exit 1 ;;
+  esac
+  BUN_TARGETS+=("$bun_tgt"); BIN_NAMES+=("$bin_name")
+}
+# Order matters: build the verified/likely-good targets first so a flaky Linux
+# cross-compile can't abort the Windows/macOS artifacts.
+add "bun-darwin-arm64"  "dvalincode-gui-macos-arm64"
+add "bun-darwin-x64"    "dvalincode-gui-macos-x64"
+add "bun-windows-x64"   "dvalincode-gui-windows-x64"
+add "bun-linux-arm64"   "dvalincode-gui-linux-arm64"
+add "bun-linux-x64"     "dvalincode-gui-linux-x64"
+[ "${#BUN_TARGETS[@]}" -gt 0 ] || { echo "error: no targets for '$FILTER'" >&2; exit 1; }
+
+rm -rf "$RELEASE_DIR"; mkdir -p "$RELEASE_DIR/tmp" "$RELEASE_DIR/pkg"
+
+prepare_macos_icon() {
+  command -v sips >/dev/null 2>&1 && command -v iconutil >/dev/null 2>&1 || return 0
+  local base_png="${RELEASE_DIR}/tmp/AppIcon-1024.png" iconset="${RELEASE_DIR}/tmp/AppIcon.iconset"
+  mkdir -p "$iconset"
+  sips -s format png "$ICON_SOURCE" --out "$base_png" >/dev/null
+  for size in 16 32 128 256 512; do
+    sips -z "$size" "$size" "$base_png" --out "${iconset}/icon_${size}x${size}.png" >/dev/null
+    sips -z "$((size*2))" "$((size*2))" "$base_png" --out "${iconset}/icon_${size}x${size}@2x.png" >/dev/null
+  done
+  iconutil -c icns "$iconset" -o "$MACOS_ICON"
+}
+
+# A real dock GUI app: no LSUIElement, and an ATS exception so WKWebView may load
+# the embedded http://127.0.0.1 server.
+create_gui_macos_app() {
+  local pkg_dir="$1" bin_file="$2" arch_suffix="$3"
+  [ -f "$MACOS_ICON" ] || return 0
+  local app_dir="${pkg_dir}/DvalinCode.app"
+  mkdir -p "${app_dir}/Contents/MacOS/web" "${app_dir}/Contents/Resources"
+  cp "${pkg_dir}/${bin_file}" "${app_dir}/Contents/MacOS/${bin_file}"
+  cp -r web/dist "${app_dir}/Contents/MacOS/web/dist"
+  cp "$MACOS_ICON" "${app_dir}/Contents/Resources/AppIcon.icns"
+  chmod +x "${app_dir}/Contents/MacOS/${bin_file}"
+  cat > "${app_dir}/Contents/Info.plist" << PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict>
+  <key>CFBundleDisplayName</key><string>DvalinCode</string>
+  <key>CFBundleExecutable</key><string>${bin_file}</string>
+  <key>CFBundleIconFile</key><string>AppIcon</string>
+  <key>CFBundleIdentifier</key><string>dev.dvalincode.gui.${arch_suffix}</string>
+  <key>CFBundleName</key><string>DvalinCode</string>
+  <key>CFBundlePackageType</key><string>APPL</string>
+  <key>CFBundleShortVersionString</key><string>${VERSION}</string>
+  <key>CFBundleVersion</key><string>${VERSION}</string>
+  <key>LSMinimumSystemVersion</key><string>11.0</string>
+  <key>NSHighResolutionCapable</key><true/>
+  <key>NSAppTransportSecurity</key><dict>
+    <key>NSAllowsLocalNetworking</key><true/>
+    <key>NSAllowsArbitraryLoads</key><true/>
+  </dict>
+</dict></plist>
+PLIST
+}
+
+[[ "$FILTER" == "all" || "$FILTER" == "darwin" ]] && { echo "▶ Preparing macOS icon…"; prepare_macos_icon; echo; }
+
+for i in "${!BUN_TARGETS[@]}"; do
+  bun_target="${BUN_TARGETS[$i]}"; bin_name="${BIN_NAMES[$i]}"
+  is_windows=false; [[ "$bun_target" == *windows* ]] && is_windows=true
+  $is_windows && bin_file="${bin_name}.exe" || bin_file="${bin_name}"
+
+  echo "▶ Compiling ${bin_file}  (${bun_target})"
+  build_args=("$ENTRY" --compile --minify --target="$bun_target" --outfile "${RELEASE_DIR}/tmp/${bin_file}")
+  if $is_windows && is_windows_host; then
+    build_args+=(--windows-icon="$ICON_SOURCE" --windows-title="DvalinCode" --windows-version="${VERSION}.0")
+  fi
+  if ! "$BUN" build "${build_args[@]}"; then
+    echo "  ! build failed for ${bin_file} (cross-compile of native webview) — skipping"
+    echo
+    continue
+  fi
+
+  pkg_dir="${RELEASE_DIR}/pkg/${bin_name}"; mkdir -p "${pkg_dir}/web"
+  cp "${RELEASE_DIR}/tmp/${bin_file}" "${pkg_dir}/${bin_file}"
+  cp -r web/dist "${pkg_dir}/web/dist"
+
+  if $is_windows; then
+    archive="${RELEASE_DIR}/dvalincode-gui-v${VERSION}-windows-x64.zip"
+    (cd "${RELEASE_DIR}/pkg" && zip -rq "../dvalincode-gui-v${VERSION}-windows-x64.zip" "${bin_name}" -x "*.DS_Store")
+    echo "  ✓ $(basename "$archive")  ($(du -sh "$archive" | cut -f1))"
+  else
+    if [[ "$bun_target" == *darwin* ]]; then
+      create_gui_macos_app "$pkg_dir" "$bin_file" "${bin_name#dvalincode-gui-macos-}"
+    fi
+    suffix="${bin_name#dvalincode-gui-}"
+    archive_name="dvalincode-gui-v${VERSION}-${suffix}.tar.gz"
+    (cd "${RELEASE_DIR}/pkg" && tar czf "../${archive_name}" "${bin_name}")
+    echo "  ✓ ${archive_name}  ($(du -sh "${RELEASE_DIR}/${archive_name}" | cut -f1))"
+  fi
+  echo
+done
+
+echo "▶ Generating SHA256SUMS-gui.txt"
+(cd "$RELEASE_DIR" && { command -v shasum >/dev/null 2>&1 && shasum -a 256 dvalincode-gui-v* > SHA256SUMS-gui.txt || sha256sum dvalincode-gui-v* > SHA256SUMS-gui.txt; })
+echo "  ✓ done — artifacts in ${RELEASE_DIR}/"

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -212,9 +212,8 @@ for i in "${!BUN_TARGETS[@]}"; do
     (cd "${RELEASE_DIR}/pkg" && zip -r "../dvalincode-v${VERSION}-windows-x64.zip" "${bin_name}" -x "*.DS_Store")
     echo "  ✓ dvalincode-v${VERSION}-windows-x64.zip  ($(du -sh "$archive" | cut -f1))"
   else
-    if [[ "$bun_target" == *darwin* ]]; then
-      create_macos_app "$pkg_dir" "$bin_file" "${bin_name#dvalincode-macos-}"
-    fi
+    # The CLI ships as a terminal binary only — no double-click .app (the
+    # desktop GUI app is a separate artifact built by scripts/build-gui.sh).
 
     # macOS / Linux tar.gz
     cat > "${pkg_dir}/start.sh" << 'SH'

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -17,7 +17,7 @@ export function buildProgram(): Command {
   program
     .name('dvalincode')
     .description('Local-first coding agent — terminal UI by default, `serve` for the web GUI')
-    .version('0.6.0');
+    .version('0.7.0');
 
   registerScanCommand(program);
   registerToolsCommand(program, registry);

--- a/src/gui/index.ts
+++ b/src/gui/index.ts
@@ -1,0 +1,19 @@
+// DvalinCode desktop GUI — a native window over the same engine/server as the
+// web GUI and TUI. Starts the embedded server on an ephemeral localhost port
+// (no browser), then opens an OS-native webview (WKWebView / WebView2 /
+// WebKitGTK via webview-bun) pointed at it. This entry is built only with Bun
+// (`bun build --compile`); it is excluded from the tsc build because it imports
+// `bun:ffi` transitively. The CLI binary never imports this file, so it stays
+// webview-free.
+import { Webview } from 'webview-bun';
+import { startServer } from '../server/index.js';
+
+const { port } = await startServer({ host: '127.0.0.1', port: 0, open: false });
+
+const webview = new Webview(false, { width: 1280, height: 832, hint: 0 /* NONE — resizable */ });
+webview.title = 'DvalinCode';
+webview.navigate(`http://127.0.0.1:${port}`);
+webview.run();
+
+// run() blocks until the window is closed; then tear everything down.
+process.exit(0);

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -86,7 +86,11 @@ export function startServer(
   const host = opts.host ?? process.env.HOST ?? '127.0.0.1';
   return new Promise((resolve) => {
     server.listen(port, host, () => {
-      const url = `http://localhost:${port}`;
+      // Resolve the actual bound port — supports an ephemeral port (0), which
+      // the desktop GUI uses to avoid colliding with a running `serve`.
+      const addr = server.address();
+      const actualPort = typeof addr === 'object' && addr ? addr.port : port;
+      const url = `http://localhost:${actualPort}`;
       console.log('');
       console.log('DvalinCode is running.');
       console.log(`Open the Web GUI to use the coding assistant: ${url}`);
@@ -102,7 +106,7 @@ export function startServer(
                                            `xdg-open "${url}"`;
         exec(cmd, () => { /* ignore errors */ });
       }
-      resolve({ url, port, host });
+      resolve({ url, port: actualPort, host });
     });
   });
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,6 @@
     "sourceMap": true
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["dist", "node_modules"]
+  "exclude": ["dist", "node_modules", "src/gui"]
 }
 


### PR DESCRIPTION
## Summary

Adds a **native desktop application** (a real window, not a browser tab) as a **third frontend over the same engine** — the terminal UI, web GUI, and now the desktop app all drive the shared turn-runner. The current `dvalincode` binary is repositioned as the **CLI** (terminal + `serve`).

- **`src/gui/index.ts`** — starts the embedded server on an ephemeral `127.0.0.1` port (no browser) and opens an OS-native webview ([webview-bun](https://github.com/tr1ckydev/webview-bun): WKWebView / WebView2 / WebKitGTK). No Electron → stays a small self-contained binary. Only this entry imports `webview-bun`, so the **CLI binary stays webview-free**; it's excluded from the `tsc` build (imports `bun:ffi`) and built only via `bun build --compile`.
- **`src/server/index.ts`** — `startServer` now reports the *actual* bound port, so the GUI can use an ephemeral port without colliding with `serve`.
- **`scripts/build-gui.sh`** — per-platform GUI build + packaging: macOS `DvalinCode.app` (real dock app — no `LSUIElement`, plus an ATS exception so WKWebView may load the local HTTP server), Windows zip, Linux tar.gz, into `release-gui/` with its own `SHA256SUMS-gui.txt`.
- **`scripts/build-release.sh`** — removes the broken double-click `.app` from the CLI release (a terminal tool isn't double-clicked; the desktop `.app` is now its own artifact).
- `package.json` 0.6.0 → 0.7.0; README EN/zh document the beta desktop app.

## Testing

- `npm run build` · `npm test` (**81/81**) green — CLI unaffected (`webview-bun` only imported by `src/gui`, excluded from `tsc`).
- **Feasibility verified on macOS:** `bun --compile` embeds `libwebview` into a self-contained 61 MB binary that `dlopen`s it at runtime without crashing; `strings` confirms `WKWebViewConfiguration` baked in.
- `build-gui.sh` cross-compiles + packages all five targets; the macOS `.app` bundles `web/dist` and has the correct executable/ATS/no-`LSUIElement`.

## Notes

- **The desktop binaries are experimental / unverified-rendering.** The automated environment has no GUI session, so the window itself couldn't be visually confirmed here. They will ship as a **pre-release** for on-device testing (Windows first, per the author), and `v0.6.0` remains the stable "latest" CLI.
- **Linux** webview embedding under cross-compile is the least certain (its lib uses a dynamic FFI import); a per-OS CI matrix is the follow-up for verified Linux/Windows builds.
- No signing/notarization yet (Gatekeeper/SmartScreen will warn), as with the existing binaries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)