### PR TITLE
[codex] add local memory tools and e2e smoke

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "dev": "tsx src/index.ts",
     "start": "node dist/index.js",
     "test": "vitest run",
+    "test:e2e": "playwright test",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "check": "npm run typecheck && npm test",
     "build:release": "bash scripts/build-release.sh",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from 'playwright/test';
+
+export default defineConfig({
+  testDir: './tests/e2e',
+  testMatch: '**/*.e2e.ts',
+  timeout: 30_000,
+  use: {
+    baseURL: 'http://127.0.0.1:5921',
+    trace: 'on-first-retry',
+  },
+  webServer: {
+    command: 'node tests/e2e/start-server.mjs',
+    url: 'http://127.0.0.1:5921',
+    reuseExistingServer: !process.env.CI,
+    timeout: 60_000,
+  },
+});

--- a/src/agent/modes.ts
+++ b/src/agent/modes.ts
@@ -8,7 +8,7 @@ export type CodePermissionMode = 'ask' | 'plan' | 'auto' | 'bypass';
 
 /** Tools allowed per mode; `null` means all registered tools. */
 export const MODE_TOOLS: Record<AgentMode, string[] | null> = {
-  chat:   ['read_file', 'list_files', 'search_text'],
+  chat:   ['read_file', 'list_files', 'search_text', 'git_status', 'git_diff', 'project_scripts', 'memory_search'],
   cowork: null,
   code:   null,
 };

--- a/src/agent/session.ts
+++ b/src/agent/session.ts
@@ -24,6 +24,7 @@ import type { ProviderAdapter } from '../providers/types.js';
 import { readConfig } from '../server/configStore.js';
 import { createSession, loadSession, saveSession, summarizeSession } from '../sessions/store.js';
 import { renderReport } from '../audit/report.js';
+import { renderRelevantMemory } from '../memory/store.js';
 
 const execAsync = promisify(execFile);
 
@@ -123,6 +124,7 @@ export async function runAgentTurn(input: RunTurnInput, hooks: RunTurnHooks = {}
     mode,
     codePermissionMode,
     registry,
+    userContent,
     sessionSummary: session.summary,
   });
 
