### PR TITLE
fix(ci): gate release signing steps on env, not secrets in if:

### DIFF
--- a/.github/workflows/release-gui.yml
+++ b/.github/workflows/release-gui.yml
@@ -36,6 +36,9 @@ jobs:
     # is Developer-ID signed, notarized, and stapled (prompt-free download).
     env:
       DVALINCODE_SIGN_IDENTITY: ${{ secrets.MACOS_SIGN_IDENTITY }}
+      # `secrets` can't be used in step `if:` — fold presence into env booleans.
+      HAS_SIGNING_CERT: ${{ secrets.MACOS_CERTIFICATE_P12 != '' }}
+      HAS_NOTARY_CREDS: ${{ secrets.APPLE_ID != '' }}
 
     steps:
       - uses: actions/checkout@v4
@@ -62,7 +65,7 @@ jobs:
 
       # Import the Developer ID cert (skipped without the secret → ad-hoc).
       - name: Import Developer ID certificate
-        if: ${{ secrets.MACOS_CERTIFICATE_P12 != '' }}
+        if: env.HAS_SIGNING_CERT == 'true'
         env:
           CERT_P12: ${{ secrets.MACOS_CERTIFICATE_P12 }}
           CERT_PASSWORD: ${{ secrets.MACOS_CERTIFICATE_PASSWORD }}
@@ -86,7 +89,7 @@ jobs:
       # stapled ticket travels with it (offline-verifiable). Skipped without
       # Apple credentials. .app bundles (unlike bare binaries) can be stapled.
       - name: Notarize + staple desktop app
-        if: ${{ secrets.APPLE_ID != '' }}
+        if: env.HAS_NOTARY_CREDS == 'true'
         env:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,9 @@ jobs:
     env:
       # Empty unless configured → build scripts fall back to ad-hoc signing.
       DVALINCODE_SIGN_IDENTITY: ${{ secrets.MACOS_SIGN_IDENTITY }}
+      # `secrets` can't be used in step `if:` — fold presence into env booleans.
+      HAS_SIGNING_CERT: ${{ secrets.MACOS_CERTIFICATE_P12 != '' }}
+      HAS_NOTARY_CREDS: ${{ secrets.APPLE_ID != '' }}
 
     steps:
       - uses: actions/checkout@v4
@@ -72,7 +75,7 @@ jobs:
       # Import the Developer ID cert into a temp keychain so the build step can
       # sign with it. Skipped entirely when the secret is absent (→ ad-hoc).
       - name: Import Developer ID certificate
-        if: ${{ secrets.MACOS_CERTIFICATE_P12 != '' }}
+        if: env.HAS_SIGNING_CERT == 'true'
         env:
           CERT_P12: ${{ secrets.MACOS_CERTIFICATE_P12 }}
           CERT_PASSWORD: ${{ secrets.MACOS_CERTIFICATE_PASSWORD }}
@@ -107,7 +110,7 @@ jobs:
       # relies on Gatekeeper's online notarization check on first run. For
       # offline-stapled CLI distribution, ship a signed .dmg/.pkg instead.
       - name: Notarize macOS archives
-        if: ${{ secrets.APPLE_ID != '' }}
+        if: env.HAS_NOTARY_CREDS == 'true'
         env:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}


### PR DESCRIPTION
The v0.7.0 release workflow failed to load (0s startup failure) because `secrets` was referenced directly in step `if:` conditions — GitHub Actions disallows that and rejects the whole workflow.

Fix: map the secrets to job-level `env` booleans and gate on them:
- `HAS_SIGNING_CERT: ${{ secrets.MACOS_CERTIFICATE_P12 != '' }}`
- `HAS_NOTARY_CREDS: ${{ secrets.APPLE_ID != '' }}`
- steps now use `if: env.HAS_SIGNING_CERT == 'true'` / `if: env.HAS_NOTARY_CREDS == 'true'`.

Applied to both `release.yml` and `release-gui.yml`. No release was published by the failed run. After merge, `v0.7.0` will be re-tagged to trigger a clean build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)