### PR TITLE
build(release): macOS signing fix + notarization skeleton

### DIFF
--- a/.github/workflows/release-gui.yml
+++ b/.github/workflows/release-gui.yml
@@ -31,6 +31,12 @@ jobs:
   build-gui:
     runs-on: macos-latest
 
+    # Optional Developer ID signing + notarization — same secrets as release.yml.
+    # Without them the .app is ad-hoc signed (preview-grade). With them the app
+    # is Developer-ID signed, notarized, and stapled (prompt-free download).
+    env:
+      DVALINCODE_SIGN_IDENTITY: ${{ secrets.MACOS_SIGN_IDENTITY }}
+
     steps:
       - uses: actions/checkout@v4
 
@@ -54,8 +60,56 @@ jobs:
         with:
           bun-version: latest
 
+      # Import the Developer ID cert (skipped without the secret → ad-hoc).
+      - name: Import Developer ID certificate
+        if: ${{ secrets.MACOS_CERTIFICATE_P12 != '' }}
+        env:
+          CERT_P12: ${{ secrets.MACOS_CERTIFICATE_P12 }}
+          CERT_PASSWORD: ${{ secrets.MACOS_CERTIFICATE_PASSWORD }}
+        run: |
+          KEYCHAIN="$RUNNER_TEMP/signing.keychain-db"
+          KP="$(openssl rand -base64 24)"
+          security create-keychain -p "$KP" "$KEYCHAIN"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN"
+          security unlock-keychain -p "$KP" "$KEYCHAIN"
+          echo "$CERT_P12" | base64 --decode > "$RUNNER_TEMP/cert.p12"
+          security import "$RUNNER_TEMP/cert.p12" -k "$KEYCHAIN" -P "$CERT_PASSWORD" \
+            -T /usr/bin/codesign
+          security set-key-partition-list -S apple-tool:,apple: -s -k "$KP" "$KEYCHAIN" >/dev/null
+          security list-keychains -d user -s "$KEYCHAIN" $(security list-keychains -d user | sed s/\"//g)
+          rm -f "$RUNNER_TEMP/cert.p12"
+
       - name: Build desktop GUI artifacts (all platforms, best-effort)
         run: npm run build:gui
+
+      # Notarize + staple the macOS .app, then repackage the archive so the
+      # stapled ticket travels with it (offline-verifiable). Skipped without
+      # Apple credentials. .app bundles (unlike bare binaries) can be stapled.
+      - name: Notarize + staple desktop app
+        if: ${{ secrets.APPLE_ID != '' }}
+        env:
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          APPLE_APP_PASSWORD: ${{ secrets.APPLE_APP_PASSWORD }}
+        run: |
+          shopt -s nullglob
+          for tgz in release-gui/dvalincode-gui-v*-macos-*.tar.gz; do
+            work="$RUNNER_TEMP/$(basename "$tgz" .tar.gz)"
+            rm -rf "$work"; mkdir -p "$work"
+            tar xzf "$tgz" -C "$work"
+            app="$(find "$work" -maxdepth 3 -name '*.app' | head -1)"
+            [ -n "$app" ] || { echo "  ! no .app in $tgz, skipping"; continue; }
+            echo "▶ Notarizing $(basename "$app") from $tgz"
+            ditto -c -k --keepParent "$app" "$RUNNER_TEMP/app.zip"
+            xcrun notarytool submit "$RUNNER_TEMP/app.zip" \
+              --apple-id "$APPLE_ID" --team-id "$APPLE_TEAM_ID" \
+              --password "$APPLE_APP_PASSWORD" --wait
+            xcrun stapler staple "$app"
+            ( cd "$work" && tar czf "$GITHUB_WORKSPACE/$tgz" ./* )
+            rm -f "$RUNNER_TEMP/app.zip"
+          done
+          # Refresh checksums for the repackaged archives.
+          ( cd release-gui && shasum -a 256 dvalincode-gui-v* > SHA256SUMS-gui.txt )
 
       - name: List artifacts
         run: ls -lh release-gui/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,10 +26,25 @@ permissions:
 
 jobs:
   build:
-    # macOS runner so `codesign` is available to ad-hoc sign the darwin binaries
+    # macOS runner so `codesign` is available to sign the darwin binaries
     # (clears the Gatekeeper "damaged" error on Apple Silicon). Bun cross-compiles
     # the linux/windows targets from here too.
     runs-on: macos-latest
+
+    # ── Optional Developer ID signing + notarization ─────────────────────────
+    # Without the secrets below, the build falls back to ad-hoc signing (still
+    # "damaged"-free locally, but a browser-downloaded copy shows "unidentified
+    # developer"). Set these repo secrets to get fully notarized, prompt-free
+    # downloads:
+    #   MACOS_SIGN_IDENTITY      "Developer ID Application: NAME (TEAMID)"
+    #   MACOS_CERTIFICATE_P12    base64 of the exported Developer ID .p12
+    #   MACOS_CERTIFICATE_PASSWORD   password for that .p12
+    #   APPLE_ID                 Apple ID email (for notarytool)
+    #   APPLE_TEAM_ID            10-char Team ID
+    #   APPLE_APP_PASSWORD       app-specific password for the Apple ID
+    env:
+      # Empty unless configured → build scripts fall back to ad-hoc signing.
+      DVALINCODE_SIGN_IDENTITY: ${{ secrets.MACOS_SIGN_IDENTITY }}
 
     steps:
       - uses: actions/checkout@v4
@@ -54,6 +69,26 @@ jobs:
         with:
           bun-version: latest
 
+      # Import the Developer ID cert into a temp keychain so the build step can
+      # sign with it. Skipped entirely when the secret is absent (→ ad-hoc).
+      - name: Import Developer ID certificate
+        if: ${{ secrets.MACOS_CERTIFICATE_P12 != '' }}
+        env:
+          CERT_P12: ${{ secrets.MACOS_CERTIFICATE_P12 }}
+          CERT_PASSWORD: ${{ secrets.MACOS_CERTIFICATE_PASSWORD }}
+        run: |
+          KEYCHAIN="$RUNNER_TEMP/signing.keychain-db"
+          KP="$(openssl rand -base64 24)"
+          security create-keychain -p "$KP" "$KEYCHAIN"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN"
+          security unlock-keychain -p "$KP" "$KEYCHAIN"
+          echo "$CERT_P12" | base64 --decode > "$RUNNER_TEMP/cert.p12"
+          security import "$RUNNER_TEMP/cert.p12" -k "$KEYCHAIN" -P "$CERT_PASSWORD" \
+            -T /usr/bin/codesign
+          security set-key-partition-list -S apple-tool:,apple: -s -k "$KP" "$KEYCHAIN" >/dev/null
+          security list-keychains -d user -s "$KEYCHAIN" $(security list-keychains -d user | sed s/\"//g)
+          rm -f "$RUNNER_TEMP/cert.p12"
+
       # build:release also runs the structure + checksum smoke test on every
       # archive and fails the job if any archive is malformed.
       - name: Build CLI + Web bundle (all platforms)
@@ -65,6 +100,25 @@ jobs:
       # Explicit artifact verification, independent of the build step.
       - name: Verify checksums
         run: cd release && shasum -a 256 -c SHA256SUMS.txt
+
+      # Notarize the macOS archives so Gatekeeper clears them on download.
+      # Skipped without the Apple credentials (→ ad-hoc builds ship as-is).
+      # NOTE: a bare CLI binary inside a .tar.gz cannot be stapled, so this
+      # relies on Gatekeeper's online notarization check on first run. For
+      # offline-stapled CLI distribution, ship a signed .dmg/.pkg instead.
+      - name: Notarize macOS archives
+        if: ${{ secrets.APPLE_ID != '' }}
+        env:
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          APPLE_APP_PASSWORD: ${{ secrets.APPLE_APP_PASSWORD }}
+        run: |
+          for a in release/dvalincode-v*-macos-*.tar.gz; do
+            echo "▶ Notarizing $a"
+            xcrun notarytool submit "$a" \
+              --apple-id "$APPLE_ID" --team-id "$APPLE_TEAM_ID" \
+              --password "$APPLE_APP_PASSWORD" --wait
+          done
 
       # Always upload the archives so they can be downloaded and inspected
       # before a tag is pushed (manual run) and kept as a record (tag run).

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,10 @@ permissions:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    # macOS runner so `codesign` is available to ad-hoc sign the darwin binaries
+    # (clears the Gatekeeper "damaged" error on Apple Silicon). Bun cross-compiles
+    # the linux/windows targets from here too.
+    runs-on: macos-latest
 
     steps:
       - uses: actions/checkout@v4
@@ -61,7 +64,7 @@ jobs:
 
       # Explicit artifact verification, independent of the build step.
       - name: Verify checksums
-        run: cd release && sha256sum -c SHA256SUMS.txt
+        run: cd release && shasum -a 256 -c SHA256SUMS.txt
 
       # Always upload the archives so they can be downloaded and inspected
       # before a tag is pushed (manual run) and kept as a record (tag run).

--- a/scripts/build-gui.sh
+++ b/scripts/build-gui.sh
@@ -32,6 +32,10 @@ ICON_SOURCE="web/public/logo.svg"
 MACOS_ICON="${RELEASE_DIR}/tmp/AppIcon.icns"
 ENTRY="src/gui/index.ts"
 
+# "-" = ad-hoc (default); "Developer ID Application: NAME (TEAMID)" for
+# notarization, wired from DVALINCODE_SIGN_IDENTITY by the release workflow.
+SIGN_IDENTITY="${DVALINCODE_SIGN_IDENTITY:--}"
+
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 echo "  DvalinCode v${VERSION} — Desktop GUI Build"
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
@@ -131,8 +135,13 @@ for i in "${!BUN_TARGETS[@]}"; do
   # Ad-hoc sign macOS binaries so Gatekeeper doesn't flag them as "damaged" on
   # Apple Silicon (not notarization — see scripts/build-release.sh note).
   if [[ "$bun_target" == *darwin* ]] && command -v codesign >/dev/null 2>&1; then
-    codesign --force --sign - "${RELEASE_DIR}/tmp/${bin_file}" 2>/dev/null \
-      && echo "  ✓ ad-hoc signed ${bin_file}" || echo "  ! codesign failed for ${bin_file}"
+    if [ "$SIGN_IDENTITY" = "-" ]; then
+      codesign --force --sign - "${RELEASE_DIR}/tmp/${bin_file}" 2>/dev/null \
+        && echo "  ✓ ad-hoc signed ${bin_file}" || echo "  ! codesign failed for ${bin_file}"
+    else
+      codesign --force --options runtime --timestamp --sign "$SIGN_IDENTITY" "${RELEASE_DIR}/tmp/${bin_file}" 2>/dev/null \
+        && echo "  ✓ Developer ID signed ${bin_file}" || echo "  ! codesign failed for ${bin_file}"
+    fi
   fi
 
   pkg_dir="${RELEASE_DIR}/pkg/${bin_name}"; mkdir -p "${pkg_dir}/web"
@@ -146,10 +155,15 @@ for i in "${!BUN_TARGETS[@]}"; do
   else
     if [[ "$bun_target" == *darwin* ]]; then
       create_gui_macos_app "$pkg_dir" "$bin_file" "${bin_name#dvalincode-gui-macos-}"
-      # Deep ad-hoc sign the bundle so the .app launches without "damaged".
+      # Deep-sign the bundle so the .app launches without "damaged".
       if [ -d "${pkg_dir}/DvalinCode.app" ] && command -v codesign >/dev/null 2>&1; then
-        codesign --force --deep --sign - "${pkg_dir}/DvalinCode.app" 2>/dev/null \
-          && echo "  ✓ ad-hoc signed DvalinCode.app" || echo "  ! codesign failed for DvalinCode.app"
+        if [ "$SIGN_IDENTITY" = "-" ]; then
+          codesign --force --deep --sign - "${pkg_dir}/DvalinCode.app" 2>/dev/null \
+            && echo "  ✓ ad-hoc signed DvalinCode.app" || echo "  ! codesign failed for DvalinCode.app"
+        else
+          codesign --force --deep --options runtime --timestamp --sign "$SIGN_IDENTITY" "${pkg_dir}/DvalinCode.app" 2>/dev/null \
+            && echo "  ✓ Developer ID signed DvalinCode.app" || echo "  ! codesign failed for DvalinCode.app"
+        fi
       fi
     fi
     suffix="${bin_name#dvalincode-gui-}"

--- a/scripts/build-gui.sh
+++ b/scripts/build-gui.sh
@@ -128,6 +128,13 @@ for i in "${!BUN_TARGETS[@]}"; do
     continue
   fi
 
+  # Ad-hoc sign macOS binaries so Gatekeeper doesn't flag them as "damaged" on
+  # Apple Silicon (not notarization — see scripts/build-release.sh note).
+  if [[ "$bun_target" == *darwin* ]] && command -v codesign >/dev/null 2>&1; then
+    codesign --force --sign - "${RELEASE_DIR}/tmp/${bin_file}" 2>/dev/null \
+      && echo "  ✓ ad-hoc signed ${bin_file}" || echo "  ! codesign failed for ${bin_file}"
+  fi
+
   pkg_dir="${RELEASE_DIR}/pkg/${bin_name}"; mkdir -p "${pkg_dir}/web"
   cp "${RELEASE_DIR}/tmp/${bin_file}" "${pkg_dir}/${bin_file}"
   cp -r web/dist "${pkg_dir}/web/dist"
@@ -139,6 +146,11 @@ for i in "${!BUN_TARGETS[@]}"; do
   else
     if [[ "$bun_target" == *darwin* ]]; then
       create_gui_macos_app "$pkg_dir" "$bin_file" "${bin_name#dvalincode-gui-macos-}"
+      # Deep ad-hoc sign the bundle so the .app launches without "damaged".
+      if [ -d "${pkg_dir}/DvalinCode.app" ] && command -v codesign >/dev/null 2>&1; then
+        codesign --force --deep --sign - "${pkg_dir}/DvalinCode.app" 2>/dev/null \
+          && echo "  ✓ ad-hoc signed DvalinCode.app" || echo "  ! codesign failed for DvalinCode.app"
+      fi
     fi
     suffix="${bin_name#dvalincode-gui-}"
     archive_name="dvalincode-gui-v${VERSION}-${suffix}.tar.gz"

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -42,6 +42,13 @@ VERSION="$(node -p "require('./package.json').version" 2>/dev/null || echo "0.0.
 RELEASE_DIR="release"
 ICON_SOURCE="web/public/logo.svg"   # used only for the Windows .exe icon/metadata
 
+# Code-signing identity for macOS binaries:
+#   "-"  (default) → ad-hoc signature: clears the "damaged" error, NOT notarized.
+#   "Developer ID Application: NAME (TEAMID)" → real signature for notarization;
+#     set via DVALINCODE_SIGN_IDENTITY (the release workflow wires this from a
+#     secret). Requires the cert to be present in the build host's keychain.
+SIGN_IDENTITY="${DVALINCODE_SIGN_IDENTITY:--}"
+
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 echo "  DvalinCode v${VERSION} — CLI + Web Bundle Release"
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
@@ -135,8 +142,15 @@ for i in "${!BUN_TARGETS[@]}"; do
   # quarantine flag cleared (the installer does this automatically). `codesign`
   # exists only on a macOS build host, so this no-ops elsewhere.
   if [[ "$bun_target" == *darwin* ]] && command -v codesign >/dev/null 2>&1; then
-    if codesign --force --sign - "${RELEASE_DIR}/tmp/${bin_file}" 2>/dev/null; then
-      echo "  ✓ ad-hoc signed ${bin_file}"
+    if [ "$SIGN_IDENTITY" = "-" ]; then
+      cs_args=(--force --sign -); cs_label="ad-hoc signed"
+    else
+      # Hardened runtime + timestamp are required for notarization to pass.
+      cs_args=(--force --options runtime --timestamp --sign "$SIGN_IDENTITY")
+      cs_label="Developer ID signed"
+    fi
+    if codesign "${cs_args[@]}" "${RELEASE_DIR}/tmp/${bin_file}" 2>/dev/null; then
+      echo "  ✓ ${cs_label} ${bin_file}"
     else
       echo "  ! codesign failed for ${bin_file} (shipping unsigned)"
     fi

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -129,6 +129,19 @@ for i in "${!BUN_TARGETS[@]}"; do
 
   "$BUN" build "${build_args[@]}"
 
+  # Ad-hoc sign macOS binaries so Gatekeeper doesn't report them as "damaged"
+  # on Apple Silicon. This is NOT notarization — it only clears the hard
+  # "damaged"/won't-run failure; a browser-downloaded copy still needs the
+  # quarantine flag cleared (the installer does this automatically). `codesign`
+  # exists only on a macOS build host, so this no-ops elsewhere.
+  if [[ "$bun_target" == *darwin* ]] && command -v codesign >/dev/null 2>&1; then
+    if codesign --force --sign - "${RELEASE_DIR}/tmp/${bin_file}" 2>/dev/null; then
+      echo "  ✓ ad-hoc signed ${bin_file}"
+    else
+      echo "  ! codesign failed for ${bin_file} (shipping unsigned)"
+    fi
+  fi
+
   # ── Package ──────────────────────────────────────────────────────
   pkg_dir="${RELEASE_DIR}/pkg/${bin_name}"
   mkdir -p "${pkg_dir}/web"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -138,6 +138,18 @@ WRAPPER
 fi
 ok "Installed to ${C_BOLD}${INSTALL_DIR}${C_RESET}"
 
+# ── macOS: clear Gatekeeper quarantine ────────────────────────────────
+# curl downloads aren't quarantined, but be defensive (re-runs, manual copies,
+# browser-downloaded archives) so the unsigned binary isn't flagged as
+# "damaged" / blocked on Apple Silicon.
+case "$PLATFORM" in
+  macos-*)
+    if command -v xattr >/dev/null 2>&1; then
+      xattr -dr com.apple.quarantine "$INSTALL_DIR" 2>/dev/null || true
+    fi
+    ;;
+esac
+
 # ── PATH setup ────────────────────────────────────────────────────────
 ADD_TO_PATH=true
 case ":$PATH:" in


### PR DESCRIPTION
Fixes the macOS Gatekeeper **"is damaged and can't be opened"** friction and lays the groundwork for fully prompt-free downloads.

> Note: the ad-hoc signing + dequarantine work was authored in #26 but lost in its squash-merge (only the first commit landed). This PR re-applies it **and** adds the notarization skeleton.

## Step 1 — installer clears quarantine (free, CLI)
`install.sh` runs `xattr -dr com.apple.quarantine` on the install dir after install (macOS only, guarded). `curl` downloads aren't quarantined anyway, so the one-line installer is prompt-free.

## Step 2 — ad-hoc sign macOS artifacts (free)
- `build-release.sh` / `build-gui.sh` sign the darwin binaries (and deep-sign `DvalinCode.app`) with `codesign --sign -`, clearing the hard "damaged" failure on Apple Silicon. Guarded by `command -v codesign` → no-op off macOS.
- `release.yml` now runs on **`macos-latest`** so `codesign` is available for the released artifacts (Bun cross-compiles linux/windows from there); checksum verify uses `shasum -a 256 -c`.

## Step 3 — Developer ID signing + notarization skeleton (gated, inert)
Does nothing until these **optional** repo secrets are set; until then builds ad-hoc sign as in Step 2:

| Secret | Purpose |
|---|---|
| `MACOS_SIGN_IDENTITY` | `Developer ID Application: NAME (TEAMID)` |
| `MACOS_CERTIFICATE_P12` | base64 of the exported Developer ID `.p12` |
| `MACOS_CERTIFICATE_PASSWORD` | password for the `.p12` |
| `APPLE_ID` / `APPLE_TEAM_ID` / `APPLE_APP_PASSWORD` | `notarytool` credentials |

- Build scripts sign with `$DVALINCODE_SIGN_IDENTITY` (hardened runtime + timestamp) when set, else ad-hoc.
- Both workflows gain a gated **"Import Developer ID certificate"** step (temp keychain) and a gated notarization step. `release-gui.yml` also **staples** the `.app` and repackages + re-checksums.
- Bare CLI binaries in a `.tar.gz` can't be stapled → rely on Gatekeeper's online check; `.app` bundles are stapled for offline verification.

## Validation (macOS arm64)
- `build-release.sh darwin` + `build-gui.sh darwin`: artifacts ad-hoc-signed (`codesign --verify` → valid), smoke + checksum pass, signed binary runs (`serve` → HTTP 200).
- All three scripts pass `bash -n`; the identity-override path resolves correctly.
- The notarization steps require a real Apple cert/account to execute, so they ship as a validated-shape, secret-gated skeleton.

🤖 Generated with [Claude Code](https://claude.com/claude-code)