@@ -168,6 +170,7 @@ async function buildSystemPrompt(opts: {
   mode: AgentMode;
   codePermissionMode: CodePermissionMode;
   registry: ToolRegistry;
+  userContent: string;
   sessionSummary?: string;
 }): Promise<string> {
   const { cwd, mode, codePermissionMode, registry } = opts;
@@ -176,6 +179,7 @@ async function buildSystemPrompt(opts: {
 
   const summary = await scanProject(cwd);
   const sessionContext = opts.sessionSummary ? `\nPrevious session summary: ${opts.sessionSummary}\n` : '';
+  const localMemory = await renderRelevantMemory(cwd, opts.userContent, 8);
 
   const agentsMd = await readTextFileSafe(path.join(cwd, 'AGENTS.md'));
   const projectInstructions = agentsMd
@@ -203,6 +207,7 @@ async function buildSystemPrompt(opts: {
     summary.signals.length > 0 ? `Signals: ${summary.signals.join(', ')}` : '',
     gitContext,
     projectInstructions,
+    localMemory,
     sessionContext,
     '',
     '=== TOOLS ===',

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,6 +2,7 @@ import { Command } from 'commander';
 import { registerAskCommand } from './commands/ask.js';
 import { registerChatCommand } from './commands/chat.js';
 import { registerInitCommand } from './commands/init.js';
+import { registerMemoryCommand } from './commands/memory.js';
 import { registerRunToolCommand } from './commands/runTool.js';
 import { registerScanCommand } from './commands/scan.js';
 import { registerToolsCommand } from './commands/tools.js';
@@ -25,6 +26,7 @@ export function buildProgram(): Command {
   registerAskCommand(program, registry);
   registerChatCommand(program, registry);
   registerInitCommand(program);
+  registerMemoryCommand(program);
   registerReportCommand(program);
   registerServeCommand(program);
   registerTuiCommand(program);

--- a/src/commands/memory.ts
+++ b/src/commands/memory.ts
@@ -1,0 +1,80 @@
+import path from 'node:path';
+import type { Command } from 'commander';
+import { importMemory, type MemoryImportSource } from '../memory/importers.js';
+import { listMemoryEntries, searchMemory, type MemoryScope } from '../memory/store.js';
+
+export function registerMemoryCommand(program: Command): void {
+  const memory = program
+    .command('memory')
+    .description('Inspect and import local DvalinCode memory');
+
+  memory
+    .command('list')
+    .description('List stored memory entries')
+    .option('--scope <scope>', 'user or project')
+    .option('--cwd <path>', 'workspace path', '.')
+    .action(async (opts: { scope?: MemoryScope; cwd: string }) => {
+      const entries = await listMemoryEntries({
+        cwd: path.resolve(process.cwd(), opts.cwd),
+        scopes: opts.scope ? [opts.scope] : undefined,
+      });
+      if (entries.length === 0) {
+        console.log('No memory entries.');
+        return;
+      }
+      for (const entry of entries) {
+        console.log(`${entry.id} (${entry.scope}/${entry.kind}) ${entry.content}`);
+      }
+    });
+
+  memory
+    .command('search')
+    .description('Search stored memory entries')
+    .argument('<query>', 'query text')
+    .option('--scope <scope>', 'user or project')
+    .option('--cwd <path>', 'workspace path', '.')
+    .option('--max <n>', 'maximum results', '8')
+    .action(async (query: string, opts: { scope?: MemoryScope; cwd: string; max: string }) => {
+      const results = await searchMemory(query, {
+        cwd: path.resolve(process.cwd(), opts.cwd),
+        scopes: opts.scope ? [opts.scope] : undefined,
+        maxResults: Number.parseInt(opts.max, 10) || 8,
+      });
+      if (results.length === 0) {
+        console.log('No matching memory entries.');
+        return;
+      }
+      for (const entry of results) {
+        console.log(`${entry.id} (${entry.scope}/${entry.kind}, score ${entry.score}) ${entry.content}`);
+      }
+    });
+
+  memory
+    .command('import')
+    .description('Import memory from Claude Code, Hermes, or Markdown')
+    .argument('<source>', 'claude, hermes, or markdown')
+    .option('--path <path>', 'source file or directory')
+    .option('--scope <scope>', 'user or project')
+    .option('--cwd <path>', 'workspace path', '.')
+    .option('--dry-run', 'preview candidate entries without saving')
+    .action(async (source: MemoryImportSource, opts: { path?: string; scope?: MemoryScope; cwd: string; dryRun?: boolean }) => {
+      if (!['claude', 'hermes', 'markdown'].includes(source)) {
+        throw new Error('source must be claude, hermes, or markdown');
+      }
+      const result = await importMemory({
+        source,
+        sourcePath: opts.path ? path.resolve(process.cwd(), opts.path) : undefined,
+        cwd: path.resolve(process.cwd(), opts.cwd),
+        scope: opts.scope,
+        dryRun: opts.dryRun,
+      });
+      console.log(
+        opts.dryRun
+          ? `Found ${result.candidates.length} candidate memory entries.`
+          : `Imported ${result.imported} memory entries. Skipped ${result.skipped}.`,
+      );
+      for (const candidate of result.candidates.slice(0, 20)) {
+        console.log(`- (${candidate.kind ?? 'note'}) ${candidate.content}`);
+      }
+    });
+}

--- a/src/memory/importers.ts
+++ b/src/memory/importers.ts
@@ -1,0 +1,203 @@
+import { stat, readFile, readdir } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import path from 'node:path';
+import type { MemoryCandidate, MemoryScope, MemorySource } from './store.js';
+import { addMemoryEntries } from './store.js';
+
+export type MemoryImportSource = 'claude' | 'hermes' | 'markdown';
+
+export type MemoryImportOptions = {
+  source: MemoryImportSource;
+  sourcePath?: string;
+  cwd?: string;
+  scope?: MemoryScope;
+  dryRun?: boolean;
+};
+
+export type MemoryImportResult = {
+  source: MemoryImportSource;
+  scope: MemoryScope;
+  candidates: MemoryCandidate[];
+  imported: number;
+  skipped: number;
+};
+
+export async function importMemory(options: MemoryImportOptions): Promise<MemoryImportResult> {
+  const scope = options.scope ?? defaultScope(options.source);
+  const candidates = await collectCandidates(options);
+  if (options.dryRun) {
+    return { source: options.source, scope, candidates, imported: 0, skipped: 0 };
+  }
+  const result = await addMemoryEntries({ scope, cwd: options.cwd, candidates });
+  return {
+    source: options.source,
+    scope,
+    candidates,
+    imported: result.imported.length,
+    skipped: result.skipped,
+  };
+}
+
+async function collectCandidates(options: MemoryImportOptions): Promise<MemoryCandidate[]> {
+  switch (options.source) {
+    case 'claude':
+      return collectClaudeCandidates(options.sourcePath, options.cwd);
+    case 'hermes':
+      return collectHermesCandidates(options.sourcePath);
+    case 'markdown':
+      if (!options.sourcePath) throw new Error('markdown import requires sourcePath');
+      return collectMarkdownCandidates([options.sourcePath], 'import:markdown');
+  }
+}
+
+async function collectClaudeCandidates(sourcePath: string | undefined, cwd: string | undefined): Promise<MemoryCandidate[]> {
+  const paths = sourcePath ? [sourcePath] : await defaultClaudePaths(cwd);
+  return collectMarkdownCandidates(paths, 'import:claude');
+}
+
+async function collectHermesCandidates(sourcePath: string | undefined): Promise<MemoryCandidate[]> {
+  const base = sourcePath ?? path.join(homedir(), '.hermes', 'memories');
+  return collectMarkdownCandidates([base], 'import:hermes');
+}
+
+async function defaultClaudePaths(cwd: string | undefined): Promise<string[]> {
+  const paths: string[] = [];
+  if (cwd) {
+    paths.push(path.join(cwd, 'CLAUDE.md'));
+    paths.push(path.join(cwd, 'CLAUDE.local.md'));
+    const discovered = await findClaudeProjectMemoryDir(cwd);
+    if (discovered) paths.push(discovered);
+  }
+  paths.push(path.join(homedir(), '.claude', 'CLAUDE.md'));
+  return paths;
+}
+
+async function findClaudeProjectMemoryDir(cwd: string): Promise<string | undefined> {
+  const projectsRoot = path.join(homedir(), '.claude', 'projects');
+  const basename = path.basename(cwd).toLowerCase();
+  try {
+    const children = await readdir(projectsRoot, { withFileTypes: true });
+    for (const child of children) {
+      if (!child.isDirectory()) continue;
+      const dirName = child.name.toLowerCase();
+      if (!dirName.includes(basename)) continue;
+      const memoryDir = path.join(projectsRoot, child.name, 'memory');
+      if (await exists(path.join(memoryDir, 'MEMORY.md'))) return memoryDir;
+    }
+  } catch {
+    // Claude may not be installed or may not have auto-memory yet.
+  }
+  return undefined;
+}
+
+async function collectMarkdownCandidates(paths: string[], source: MemorySource): Promise<MemoryCandidate[]> {
+  const files: string[] = [];
+  for (const p of paths) {
+    files.push(...await markdownFiles(p));
+  }
+
+  const candidates: MemoryCandidate[] = [];
+  for (const file of files) {
+    const text = await readFile(file, 'utf-8').catch(() => '');
+    for (const chunk of splitMarkdownMemory(text)) {
+      candidates.push({
+        content: chunk,
+        kind: inferKind(chunk, file),
+        tags: inferTags(chunk, file),
+        source,
+        sourcePath: file,
+      });
+    }
+  }
+  return dedupeCandidates(candidates);
+}
+
+async function markdownFiles(input: string): Promise<string[]> {
+  if (!await exists(input)) return [];
+  const info = await stat(input);
+  if (info.isFile()) return input.toLowerCase().endsWith('.md') ? [input] : [];
+  if (!info.isDirectory()) return [];
+  const files: string[] = [];
+  const children = await readdir(input, { withFileTypes: true });
+  for (const child of children) {
+    const childPath = path.join(input, child.name);
+    if (child.isFile() && child.name.toLowerCase().endsWith('.md')) {
+      files.push(childPath);
+    }
+  }
+  return files.sort();
+}
+
+function splitMarkdownMemory(text: string): string[] {
+  const normalized = text.replace(/\r\n/g, '\n');
+  if (normalized.includes('§')) {
+    return normalized.split('§').map(cleanChunk).filter(Boolean);
+  }
+
+  const bullets = normalized
+    .split('\n')
+    .map(line => line.match(/^\s*[-*]\s+(.+)$/)?.[1] ?? '')
+    .map(cleanChunk)
+    .filter(Boolean);
+  if (bullets.length > 0) return bullets;
+
+  return normalized
+    .split(/\n{2,}/)
+    .map(cleanChunk)
+    .filter(Boolean);
+}
+
+function cleanChunk(input: string): string {
+  const text = input
+    .split('\n')
+    .filter(line => !line.trim().startsWith('#'))
+    .join('\n')
+    .trim();
+  if (!text || text.startsWith('```')) return '';
+  if (/^(id|source|updated|created):/i.test(text)) return '';
+  return text.length > 1_800 ? `${text.slice(0, 1_800).trim()}...` : text;
+}
+
+function inferKind(content: string, file: string): MemoryCandidate['kind'] {
+  const lower = `${file}\n${content}`.toLowerCase();
+  if (lower.includes('prefer') || lower.includes('preference')) return 'preference';
+  if (lower.includes('command') || lower.includes('workflow') || lower.includes('run ')) return 'workflow';
+  if (lower.includes('decision') || lower.includes('adr')) return 'decision';
+  if (lower.includes('bug') || lower.includes('lesson') || lower.includes('pitfall')) return 'lesson';
+  return 'note';
+}
+
+function inferTags(content: string, file: string): string[] {
+  const tags = new Set<string>();
+  const base = path.basename(file, path.extname(file)).toLowerCase();
+  if (base && base !== 'memory') tags.add(base);
+  for (const token of content.toLowerCase().match(/\b(test|build|deploy|api|database|frontend|backend|security|git|docker|python|typescript)\b/g) ?? []) {
+    tags.add(token);
+  }
+  return [...tags].slice(0, 6);
+}
+
+function dedupeCandidates(candidates: MemoryCandidate[]): MemoryCandidate[] {
+  const seen = new Set<string>();
+  const result: MemoryCandidate[] = [];
+  for (const candidate of candidates) {
+    const key = candidate.content.toLowerCase().replace(/\s+/g, ' ').trim();
+    if (!key || seen.has(key)) continue;
+    seen.add(key);
+    result.push(candidate);
+  }
+  return result;
+}
+
+function defaultScope(source: MemoryImportSource): MemoryScope {
+  return source === 'hermes' ? 'user' : 'project';
+}
+
+async function exists(input: string): Promise<boolean> {
+  try {
+    await stat(input);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/src/memory/store.ts
+++ b/src/memory/store.ts
@@ -1,0 +1,328 @@
+import { createHash, randomBytes } from 'node:crypto';
+import { mkdir, readFile, readdir, realpath, writeFile } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import path from 'node:path';
+
+export type MemoryScope = 'user' | 'project';
+export type MemoryKind = 'preference' | 'project_fact' | 'decision' | 'workflow' | 'lesson' | 'note';
+export type MemorySource =
+  | 'manual'
+  | 'agent'
+  | 'import:claude'
+  | 'import:hermes'
+  | 'import:markdown';
+
+export type MemoryEntry = {
+  id: string;
+  scope: MemoryScope;
+  kind: MemoryKind;
+  content: string;
+  tags: string[];
+  source: MemorySource;
+  sourcePath?: string;
+  projectId?: string;
+  projectRoot?: string;
+  confidence: number;
+  createdAt: string;
+  updatedAt: string;
+  lastUsedAt?: string;
+};
+
+export type MemoryCandidate = {
+  content: string;
+  kind?: MemoryKind;
+  tags?: string[];
+  source: MemorySource;
+  sourcePath?: string;
+};
+
+export type MemorySearchOptions = {
+  cwd?: string;
+  scopes?: MemoryScope[];
+  maxResults?: number;
+};
+
+export type MemorySearchResult = MemoryEntry & {
+  score: number;
+};
+
+const DEFAULT_MAX_RESULTS = 8;
+const MAX_CONTENT_CHARS = 2_000;
+
+export function dvalinHome(): string {
+  return process.env.DVALINCODE_HOME ?? path.join(homedir(), '.dvalincode');
+}
+
+export function memoryRoot(): string {
+  return path.join(dvalinHome(), 'memory');
+}
+
+export async function projectMemoryId(cwd: string): Promise<string> {
+  const resolved = await realpath(cwd).catch(() => path.resolve(cwd));
+  return createHash('sha256').update(resolved).digest('hex').slice(0, 16);
+}
+
+export async function projectMemoryDir(cwd: string): Promise<string> {
+  return path.join(memoryRoot(), 'projects', await projectMemoryId(cwd));
+}
+
+export function userMemoryDir(): string {
+  return path.join(memoryRoot(), 'user');
+}
+
+export async function addMemoryEntry(input: {
+  scope: MemoryScope;
+  cwd?: string;
+  content: string;
+  kind?: MemoryKind;
+  tags?: string[];
+  source?: MemorySource;
+  sourcePath?: string;
+  confidence?: number;
+}): Promise<MemoryEntry> {
+  const dir = await dirForScope(input.scope, input.cwd);
+  const now = new Date().toISOString();
+  const project = input.scope === 'project' && input.cwd
+    ? { projectId: await projectMemoryId(input.cwd), projectRoot: await realpath(input.cwd).catch(() => path.resolve(input.cwd!)) }
+    : {};
+  const entry: MemoryEntry = {
+    id: newMemoryId(),
+    scope: input.scope,
+    kind: input.kind ?? 'note',
+    content: sanitizeMemoryContent(input.content),
+    tags: normalizeTags(input.tags ?? []),
+    source: input.source ?? 'agent',
+    sourcePath: input.sourcePath,
+    confidence: clampConfidence(input.confidence ?? 0.7),
+    createdAt: now,
+    updatedAt: now,
+    ...project,
+  };
+
+  const entries = await readEntries(dir);
+  const duplicate = entries.find(existing =>
+    existing.scope === entry.scope &&
+    normalizeForDedupe(existing.content) === normalizeForDedupe(entry.content)
+  );
+  if (duplicate) return duplicate;
+
+  entries.push(entry);
+  await writeEntries(dir, entries);
+  return entry;
+}
+
+export async function addMemoryEntries(input: {
+  scope: MemoryScope;
+  cwd?: string;
+  candidates: MemoryCandidate[];
+}): Promise<{ imported: MemoryEntry[]; skipped: number }> {
+  const known = new Set(
+    (await listMemoryEntries({ cwd: input.cwd, scopes: [input.scope] }))
+      .map(entry => normalizeForDedupe(entry.content)),
+  );
+  const imported: MemoryEntry[] = [];
+  let skipped = 0;
+  for (const candidate of input.candidates) {
+    const key = normalizeForDedupe(candidate.content);
+    if (!key || known.has(key)) {
+      skipped++;
+      continue;
+    }
+    const entry = await addMemoryEntry({
+      scope: input.scope,
+      cwd: input.cwd,
+      content: candidate.content,
+      kind: candidate.kind,
+      tags: candidate.tags,
+      source: candidate.source,
+      sourcePath: candidate.sourcePath,
+      confidence: candidate.source.startsWith('import:') ? 0.6 : 0.7,
+    });
+    known.add(key);
+    imported.push(entry);
+  }
+  return { imported, skipped };
+}
+
+export async function listMemoryEntries(options: MemorySearchOptions = {}): Promise<MemoryEntry[]> {
+  const dirs = await candidateDirs(options.cwd, options.scopes);
+  const all: MemoryEntry[] = [];
+  for (const dir of dirs) {
+    all.push(...await readEntries(dir));
+  }
+  return all.sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
+}
+
+export async function searchMemory(query: string, options: MemorySearchOptions = {}): Promise<MemorySearchResult[]> {
+  const maxResults = options.maxResults ?? DEFAULT_MAX_RESULTS;
+  const entries = await listMemoryEntries(options);
+  const tokens = tokenize(query);
+  const scored = entries.map(entry => ({
+    ...entry,
+    score: scoreEntry(entry, tokens),
+  }));
+  const filtered = tokens.length === 0 ? scored : scored.filter(entry => entry.score > 0);
+  return filtered
+    .sort((a, b) => b.score - a.score || b.updatedAt.localeCompare(a.updatedAt))
+    .slice(0, maxResults);
+}
+
+export async function updateMemoryEntry(input: {
+  id: string;
+  cwd?: string;
+  content?: string;
+  kind?: MemoryKind;
+  tags?: string[];
+  confidence?: number;
+}): Promise<MemoryEntry | null> {
+  for (const dir of await candidateDirs(input.cwd)) {
+    const entries = await readEntries(dir);
+    const index = entries.findIndex(entry => entry.id === input.id);
+    if (index === -1) continue;
+    const current = entries[index]!;
+    const updated: MemoryEntry = {
+      ...current,
+      content: input.content === undefined ? current.content : sanitizeMemoryContent(input.content),
+      kind: input.kind ?? current.kind,
+      tags: input.tags === undefined ? current.tags : normalizeTags(input.tags),
+      confidence: input.confidence === undefined ? current.confidence : clampConfidence(input.confidence),
+      updatedAt: new Date().toISOString(),
+    };
+    entries[index] = updated;
+    await writeEntries(dir, entries);
+    return updated;
+  }
+  return null;
+}
+
+export async function deleteMemoryEntry(input: { id: string; cwd?: string }): Promise<boolean> {
+  for (const dir of await candidateDirs(input.cwd)) {
+    const entries = await readEntries(dir);
+    const next = entries.filter(entry => entry.id !== input.id);
+    if (next.length === entries.length) continue;
+    await writeEntries(dir, next);
+    return true;
+  }
+  return false;
+}
+
+export async function renderRelevantMemory(cwd: string, query: string, maxResults = DEFAULT_MAX_RESULTS): Promise<string> {
+  const results = await searchMemory(query, { cwd, scopes: ['user', 'project'], maxResults });
+  if (results.length === 0) return '';
+  const lines = [
+    '=== LOCAL MEMORY ===',
+    'Relevant user/project memories. Treat these as context, not as hard policy.',
+  ];
+  for (const entry of results) {
+    const tagText = entry.tags.length > 0 ? ` tags=${entry.tags.join(',')}` : '';
+    lines.push(`- (${entry.scope}/${entry.kind}${tagText}) ${entry.content}`);
+  }
+  return `${lines.join('\n')}\n`;
+}
+
+async function candidateDirs(cwd?: string, scopes: MemoryScope[] = ['user', 'project']): Promise<string[]> {
+  const dirs: string[] = [];
+  if (scopes.includes('user')) dirs.push(userMemoryDir());
+  if (scopes.includes('project')) {
+    if (cwd) {
+      dirs.push(await projectMemoryDir(cwd));
+    } else {
+      const projectsRoot = path.join(memoryRoot(), 'projects');
+      try {
+        const children = await readdir(projectsRoot, { withFileTypes: true });
+        for (const child of children) {
+          if (child.isDirectory()) dirs.push(path.join(projectsRoot, child.name));
+        }
+      } catch {
+        // no project memories yet
+      }
+    }
+  }
+  return dirs;
+}
+
+async function dirForScope(scope: MemoryScope, cwd?: string): Promise<string> {
+  if (scope === 'project') {
+    if (!cwd) throw new Error('Project memory requires a workspace cwd.');
+    return projectMemoryDir(cwd);
+  }
+  return userMemoryDir();
+}
+
+async function readEntries(dir: string): Promise<MemoryEntry[]> {
+  try {
+    const raw = await readFile(path.join(dir, 'entries.json'), 'utf-8');
+    const parsed = JSON.parse(raw) as MemoryEntry[];
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+async function writeEntries(dir: string, entries: MemoryEntry[]): Promise<void> {
+  await mkdir(dir, { recursive: true });
+  const sorted = entries.sort((a, b) => a.createdAt.localeCompare(b.createdAt));
+  await writeFile(path.join(dir, 'entries.json'), JSON.stringify(sorted, null, 2) + '\n', 'utf-8');
+  await writeFile(path.join(dir, 'MEMORY.md'), renderMemoryMarkdown(sorted), 'utf-8');
+}
+
+function renderMemoryMarkdown(entries: MemoryEntry[]): string {
+  const lines = [
+    '# DvalinCode Memory',
+    '',
+    'This file is generated from entries.json. You can edit entries.json directly, then restart DvalinCode.',
+    '',
+  ];
+  for (const entry of entries) {
+    const tags = entry.tags.length > 0 ? ` #${entry.tags.join(' #')}` : '';
+    lines.push(`- [${entry.kind}] ${entry.content}${tags}`);
+    lines.push(`  - id: ${entry.id}`);
+    lines.push(`  - source: ${entry.source}${entry.sourcePath ? ` (${entry.sourcePath})` : ''}`);
+    lines.push('');
+  }
+  return lines.join('\n');
+}
+
+function newMemoryId(): string {
+  return `mem_${Date.now()}_${randomBytes(4).toString('hex')}`;
+}
+
+function normalizeTags(tags: string[]): string[] {
+  return [...new Set(tags.map(tag => tag.trim().toLowerCase()).filter(Boolean))].slice(0, 12);
+}
+
+function clampConfidence(value: number): number {
+  if (!Number.isFinite(value)) return 0.7;
+  return Math.max(0, Math.min(1, value));
+}
+
+function sanitizeMemoryContent(content: string): string {
+  const compact = content.trim().replace(/\r\n/g, '\n').replace(/\n{3,}/g, '\n\n');
+  const redacted = compact
+    .replace(/\b(sk-[A-Za-z0-9_-]{16,})\b/g, '[redacted-api-key]')
+    .replace(/\b([A-Za-z0-9_]*TOKEN[A-Za-z0-9_]*\s*=\s*)[^\s]+/gi, '$1[redacted]')
+    .replace(/\b([A-Za-z0-9_]*SECRET[A-Za-z0-9_]*\s*=\s*)[^\s]+/gi, '$1[redacted]');
+  return redacted.slice(0, MAX_CONTENT_CHARS);
+}
+
+function normalizeForDedupe(content: string): string {
+  return content.trim().toLowerCase().replace(/\s+/g, ' ');
+}
+
+function tokenize(query: string): string[] {
+  return [...new Set(query.toLowerCase().split(/[^a-z0-9_./-]+/).filter(token => token.length >= 2))];
+}
+
+function scoreEntry(entry: MemoryEntry, tokens: string[]): number {
+  if (tokens.length === 0) return 1;
+  const content = entry.content.toLowerCase();
+  const tags = entry.tags.join(' ').toLowerCase();
+  let score = 0;
+  for (const token of tokens) {
+    if (content.includes(token)) score += 2;
+    if (tags.includes(token)) score += 3;
+    if (entry.kind.includes(token)) score += 1;
+    if (entry.sourcePath?.toLowerCase().includes(token)) score += 1;
+  }
+  return score;
+}

--- a/src/tools/gitDiff.ts
+++ b/src/tools/gitDiff.ts
@@ -1,0 +1,64 @@
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import path from 'node:path';
+import { z } from 'zod';
+import { resolveInsideWorkspace } from '../core/workspace.js';
+import type { Tool } from './types.js';
+
+const execAsync = promisify(execFile);
+
+const inputSchema = z
+  .object({
+    filePath: z.string().min(1).optional(),
+    staged: z.boolean().default(false),
+    maxBytes: z.number().int().positive().max(128_000).default(64_000),
+  })
+  .strict();
+
+type Input = z.infer<typeof inputSchema>;
+
+export const gitDiffTool: Tool<Input> = {
+  name: 'git_diff',
+  description: 'Show the current git diff, optionally scoped to one workspace file. Use before reviewing or summarizing changes.',
+  access: 'read',
+  inputSchema,
+  isConcurrencySafe: () => true,
+  isUndoable: () => false,
+
+  async run(input, context) {
+    const args = ['diff'];
+    if (input.staged) args.push('--cached');
+    if (input.filePath) {
+      const resolved = await resolveInsideWorkspace(context.cwd, input.filePath);
+      args.push('--', path.relative(context.cwd, resolved));
+    }
+
+    try {
+      const { stdout } = await execAsync('git', args, {
+        cwd: context.cwd,
+        maxBuffer: input.maxBytes + 16_000,
+      });
+      const diff = truncate(stdout.trimEnd(), input.maxBytes);
+      return {
+        title: 'git diff',
+        output: diff || 'No diff.',
+        metadata: {
+          staged: input.staged,
+          filePath: input.filePath,
+          truncated: stdout.length > input.maxBytes,
+        },
+      };
+    } catch (err) {
+      return {
+        title: 'git diff',
+        output: `Unable to read git diff: ${err instanceof Error ? err.message : String(err)}`,
+      };
+    }
+  },
+};
+
+function truncate(text: string, maxBytes: number): string {
+  const bytes = Buffer.byteLength(text, 'utf8');
+  if (bytes <= maxBytes) return text;
+  return `${text.slice(0, maxBytes)}\n[diff truncated at ${maxBytes} bytes]`;
+}

--- a/src/tools/memoryDelete.ts
+++ b/src/tools/memoryDelete.ts
@@ -1,0 +1,29 @@
+import { z } from 'zod';
+import { deleteMemoryEntry } from '../memory/store.js';
+import type { Tool } from './types.js';
+
+const inputSchema = z
+  .object({
+    id: z.string().min(1),
+  })
+  .strict();
+
+type Input = z.infer<typeof inputSchema>;
+
+export const memoryDeleteTool: Tool<Input> = {
+  name: 'memory_delete',
+  description: 'Delete a stale or incorrect local memory entry by id.',
+  access: 'write',
+  inputSchema,
+  isConcurrencySafe: () => false,
+  isUndoable: () => false,
+
+  async run(input, context) {
+    const deleted = await deleteMemoryEntry({ id: input.id, cwd: context.cwd });
+    return {
+      title: 'memory_delete',
+      output: deleted ? `Deleted memory ${input.id}.` : `Memory not found: ${input.id}`,
+      metadata: { deleted },
+    };
+  },
+};

--- a/src/tools/memoryImport.ts
+++ b/src/tools/memoryImport.ts
@@ -1,0 +1,73 @@
+import { realpath } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import path from 'node:path';
+import { z } from 'zod';
+import { importMemory } from '../memory/importers.js';
+import { dvalinHome } from '../memory/store.js';
+import type { Tool } from './types.js';
+
+const inputSchema = z
+  .object({
+    source: z.enum(['claude', 'hermes', 'markdown']),
+    path: z.string().min(1).optional(),
+    scope: z.enum(['user', 'project']).optional(),
+    dryRun: z.boolean().default(false),
+  })
+  .strict();
+
+type Input = z.infer<typeof inputSchema>;
+
+export const memoryImportTool: Tool<Input> = {
+  name: 'memory_import',
+  description: 'Import memory from Claude Code, Hermes, or a Markdown file/directory into DvalinCode local memory. Use dryRun first to preview candidates.',
+  access: 'write',
+  inputSchema,
+  isConcurrencySafe: () => false,
+  isUndoable: () => false,
+
+  async run(input, context) {
+    const sourcePath = input.path ? await resolveAllowedImportPath(input.path, context.cwd) : undefined;
+    const result = await importMemory({
+      source: input.source,
+      sourcePath,
+      cwd: context.cwd,
+      scope: input.scope,
+      dryRun: input.dryRun,
+    });
+
+    const preview = result.candidates.slice(0, 12).map((candidate, index) => {
+      const tags = candidate.tags && candidate.tags.length > 0 ? ` #${candidate.tags.join(' #')}` : '';
+      return `${index + 1}. (${candidate.kind ?? 'note'}) ${candidate.content}${tags}`;
+    }).join('\n\n');
+
+    return {
+      title: 'memory_import',
+      output: [
+        input.dryRun
+          ? `Found ${result.candidates.length} candidate memory entr${result.candidates.length === 1 ? 'y' : 'ies'} from ${input.source}.`
+          : `Imported ${result.imported} memory entr${result.imported === 1 ? 'y' : 'ies'} from ${input.source}. Skipped ${result.skipped}.`,
+        preview ? `\nPreview:\n${preview}` : '',
+      ].filter(Boolean).join('\n'),
+      metadata: result,
+    };
+  },
+};
+
+async function resolveAllowedImportPath(inputPath: string, cwd: string): Promise<string> {
+  const resolved = await realpath(path.resolve(cwd, inputPath));
+  const roots = await Promise.all([
+    realpath(cwd),
+    realpath(path.join(homedir(), '.claude')).catch(() => ''),
+    realpath(path.join(homedir(), '.hermes')).catch(() => ''),
+    realpath(dvalinHome()).catch(() => ''),
+  ]);
+  if (!roots.filter(Boolean).some(root => isInside(root, resolved))) {
+    throw new Error(`Import path is outside allowed memory locations: ${inputPath}`);
+  }
+  return resolved;
+}
+
+function isInside(root: string, candidate: string): boolean {
+  const relative = path.relative(root, candidate);
+  return relative === '' || (!relative.startsWith('..') && !path.isAbsolute(relative));
+}

--- a/src/tools/memorySearch.ts
+++ b/src/tools/memorySearch.ts
@@ -1,0 +1,48 @@
+import { z } from 'zod';
+import { searchMemory } from '../memory/store.js';
+import type { Tool } from './types.js';
+
+const inputSchema = z
+  .object({
+    query: z.string().default(''),
+    scopes: z.array(z.enum(['user', 'project'])).optional(),
+    maxResults: z.number().int().positive().max(20).default(8),
+  })
+  .strict();
+
+type Input = z.infer<typeof inputSchema>;
+
+export const memorySearchTool: Tool<Input> = {
+  name: 'memory_search',
+  description: 'Search local user/project memory for preferences, project facts, decisions, workflows, and lessons.',
+  access: 'read',
+  inputSchema,
+  isConcurrencySafe: () => true,
+  isUndoable: () => false,
+
+  async run(input, context) {
+    const results = await searchMemory(input.query, {
+      cwd: context.cwd,
+      scopes: input.scopes,
+      maxResults: input.maxResults,
+    });
+
+    if (results.length === 0) {
+      return { title: 'memory_search', output: 'No matching memory entries.' };
+    }
+
+    const output = results.map((entry, index) => {
+      const tags = entry.tags.length > 0 ? ` #${entry.tags.join(' #')}` : '';
+      return [
+        `${index + 1}. ${entry.id} (${entry.scope}/${entry.kind}, score ${entry.score})${tags}`,
+        `   ${entry.content}`,
+      ].join('\n');
+    }).join('\n\n');
+
+    return {
+      title: 'memory_search',
+      output,
+      metadata: { entries: results },
+    };
+  },
+};

--- a/src/tools/memoryUpdate.ts
+++ b/src/tools/memoryUpdate.ts
@@ -1,0 +1,43 @@
+import { z } from 'zod';
+import { updateMemoryEntry } from '../memory/store.js';
+import type { Tool } from './types.js';
+
+const inputSchema = z
+  .object({
+    id: z.string().min(1),
+    content: z.string().min(1).max(2_000).optional(),
+    kind: z.enum(['preference', 'project_fact', 'decision', 'workflow', 'lesson', 'note']).optional(),
+    tags: z.array(z.string()).optional(),
+    confidence: z.number().min(0).max(1).optional(),
+  })
+  .strict();
+
+type Input = z.infer<typeof inputSchema>;
+
+export const memoryUpdateTool: Tool<Input> = {
+  name: 'memory_update',
+  description: 'Update an existing local memory entry by id. Use to correct stale or imprecise memories.',
+  access: 'write',
+  inputSchema,
+  isConcurrencySafe: () => false,
+  isUndoable: () => false,
+
+  async run(input, context) {
+    const updated = await updateMemoryEntry({
+      id: input.id,
+      cwd: context.cwd,
+      content: input.content,
+      kind: input.kind,
+      tags: input.tags,
+      confidence: input.confidence,
+    });
+    if (!updated) {
+      return { title: 'memory_update', output: `Memory not found: ${input.id}` };
+    }
+    return {
+      title: 'memory_update',
+      output: `Updated memory ${updated.id}.`,
+      metadata: { entry: updated },
+    };
+  },
+};

--- a/src/tools/memoryWrite.ts
+++ b/src/tools/memoryWrite.ts
@@ -1,0 +1,42 @@
+import { z } from 'zod';
+import { addMemoryEntry } from '../memory/store.js';
+import type { Tool } from './types.js';
+
+const inputSchema = z
+  .object({
+    scope: z.enum(['user', 'project']).default('project'),
+    kind: z.enum(['preference', 'project_fact', 'decision', 'workflow', 'lesson', 'note']).default('note'),
+    content: z.string().min(1).max(2_000),
+    tags: z.array(z.string()).default([]),
+    confidence: z.number().min(0).max(1).default(0.7),
+  })
+  .strict();
+
+type Input = z.infer<typeof inputSchema>;
+
+export const memoryWriteTool: Tool<Input> = {
+  name: 'memory_write',
+  description: 'Store a curated local memory entry. Use for durable preferences, project facts, decisions, workflows, or lessons worth carrying into future sessions.',
+  access: 'write',
+  inputSchema,
+  isConcurrencySafe: () => false,
+  isUndoable: () => false,
+
+  async run(input, context) {
+    const entry = await addMemoryEntry({
+      scope: input.scope,
+      cwd: context.cwd,
+      kind: input.kind,
+      content: input.content,
+      tags: input.tags,
+      source: 'agent',
+      confidence: input.confidence,
+    });
+
+    return {
+      title: 'memory_write',
+      output: `Saved memory ${entry.id} (${entry.scope}/${entry.kind}).`,
+      metadata: { entry },
+    };
+  },
+};

--- a/src/tools/projectScripts.ts
+++ b/src/tools/projectScripts.ts
@@ -1,0 +1,77 @@
+import { readFile, stat } from 'node:fs/promises';
+import path from 'node:path';
+import { z } from 'zod';
+import type { Tool } from './types.js';
+
+const inputSchema = z.object({}).strict();
+
+type ScriptInfo = {
+  source: string;
+  name: string;
+  command: string;
+};
+
+export const projectScriptsTool: Tool<z.infer<typeof inputSchema>> = {
+  name: 'project_scripts',
+  description: 'List known project scripts and checks from package.json, Makefile, and common Python project files.',
+  access: 'read',
+  inputSchema,
+  isConcurrencySafe: () => true,
+  isUndoable: () => false,
+
+  async run(_input, context) {
+    const scripts = await detectScripts(context.cwd);
+    if (scripts.length === 0) {
+      return { title: 'project_scripts', output: 'No project scripts detected.' };
+    }
+    return {
+      title: 'project scripts',
+      output: scripts.map(script => `${script.source}:${script.name} — ${script.command}`).join('\n'),
+      metadata: { scripts },
+    };
+  },
+};
+
+export async function detectScripts(cwd: string): Promise<ScriptInfo[]> {
+  const scripts: ScriptInfo[] = [];
+  const pkg = await readJson(path.join(cwd, 'package.json')) as { scripts?: Record<string, string> } | null;
+  if (pkg?.scripts) {
+    for (const [name, command] of Object.entries(pkg.scripts)) {
+      scripts.push({ source: 'package.json', name, command });
+    }
+  }
+
+  if (await exists(path.join(cwd, 'Makefile'))) {
+    const text = await readFile(path.join(cwd, 'Makefile'), 'utf-8').catch(() => '');
+    for (const line of text.split(/\r?\n/)) {
+      const match = line.match(/^([A-Za-z0-9_.-]+):(?:\s|$)/);
+      if (match && !match[1]?.startsWith('.')) {
+        scripts.push({ source: 'Makefile', name: match[1], command: `make ${match[1]}` });
+      }
+    }
+  }
+
+  if (await exists(path.join(cwd, 'pyproject.toml'))) {
+    scripts.push({ source: 'pyproject.toml', name: 'python-tests', command: 'pytest' });
+    scripts.push({ source: 'pyproject.toml', name: 'python-typecheck', command: 'mypy .' });
+  }
+
+  return scripts;
+}
+
+async function readJson(filePath: string): Promise<unknown | null> {
+  try {
+    return JSON.parse(await readFile(filePath, 'utf-8'));
+  } catch {
+    return null;
+  }
+}
+
+async function exists(filePath: string): Promise<boolean> {
+  try {
+    await stat(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -2,8 +2,16 @@ import { assertToolPermission } from '../core/permissions.js';
 import type { DvalinContext } from '../core/context.js';
 import { emitToolAudit } from '../audit/taps.js';
 import { editFileTool } from './editFile.js';
+import { gitDiffTool } from './gitDiff.js';
 import { listFilesTool } from './listFiles.js';
+import { memoryDeleteTool } from './memoryDelete.js';
+import { memoryImportTool } from './memoryImport.js';
+import { memorySearchTool } from './memorySearch.js';
+import { memoryUpdateTool } from './memoryUpdate.js';
+import { memoryWriteTool } from './memoryWrite.js';
+import { projectScriptsTool } from './projectScripts.js';
 import { readFileTool } from './readFile.js';
+import { runCheckTool } from './runCheck.js';
 import { searchTextTool } from './searchText.js';
 import { shellTool } from './shell.js';
 import { writeFileTool } from './writeFile.js';
@@ -74,13 +82,20 @@ export class ToolRegistry {
 export function createDefaultToolRegistry(): ToolRegistry {
   const registry = new ToolRegistry();
   registry.register(editFileTool);
+  registry.register(gitDiffTool);
   registry.register(gitStatusTool);
   registry.register(listFilesTool);
+  registry.register(memoryDeleteTool);
+  registry.register(memoryImportTool);
+  registry.register(memorySearchTool);
+  registry.register(memoryUpdateTool);
+  registry.register(memoryWriteTool);
+  registry.register(projectScriptsTool);
   registry.register(readFileTool);
+  registry.register(runCheckTool);
   registry.register(searchTextTool);
   registry.register(shellTool);
   registry.register(writeFileTool);
   registry.register(deleteFileTool);
   return registry;
 }
-

--- a/src/tools/runCheck.ts
+++ b/src/tools/runCheck.ts
@@ -1,0 +1,151 @@
+import { spawn } from 'node:child_process';
+import { stat } from 'node:fs/promises';
+import path from 'node:path';
+import { z } from 'zod';
+import { detectScripts } from './projectScripts.js';
+import type { Tool } from './types.js';
+
+const inputSchema = z
+  .object({
+    kind: z.enum(['test', 'typecheck', 'build', 'lint', 'custom']),
+    command: z.string().min(1).optional(),
+    args: z.array(z.string()).default([]),
+    timeoutMs: z.number().int().positive().max(120_000).default(60_000),
+  })
+  .strict();
+
+type Input = z.infer<typeof inputSchema>;
+
+export const runCheckTool: Tool<Input> = {
+  name: 'run_check',
+  description: 'Run a project check such as test, typecheck, build, or lint with structured output. Prefer this over shell for standard validation.',
+  access: 'execute',
+  inputSchema,
+  isConcurrencySafe: () => false,
+  isUndoable: () => false,
+
+  async run(input, context) {
+    const picked = input.kind === 'custom'
+      ? pickCustom(input)
+      : await pickProjectCheck(context.cwd, input.kind, input.args);
+
+    if (!picked) {
+      return {
+        title: 'run_check',
+        output: `No ${input.kind} script detected. Use project_scripts to inspect available commands, or run_check kind=custom with an explicit command.`,
+        metadata: { kind: input.kind, skipped: true },
+      };
+    }
+
+    const result = await runProcess(picked.command, picked.args, context.cwd, input.timeoutMs);
+    return {
+      title: `run_check ${input.kind}`,
+      output: result.output || '(no output)',
+      metadata: {
+        kind: input.kind,
+        command: picked.command,
+        args: picked.args,
+        exitCode: result.exitCode,
+        timedOut: result.timedOut,
+      },
+    };
+  },
+};
+
+type PickedCommand = { command: string; args: string[] };
+
+function pickCustom(input: Input): PickedCommand | null {
+  if (!input.command) return null;
+  return { command: input.command, args: input.args };
+}
+
+async function pickProjectCheck(cwd: string, kind: Exclude<Input['kind'], 'custom'>, extraArgs: string[]): Promise<PickedCommand | null> {
+  const scripts = await detectScripts(cwd);
+  const scriptNames = preferredScriptNames(kind);
+  const script = scripts.find(s => s.source === 'package.json' && scriptNames.includes(s.name));
+  if (script) {
+    const pm = await detectPackageManager(cwd);
+    return pm === 'yarn'
+      ? { command: 'yarn', args: [script.name, ...extraArgs] }
+      : { command: pm, args: ['run', script.name, ...extraArgs] };
+  }
+
+  if (kind === 'test' && await exists(path.join(cwd, 'pyproject.toml'))) {
+    return { command: 'pytest', args: extraArgs };
+  }
+  if (kind === 'build' && scripts.some(s => s.source === 'Makefile' && s.name === 'build')) {
+    return { command: 'make', args: ['build', ...extraArgs] };
+  }
+  if (kind === 'test' && scripts.some(s => s.source === 'Makefile' && s.name === 'test')) {
+    return { command: 'make', args: ['test', ...extraArgs] };
+  }
+  return null;
+}
+
+function preferredScriptNames(kind: Exclude<Input['kind'], 'custom'>): string[] {
+  switch (kind) {
+    case 'test':
+      return ['test', 'test:unit'];
+    case 'typecheck':
+      return ['typecheck', 'type-check', 'check:types', 'tsc'];
+    case 'build':
+      return ['build'];
+    case 'lint':
+      return ['lint'];
+  }
+}
+
+async function detectPackageManager(cwd: string): Promise<'npm' | 'pnpm' | 'yarn'> {
+  if (await exists(path.join(cwd, 'pnpm-lock.yaml'))) return 'pnpm';
+  if (await exists(path.join(cwd, 'yarn.lock'))) return 'yarn';
+  return 'npm';
+}
+
+function runProcess(
+  command: string,
+  args: string[],
+  cwd: string,
+  timeoutMs: number,
+): Promise<{ output: string; exitCode: number | null; timedOut: boolean }> {
+  return new Promise(resolve => {
+    const child = spawn(command, args, {
+      cwd,
+      shell: false,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    let output = '';
+    let timedOut = false;
+    const append = (chunk: Buffer) => {
+      output += chunk.toString('utf8');
+      if (output.length > 32_000) {
+        output = `${output.slice(0, 32_000)}\n[output truncated]`;
+      }
+    };
+
+    const timer = setTimeout(() => {
+      timedOut = true;
+      child.kill('SIGTERM');
+    }, timeoutMs);
+
+    child.stdout.on('data', append);
+    child.stderr.on('data', append);
+    child.on('error', error => {
+      clearTimeout(timer);
+      resolve({ output: error.message, exitCode: 1, timedOut });
+    });
+    child.on('close', code => {
+      clearTimeout(timer);
+      resolve({ output: output.trimEnd(), exitCode: code, timedOut });
+    });
+  });
+}
+
+async function exists(filePath: string): Promise<boolean> {
+  try {
+    await stat(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/tests/agent/session.test.ts
+++ b/tests/agent/session.test.ts
@@ -9,6 +9,7 @@ import {
   CODE_PERMISSION_APPROVAL,
 } from '../../src/agent/modes.js';
 import { expandAtMentions } from '../../src/agent/session.js';
+import { createDefaultToolRegistry } from '../../src/tools/registry.js';
 
 describe('resolveApprovalMode', () => {
   it('maps non-code modes directly', () => {
@@ -25,7 +26,19 @@ describe('resolveApprovalMode', () => {
 
   it('keeps chat read-only and gives cowork/code write access', () => {
     expect(MODE_APPROVAL.chat).toBe('readonly');
-    expect(MODE_TOOLS.chat).toEqual(['read_file', 'list_files', 'search_text']);
+    expect(MODE_TOOLS.chat).toEqual([
+      'read_file',
+      'list_files',
+      'search_text',
+      'git_status',
+      'git_diff',
+      'project_scripts',
+      'memory_search',
+    ]);
+    const registry = createDefaultToolRegistry();
+    for (const name of MODE_TOOLS.chat ?? []) {
+      expect(registry.get(name)?.access).toBe('read');
+    }
     expect(MODE_TOOLS.cowork).toBeNull();
     expect(CODE_PERMISSION_APPROVAL.plan).toBe('readonly');
   });

--- a/tests/e2e/app-shell.e2e.ts
+++ b/tests/e2e/app-shell.e2e.ts
@@ -1,0 +1,10 @@
+import { expect, test } from 'playwright/test';
+
+test('loads the DvalinCode app shell', async ({ page }) => {
+  await page.goto('/');
+
+  await expect(page.getByRole('heading', { name: 'DvalinCode' })).toBeVisible();
+  await expect(page.getByRole('button', { name: /Chat/ })).toBeVisible();
+  await expect(page.getByRole('button', { name: /Cowork/ })).toBeVisible();
+  await expect(page.getByRole('button', { name: /Code/ })).toBeVisible();
+});

--- a/tests/e2e/start-server.mjs
+++ b/tests/e2e/start-server.mjs
@@ -1,0 +1,55 @@
+import { spawn } from 'node:child_process';
+import path from 'node:path';
+import process from 'node:process';
+
+const root = process.cwd();
+const backendPort = '3921';
+const frontendPort = '5921';
+const env = {
+  ...process.env,
+  DVALINCODE_API_PORT: backendPort,
+  DVALINCODE_HOME: path.join(root, '.tmp', 'e2e-home'),
+  DVALINCODE_WORKSPACE_ROOTS: root,
+  VITE_AUTO_OPEN: '0',
+};
+
+const children = [
+  spawn('npm', ['run', 'server:dev'], {
+    cwd: root,
+    env: { ...env, PORT: backendPort },
+    stdio: 'inherit',
+  }),
+  spawn('npm', ['run', 'dev', '--', '--host', '127.0.0.1', '--port', frontendPort, '--strictPort'], {
+    cwd: path.join(root, 'web'),
+    env,
+    stdio: 'inherit',
+  }),
+];
+
+function shutdown(signal = 'SIGTERM') {
+  for (const child of children) {
+    if (!child.killed) child.kill(signal);
+  }
+}
+
+process.on('SIGTERM', () => {
+  shutdown('SIGTERM');
+  process.exit(0);
+});
+process.on('SIGINT', () => {
+  shutdown('SIGINT');
+  process.exit(0);
+});
+
+for (const child of children) {
+  child.on('exit', (code, signal) => {
+    if (code && code !== 0) {
+      shutdown();
+      process.exit(code);
+    }
+    if (signal) {
+      shutdown(signal);
+      process.exit(0);
+    }
+  });
+}

--- a/tests/memory.test.ts
+++ b/tests/memory.test.ts
@@ -1,0 +1,107 @@
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { rm } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createDvalinContext } from '../src/core/context.js';
+import { importMemory } from '../src/memory/importers.js';
+import {
+  addMemoryEntry,
+  deleteMemoryEntry,
+  renderRelevantMemory,
+  searchMemory,
+  updateMemoryEntry,
+} from '../src/memory/store.js';
+import { memorySearchTool } from '../src/tools/memorySearch.js';
+import { memoryWriteTool } from '../src/tools/memoryWrite.js';
+
+let tmpHome: string;
+let tmpWorkspace: string;
+
+beforeEach(() => {
+  tmpHome = mkdtempSync(path.join(os.tmpdir(), 'dvalincode-memory-home-'));
+  tmpWorkspace = mkdtempSync(path.join(os.tmpdir(), 'dvalincode-memory-ws-'));
+  process.env.DVALINCODE_HOME = tmpHome;
+});
+
+afterEach(async () => {
+  delete process.env.DVALINCODE_HOME;
+  await rm(tmpHome, { recursive: true, force: true });
+  await rm(tmpWorkspace, { recursive: true, force: true });
+});
+
+describe('memory store', () => {
+  it('stores, searches, updates, and deletes project memory', async () => {
+    const entry = await addMemoryEntry({
+      scope: 'project',
+      cwd: tmpWorkspace,
+      kind: 'workflow',
+      content: 'Run npm test before release.',
+      tags: ['tests'],
+      source: 'manual',
+    });
+
+    const found = await searchMemory('release test', { cwd: tmpWorkspace });
+    expect(found[0]?.id).toBe(entry.id);
+
+    const rendered = await renderRelevantMemory(tmpWorkspace, 'how do I test this project?');
+    expect(rendered).toContain('Run npm test before release.');
+
+    const updated = await updateMemoryEntry({
+      id: entry.id,
+      cwd: tmpWorkspace,
+      content: 'Run npm run check before release.',
+      tags: ['checks'],
+    });
+    expect(updated?.content).toContain('npm run check');
+
+    await expect(deleteMemoryEntry({ id: entry.id, cwd: tmpWorkspace })).resolves.toBe(true);
+    await expect(searchMemory('release test', { cwd: tmpWorkspace })).resolves.toHaveLength(0);
+  });
+
+  it('imports markdown candidates', async () => {
+    const source = path.join(tmpWorkspace, 'CLAUDE.md');
+    writeFileSync(source, '- Prefer pnpm for package commands.\n- API tests require local Redis.\n', 'utf-8');
+
+    const dryRun = await importMemory({
+      source: 'claude',
+      sourcePath: source,
+      cwd: tmpWorkspace,
+      dryRun: true,
+    });
+    expect(dryRun.candidates).toHaveLength(2);
+    expect(dryRun.imported).toBe(0);
+
+    const imported = await importMemory({
+      source: 'claude',
+      sourcePath: source,
+      cwd: tmpWorkspace,
+    });
+    expect(imported.imported).toBe(2);
+
+    const found = await searchMemory('Redis', { cwd: tmpWorkspace });
+    expect(found[0]?.content).toContain('Redis');
+  });
+});
+
+describe('memory tools', () => {
+  it('writes and searches memory via tools', async () => {
+    const context = createDvalinContext({ cwd: tmpWorkspace, approvalMode: 'full-auto' });
+    const written = await memoryWriteTool.run({
+      scope: 'project',
+      kind: 'decision',
+      content: 'Use hash-chained audit logs for trust.',
+      tags: ['audit'],
+      confidence: 0.9,
+    }, context);
+
+    expect(written.output).toContain('Saved memory');
+
+    const searched = await memorySearchTool.run({
+      query: 'audit trust',
+      maxResults: 5,
+    }, context);
+
+    expect(searched.output).toContain('hash-chained audit logs');
+  });
+});

--- a/tests/toolsExtras.test.ts
+++ b/tests/toolsExtras.test.ts
@@ -1,0 +1,58 @@
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { rm } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { createDvalinContext } from '../src/core/context.js';
+import { createDefaultToolRegistry } from '../src/tools/registry.js';
+import { projectScriptsTool } from '../src/tools/projectScripts.js';
+import { runCheckTool } from '../src/tools/runCheck.js';
+
+let tmpDir: string;
+
+beforeAll(() => {
+  tmpDir = mkdtempSync(path.join(os.tmpdir(), 'dvalincode-tools-extra-'));
+});
+
+afterAll(async () => {
+  await rm(tmpDir, { recursive: true, force: true });
+});
+
+describe('extra tools', () => {
+  it('registers memory and diagnostic tools by default', () => {
+    const registry = createDefaultToolRegistry();
+    const names = registry.list().map(tool => tool.name);
+    expect(names).toContain('memory_search');
+    expect(names).toContain('memory_write');
+    expect(names).toContain('memory_import');
+    expect(names).toContain('git_diff');
+    expect(names).toContain('project_scripts');
+    expect(names).toContain('run_check');
+  });
+
+  it('detects package.json scripts', async () => {
+    writeFileSync(path.join(tmpDir, 'package.json'), JSON.stringify({
+      scripts: {
+        test: 'vitest run',
+        typecheck: 'tsc --noEmit',
+      },
+    }, null, 2));
+
+    const result = await projectScriptsTool.run({}, createDvalinContext({ cwd: tmpDir }));
+    expect(result.output).toContain('package.json:test');
+    expect(result.output).toContain('package.json:typecheck');
+  });
+
+  it('runs a custom check with structured metadata', async () => {
+    const result = await runCheckTool.run({
+      kind: 'custom',
+      command: process.execPath,
+      args: ['-e', 'console.log("check ok")'],
+      timeoutMs: 10_000,
+    }, createDvalinContext({ cwd: tmpDir, approvalMode: 'full-auto' }));
+
+    expect(result.output).toContain('check ok');
+    expect(result.metadata?.exitCode).toBe(0);
+    expect(result.metadata?.kind).toBe('custom');
+  });
+});

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,6 +1,9 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
+const apiPort = process.env.DVALINCODE_API_PORT ?? '3001';
+const apiHost = process.env.DVALINCODE_API_HOST ?? '127.0.0.1';
+
 export default defineConfig({
   plugins: [react()],
   build: {
@@ -16,11 +19,11 @@ export default defineConfig({
   },
   server: {
     port: process.env.PORT ? Number(process.env.PORT) : 5173,
-    open: true,
+    open: process.env.VITE_AUTO_OPEN === '0' ? false : true,
     proxy: {
-      '/api': 'http://localhost:3001',
+      '/api': `http://${apiHost}:${apiPort}`,
       '/ws': {
-        target: 'ws://localhost:3001',
+        target: `ws://${apiHost}:${apiPort}`,
         ws: true,
       },
     },


### PR DESCRIPTION
## Summary

Adds a first local-memory slice for DvalinCode and wires it into agent context:

- add local memory storage with user/project scopes, search, update, delete, and Markdown rendering
- add Claude Code, Hermes, and Markdown memory import support with path allowlisting
- add memory CLI commands and memory tools for the agent runtime
- add `git_diff`, `project_scripts`, and `run_check` tools
- inject relevant local memory during prompt assembly
- add Playwright E2E smoke test setup using isolated ports

## Validation

- `npm test` — 16 files / 87 tests passed
- `npm run typecheck`
- `npm run test:e2e`
- `npm run build`
- `npm run web:build`

## Notes

This is a draft PR so the memory UX/API shape can still be reviewed before marking ready.
