### PR TITLE
build(release): clean up CLI bundle script + split GUI to a pre-release track

### DIFF
--- a/.github/workflows/release-gui.yml
+++ b/.github/workflows/release-gui.yml
@@ -1,0 +1,86 @@
+name: Release Desktop GUI (experimental)
+
+# Build the native desktop GUI app (webview-bun) and publish it as a GitHub
+# *pre-release*, on a track separate from the stable CLI + Web bundle.
+#
+# Why a separate track:
+#   - The desktop app depends on a native system webview (WKWebView / WebView2 /
+#     WebKitGTK) and is currently experimental / unverified per platform.
+#   - It is published as a pre-release so `releases/latest` (used by the one-line
+#     installer) keeps pointing at the stable CLI release — the installer never
+#     pulls the GUI.
+#
+# Trigger: push a `gui-v*` tag (e.g. gui-v0.7.0), or run manually.
+#   git tag gui-v0.7.0 && git push origin gui-v0.7.0
+#
+# Builds run on macOS: scripts/build-gui.sh cross-compiles every target there
+# (with skip-on-failure for flaky cross-builds) and has the sips/iconutil tools
+# needed for the macOS .app icon. Linux/Windows GUI binaries are best-effort and
+# should be validated on their own OS before being relied on.
+
+on:
+  push:
+    tags:
+      - 'gui-v*'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build-gui:
+    runs-on: macos-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install backend dependencies
+        run: npm ci
+
+      - name: Install web frontend dependencies
+        run: cd web && npm ci
+
+      - name: Type-check and test
+        run: npm run check
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Build desktop GUI artifacts (all platforms, best-effort)
+        run: npm run build:gui
+
+      - name: List artifacts
+        run: ls -lh release-gui/
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dvalincode-gui-${{ github.sha }}
+          path: release-gui/*
+          if-no-files-found: error
+
+      # ── Publish as a PRE-RELEASE (tag push only) ─────────────────
+      - name: Publish GitHub pre-release
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v2
+        with:
+          prerelease: true
+          generate_release_notes: true
+          name: "Desktop GUI ${{ github.ref_name }} (experimental)"
+          body: |
+            **Experimental** native desktop GUI build (webview-bun).
+
+            These binaries use the system webview and are unverified per platform —
+            treat as a preview. The stable CLI + Web bundle is the recommended
+            install path (`curl … | bash`) and is unaffected by this pre-release.
+          files: |
+            release-gui/dvalincode-gui-v*
+            release-gui/SHA256SUMS-gui.txt

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,13 +1,19 @@
-name: Release Binaries
+name: Release (CLI + Web bundle)
 
-# Build standalone GUI binaries (macOS arm64/x64, Linux arm64/x64, Windows x64)
-# and attach them to a GitHub Release as downloadable archives.
+# Build the stable CLI + Web bundle for all platforms (macOS arm64/x64,
+# Linux arm64/x64, Windows x64) and attach the archives to a GitHub Release.
 #
-# Each archive is self-contained:  binary  +  web/dist/  (no Node runtime needed)
+# Each archive is self-contained: CLI binary + web/dist/ + start launcher
+# (no Node runtime needed). The bare binary is the terminal agent; `serve`
+# (and the start.sh/start.bat launcher) starts the web GUI.
 #
-# Trigger: push a version tag, e.g.
-#   git tag v0.4.0 && git push origin v0.4.0
-# Or run manually from the Actions tab.
+# The native desktop GUI app ships on a separate, experimental pre-release
+# track — see .github/workflows/release-gui.yml.
+#
+# Recommended flow:
+#   1. Run manually (workflow_dispatch) → download + inspect the artifacts.
+#   2. When satisfied, push the version tag to publish:
+#        git tag v0.7.0 && git push origin v0.7.0
 
 on:
   push:
@@ -45,21 +51,28 @@ jobs:
         with:
           bun-version: latest
 
-      - name: Build release archives (all platforms)
+      # build:release also runs the structure + checksum smoke test on every
+      # archive and fails the job if any archive is malformed.
+      - name: Build CLI + Web bundle (all platforms)
         run: npm run build:release
 
       - name: List artifacts
         run: ls -lh release/
 
-      # ── Upload artifacts (workflow_dispatch) ─────────────────────
-      - name: Upload artifacts (manual trigger)
-        if: github.event_name == 'workflow_dispatch'
+      # Explicit artifact verification, independent of the build step.
+      - name: Verify checksums
+        run: cd release && sha256sum -c SHA256SUMS.txt
+
+      # Always upload the archives so they can be downloaded and inspected
+      # before a tag is pushed (manual run) and kept as a record (tag run).
+      - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: dvalincode-release
+          name: dvalincode-cli-${{ github.sha }}
           path: release/*
+          if-no-files-found: error
 
-      # ── Publish GitHub Release (tag push) ────────────────────────
+      # ── Publish GitHub Release (tag push only) ───────────────────
       - name: Publish GitHub Release
         if: startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v2

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ npm-debug.log*
 # Release build artifacts
 release/
 release-gui/
+*.bun-build

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -1,9 +1,16 @@
 #!/usr/bin/env bash
-# Build the DvalinCode GUI release:
+# Build the DvalinCode CLI + Web bundle release:
 #   1. Build the React frontend (web/dist/)
-#   2. Compile server binaries for all platforms via Bun
-#   3. Package each platform as an archive: binary + web/dist/
+#   2. Compile the CLI binary for all platforms via Bun --compile
+#   3. Package each platform as an archive: binary + web/dist/ + start script
 #   4. Generate SHA256SUMS.txt
+#   5. Smoke-test every archive (structure + checksums)
+#
+# The packaged binary is the full CLI: bare `dvalincode` opens the terminal
+# agent (TUI); `dvalincode serve` starts the web server + GUI. The bundled
+# start.sh / start.bat launcher runs `serve` for non-terminal users.
+#
+# The native desktop GUI app is a SEPARATE artifact — see scripts/build-gui.sh.
 #
 # Usage:
 #   scripts/build-release.sh             # all platforms
@@ -33,11 +40,10 @@ cd "$ROOT_DIR"
 FILTER="${1:-all}"
 VERSION="$(node -p "require('./package.json').version" 2>/dev/null || echo "0.0.0")"
 RELEASE_DIR="release"
-ICON_SOURCE="web/public/logo.svg"
-MACOS_ICON="${RELEASE_DIR}/tmp/AppIcon.icns"
+ICON_SOURCE="web/public/logo.svg"   # used only for the Windows .exe icon/metadata
 
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-echo "  DvalinCode v${VERSION} — GUI Release Build"
+echo "  DvalinCode v${VERSION} — CLI + Web Bundle Release"
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 echo
 
@@ -75,81 +81,6 @@ fi
 
 rm -rf "$RELEASE_DIR"
 mkdir -p "$RELEASE_DIR/tmp" "$RELEASE_DIR/pkg"
-
-prepare_macos_icon() {
-  if ! command -v sips >/dev/null 2>&1 || ! command -v iconutil >/dev/null 2>&1; then
-    echo "  ! sips/iconutil not found; macOS .app icon will be skipped"
-    return 0
-  fi
-
-  local base_png="${RELEASE_DIR}/tmp/AppIcon-1024.png"
-  local iconset="${RELEASE_DIR}/tmp/AppIcon.iconset"
-  mkdir -p "$iconset"
-
-  sips -s format png "$ICON_SOURCE" --out "$base_png" >/dev/null
-  for size in 16 32 128 256 512; do
-    sips -z "$size" "$size" "$base_png" --out "${iconset}/icon_${size}x${size}.png" >/dev/null
-    sips -z "$((size * 2))" "$((size * 2))" "$base_png" --out "${iconset}/icon_${size}x${size}@2x.png" >/dev/null
-  done
-  iconutil -c icns "$iconset" -o "$MACOS_ICON"
-}
-
-create_macos_app() {
-  local pkg_dir="$1"
-  local bin_file="$2"
-  local arch_suffix="$3"
-
-  if [ ! -f "$MACOS_ICON" ]; then
-    return 0
-  fi
-
-  local app_dir="${pkg_dir}/DvalinCode.app"
-  mkdir -p "${app_dir}/Contents/MacOS/web" "${app_dir}/Contents/Resources"
-  cp "${pkg_dir}/${bin_file}" "${app_dir}/Contents/MacOS/dvalincode"
-  cp -r web/dist "${app_dir}/Contents/MacOS/web/dist"
-  cp "$MACOS_ICON" "${app_dir}/Contents/Resources/AppIcon.icns"
-  chmod +x "${app_dir}/Contents/MacOS/dvalincode"
-
-  cat > "${app_dir}/Contents/Info.plist" << PLIST
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-  <key>CFBundleDevelopmentRegion</key>
-  <string>en</string>
-  <key>CFBundleDisplayName</key>
-  <string>DvalinCode</string>
-  <key>CFBundleExecutable</key>
-  <string>dvalincode</string>
-  <key>CFBundleIconFile</key>
-  <string>AppIcon</string>
-  <key>CFBundleIdentifier</key>
-  <string>dev.dvalincode.${arch_suffix}</string>
-  <key>CFBundleInfoDictionaryVersion</key>
-  <string>6.0</string>
-  <key>CFBundleName</key>
-  <string>DvalinCode</string>
-  <key>CFBundlePackageType</key>
-  <string>APPL</string>
-  <key>CFBundleShortVersionString</key>
-  <string>${VERSION}</string>
-  <key>CFBundleVersion</key>
-  <string>${VERSION}</string>
-  <key>LSMinimumSystemVersion</key>
-  <string>11.0</string>
-  <key>LSUIElement</key>
-  <true/>
-</dict>
-</plist>
-PLIST
-}
-
-if [ "$FILTER" = "all" ] || [ "$FILTER" = "darwin" ]; then
-  echo "▶ Preparing macOS app icon from ${ICON_SOURCE}…"
-  prepare_macos_icon
-  [ -f "$MACOS_ICON" ] && echo "  ✓ AppIcon.icns ready"
-  echo
-fi
 
 # ── 3. Compile + package each target ──────────────────────────────────
 # Unified entry: the binary is the full CLI. Bare `dvalincode` opens the
@@ -205,8 +136,9 @@ for i in "${!BUN_TARGETS[@]}"; do
   cp -r web/dist "${pkg_dir}/web/dist"
 
   if $is_windows; then
-    # Windows ZIP
-    printf '@echo off\r\necho Starting DvalinCode...\r\n"%%~dp0dvalincode-windows-x64.exe"\r\n' \
+    # Windows ZIP — the launcher starts the web GUI (`serve`); the bare binary
+    # is still the CLI/terminal agent for command-line users.
+    printf '@echo off\r\necho Starting DvalinCode web GUI...\r\n"%%~dp0dvalincode-windows-x64.exe" serve\r\n' \
       > "${pkg_dir}/start.bat"
     archive="${RELEASE_DIR}/dvalincode-v${VERSION}-windows-x64.zip"
     (cd "${RELEASE_DIR}/pkg" && zip -r "../dvalincode-v${VERSION}-windows-x64.zip" "${bin_name}" -x "*.DS_Store")
@@ -215,12 +147,13 @@ for i in "${!BUN_TARGETS[@]}"; do
     # The CLI ships as a terminal binary only — no double-click .app (the
     # desktop GUI app is a separate artifact built by scripts/build-gui.sh).
 
-    # macOS / Linux tar.gz
+    # macOS / Linux tar.gz — the launcher starts the web GUI (`serve`); the bare
+    # binary is still the CLI/terminal agent for command-line users.
     cat > "${pkg_dir}/start.sh" << 'SH'
 #!/usr/bin/env bash
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 BIN="$(ls "$DIR" | grep -Ev '(start\.sh|web)' | head -1)"
-exec "$DIR/$BIN"
+exec "$DIR/$BIN" serve
 SH
     chmod +x "${pkg_dir}/start.sh"
     suffix="${bin_name#dvalincode-}"
@@ -244,16 +177,75 @@ echo "▶ Generating SHA256SUMS.txt"
   fi
 )
 
+# ── 5. Smoke test ─────────────────────────────────────────────────────
+# Extract every archive and assert the layout the installer relies on:
+# a top-level dvalincode-<platform>/ dir containing the binary, web/dist/
+# index.html, and the start launcher. Then verify checksums.
+smoke_fail() { echo "  ✗ smoke: $1" >&2; exit 1; }
+
+echo
+echo "▶ Smoke-testing archives…"
+SMOKE_DIR="${RELEASE_DIR}/smoke"
+rm -rf "$SMOKE_DIR"; mkdir -p "$SMOKE_DIR"
+
+for archive in "${RELEASE_DIR}"/dvalincode-v*; do
+  name="$(basename "$archive")"
+  dest="${SMOKE_DIR}/$(echo "$name" | sed 's/[^a-zA-Z0-9]/_/g')"
+  mkdir -p "$dest"
+
+  case "$name" in
+    *.zip)
+      command -v unzip >/dev/null 2>&1 || smoke_fail "unzip not available to check ${name}"
+      unzip -q -o "$archive" -d "$dest" ;;
+    *.tar.gz)
+      tar xzf "$archive" -C "$dest" ;;
+    *) continue ;;
+  esac
+
+  root="$(find "$dest" -mindepth 1 -maxdepth 1 -type d -name 'dvalincode-*' | head -1)"
+  [ -n "$root" ] || smoke_fail "${name}: missing top-level dvalincode-* directory"
+
+  bin="$(find "$root" -maxdepth 1 -type f \( -name 'dvalincode-*' -o -name 'dvalincode-*.exe' \) ! -name '*.sh' ! -name '*.bat' | head -1)"
+  [ -n "$bin" ] || smoke_fail "${name}: binary not found"
+  case "$name" in
+    *.tar.gz) [ -x "$bin" ] || smoke_fail "${name}: binary not executable" ;;
+  esac
+
+  [ -f "${root}/web/dist/index.html" ] || smoke_fail "${name}: web/dist/index.html missing"
+
+  case "$name" in
+    *.zip)    [ -f "${root}/start.bat" ] || smoke_fail "${name}: start.bat missing" ;;
+    *.tar.gz) [ -f "${root}/start.sh" ]  || smoke_fail "${name}: start.sh missing" ;;
+  esac
+
+  echo "  ✓ ${name}: binary + web/dist/index.html + start launcher"
+done
+
+echo "▶ Verifying checksums…"
+(
+  cd "$RELEASE_DIR"
+  if command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 -c SHA256SUMS.txt
+  else
+    sha256sum -c SHA256SUMS.txt
+  fi
+) || smoke_fail "checksum verification failed"
+
+rm -rf "$SMOKE_DIR"
+
 echo
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 echo "  Artifacts in ${RELEASE_DIR}/:"
 ls -1 "$RELEASE_DIR"
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 echo
-echo "Release verification checklist:"
-echo "  1. Run: (cd ${RELEASE_DIR} && shasum -a 256 -c SHA256SUMS.txt)"
-echo "  2. macOS archives: confirm DvalinCode.app/Contents/Resources/AppIcon.icns exists."
-echo "  3. Windows archive: unzip it and run start.bat from the extracted folder."
-echo "     Expected: DvalinCode opens http://localhost:3000."
-echo "     Regression signal: ENOENT mentioning B:\\~BUN\\root\\web\\dist\\index.html."
-echo "  4. Keep web/dist adjacent to each binary in packaged archives; compiled Bun paths are virtual."
+echo "All archives passed the structure + checksum smoke test."
+echo
+echo "Manual verification before publishing:"
+echo "  • macOS/Linux: tar xzf the archive, run ./dvalincode-<platform>/start.sh"
+echo "    → DvalinCode serves http://localhost:3000 (the web GUI)."
+echo "    Bare ./dvalincode-<platform>/<binary> opens the terminal agent (TUI)."
+echo "  • Windows: unzip and run start.bat → opens http://localhost:3000."
+echo "    Regression signal: ENOENT mentioning B:\\~BUN\\root\\web\\dist\\index.html."
+echo "  • web/dist must stay adjacent to each binary; compiled Bun paths are virtual."
+echo "  • The native desktop GUI app is built separately by scripts/build-gui.sh."


### PR DESCRIPTION
Rebuilds the **stable CLI + Web bundle** release path and splits the desktop GUI onto a separate **experimental pre-release** track — without copying opencode's full Desktop distribution matrix yet.

## Phase 1 — CLI + Web bundle stays the stable track
Artifacts unchanged (5 archives + `SHA256SUMS.txt`), still built with Bun `--compile`:
`dvalincode-v<ver>-{macos-arm64,macos-x64,linux-arm64,linux-x64}.tar.gz` + `...-windows-x64.zip`.
The one-line installer continues to target only this stable set.

## Phase 2 — `scripts/build-release.sh` quality
- Reword header/banner: "GUI Release Build" → **"CLI + Web Bundle Release"** (it ships the CLI binary + `web/dist` + launcher, not a desktop app).
- Remove **dead code**: `create_macos_app()`, `prepare_macos_icon()`, and the `DvalinCode.app` icon plumbing that was defined but never called.
- `start.sh` / `start.bat` now launch **`serve`** (web GUI) for non-terminal users; the bare binary remains the terminal agent.
- Add a **smoke test**: extracts every archive and asserts the installer-required layout (top-level dir, binary, `web/dist/index.html`, start launcher), then verifies `SHA256SUMS`. Replaces the misleading "confirm `DvalinCode.app`" checklist item.

### `release.yml`
- Reworded to **"Release (CLI + Web bundle)"**; documents the dispatch → inspect → tag flow.
- **Always upload artifacts** (not just manual runs) so they can be downloaded and verified before tagging; adds an explicit `sha256sum -c` **verification step**.

## Phase 3 — GUI desktop on a separate pre-release track
- New **`release-gui.yml`**: publishes the native desktop GUI (webview-bun) as a GitHub **pre-release** on `gui-v*` tags / manual dispatch, built via `scripts/build-gui.sh` on macOS.
- `prerelease: true` keeps `releases/latest` (and the one-line installer, which builds the exact CLI asset name) pointed at the stable CLI release — **the installer never pulls the GUI**.
- Linux/Windows GUI binaries are best-effort/experimental until validated on their own OS.

## Phase 4 — follow-up (not in this PR)
Embedding the Web UI into the Bun build (like opencode's `build.ts`) to make each archive a true single binary and avoid `B:\~BUN\root\web\dist` path issues. Tracked as a future change.

## Local validation (macOS arm64)
- `build-release.sh darwin` → builds both macOS archives, smoke test + checksum verify pass.
- Compiled binary runs: `--version` → `0.7.0`; `serve` serves the embedded web UI (HTTP 200, `<title>DvalinCode</title>`).
- `build-gui.sh darwin` → produces `dvalincode-gui-v0.7.0-macos-{arm64,x64}.tar.gz` + `SHA256SUMS-gui.txt`.

## Remaining (maintainer, after merge)
1. Tag `v0.7.0` from `main` → run `release.yml` → download the 5 CLI assets.
2. Smoke each on macOS / Linux / Windows at least once.
3. Optionally tag `gui-v0.7.0` to cut the experimental GUI pre-release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)