### PR TITLE
feat(data): export/import all local data + download conversations as Markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 <p align="center">
   <a href="https://github.com/arthurpanhku/dvalincode/releases/latest"><img src="https://img.shields.io/github/v/release/arthurpanhku/dvalincode?style=for-the-badge&color=818cf8&label=Release" alt="Release"></a>
   <a href="https://github.com/arthurpanhku/dvalincode/releases"><img src="https://img.shields.io/github/downloads/arthurpanhku/dvalincode/total?style=for-the-badge&color=blue&label=Downloads" alt="Downloads"></a>
-  <a href="#-tests"><img src="https://img.shields.io/badge/Tests-81%20%2F%2081%20%E2%9C%93-success?style=for-the-badge" alt="Tests"></a>
+  <a href="#-tests"><img src="https://img.shields.io/badge/Tests-95%20%2F%2095%20%E2%9C%93-success?style=for-the-badge" alt="Tests"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-green?style=for-the-badge" alt="License"></a>
   <a href="#-quick-install"><img src="https://img.shields.io/badge/Platforms-macOS%20·%20Windows%20·%20Linux-blue?style=for-the-badge" alt="Platforms"></a>
   <a href="#-providers"><img src="https://img.shields.io/badge/LLM-OpenAI%20·%20Claude%20·%20DeepSeek%20·%20Ollama%20·%20Groq-7C3AED?style=for-the-badge" alt="LLM Support"></a>
@@ -36,6 +36,7 @@
 <tr><td><b>🖥️ Terminal or web — one binary</b></td><td>Run it bare for an interactive <b>terminal agent</b> (like Claude Code — streaming, inline approvals, red/green diffs), or <code>dvalincode serve</code> to host the <b>web GUI</b> for browser/remote use. Both frontends drive the same agent core.</td></tr>
 <tr><td><b>🪶 Zero-dependency binary</b></td><td>Single ~25MB executable per platform. No Node, no Python, no Docker.</td></tr>
 <tr><td><b>🔐 Local-first</b></td><td>Sessions, config, profiles, and audit logs live in <code>~/.dvalincode/</code>. <code>.dvalincodeignore</code> blocks the agent from reading sensitive files. <code>AGENTS.md</code> in your repo becomes persistent project instructions.</td></tr>
+<tr><td><b>💾 Portable & exportable</b></td><td>Export <b>all</b> local data (memory, sessions, config, audit) to one file and import it on another machine — your setup moves with you. Any conversation downloads as a clean <b>Markdown</b> transcript.</td></tr>
 </table>
 
 ---
@@ -57,6 +58,8 @@ The bundled **web GUI is the runtime's reference implementation and showcase** �
 
 ## ⭐ What's New in v0.7.0 — 🧪 Desktop app (beta)
 
+- **🧠 Portable memory & full data export/import** — the upgraded local memory mechanism, plus every session, config, profile, and audit log, can now be bundled into a single file and restored on another machine. Migrate your whole setup in one step: `dvalincode export` / `dvalincode import`, or the **Export / Import** buttons in the GUI Settings panel.
+- **📝 Download any AI interaction as Markdown** — every conversation can be saved as a clean Markdown transcript (user turns, assistant replies, tool calls + results, decisions — all inline). Use the download icon on any session in the sidebar, `dvalincode session md <id>`, or `GET /api/sessions/:id/markdown`.
 - **🖥️ Native desktop app** — a real application window (not a browser tab) over the same engine: `DvalinCode.app` on macOS, plus Windows/Linux builds. Built with [webview-bun](https://github.com/tr1ckydev/webview-bun) using the OS-native webview (WKWebView / WebView2 / WebKitGTK) — no Electron, stays a small self-contained binary.
 - **🧩 A third frontend, one core** — the desktop app, terminal UI, and web GUI all drive the same shared turn-runner. The current `dvalincode` binary is now positioned purely as the **CLI** (terminal + `serve`).
 - **Status:** the desktop binaries are **experimental / unverified** — grab them from the latest **pre-release** and please report how the window behaves on your OS.
@@ -216,6 +219,9 @@ Both share the same config and sessions in `~/.dvalincode/`.
 | | Multi-profile config | Save and switch between named (provider, model, API key) sets |
 | **Sessions** | Auto-save + restore | All sessions persisted to `~/.dvalincode/sessions/` as JSON |
 | | LLM summary memory | Cross-session summary keeps the agent oriented after restart |
+| **Memory** | Local user/project memory | Searchable facts, preferences, and decisions in `~/.dvalincode/memory/`; import from Claude/Hermes/Markdown |
+| **Data portability** | Export / import all data | One bundle of memory + sessions + config + audit — `dvalincode export` / `import`, or GUI Settings → Export / Import |
+| | Markdown transcript | Download any conversation as Markdown — sidebar download icon, `dvalincode session md <id>`, or `/api/sessions/:id/markdown` |
 
 ---
 
@@ -288,7 +294,7 @@ RESTORE → COMPACT → COMMAND → BUILD → RUN → SAVE → RESPOND → DONE
 npm test
 ```
 
-**81 tests · 14 files · all green.**
+**95 tests · 18 files · all green.**
 
 ---
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -9,7 +9,7 @@
 <p align="center">
   <a href="https://github.com/arthurpanhku/dvalincode/releases/latest"><img src="https://img.shields.io/github/v/release/arthurpanhku/dvalincode?style=for-the-badge&color=818cf8&label=Release" alt="Release"></a>
   <a href="https://github.com/arthurpanhku/dvalincode/releases"><img src="https://img.shields.io/github/downloads/arthurpanhku/dvalincode/total?style=for-the-badge&color=blue&label=Downloads" alt="Downloads"></a>
-  <a href="#-测试"><img src="https://img.shields.io/badge/Tests-81%20%2F%2081%20%E2%9C%93-success?style=for-the-badge" alt="Tests"></a>
+  <a href="#-测试"><img src="https://img.shields.io/badge/Tests-95%20%2F%2095%20%E2%9C%93-success?style=for-the-badge" alt="Tests"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-green?style=for-the-badge" alt="License"></a>
   <a href="#-一行安装"><img src="https://img.shields.io/badge/Platforms-macOS%20·%20Windows%20·%20Linux-blue?style=for-the-badge" alt="Platforms"></a>
   <a href="#-providers"><img src="https://img.shields.io/badge/LLM-OpenAI%20·%20Claude%20·%20DeepSeek%20·%20Ollama%20·%20Groq-7C3AED?style=for-the-badge" alt="LLM Support"></a>
@@ -36,6 +36,7 @@
 <tr><td><b>🖥️ 终端或 Web，同一个二进制</b></td><td>直接运行进入交互式<b>终端代理</b>（像 Claude Code —— 流式输出、行内审批、红绿 diff）；或 <code>dvalincode serve</code> 启动 <b>Web GUI</b> 供浏览器/远程使用。两个前端共用同一套 agent 内核。</td></tr>
 <tr><td><b>🪶 零依赖二进制</b></td><td>每平台单文件可执行程序 ~25MB。无需 Node、Python、Docker。</td></tr>
 <tr><td><b>🔐 本地优先</b></td><td>Session、配置、Profile、审计日志均保存在 <code>~/.dvalincode/</code>。<code>.dvalincodeignore</code> 阻止 Agent 访问敏感文件。仓库根目录的 <code>AGENTS.md</code> 作为项目级持久指令自动加载。</td></tr>
+<tr><td><b>💾 可导出、可迁移</b></td><td>把<b>所有</b>本地数据（记忆、Session、配置、审计）导出为一个文件，在另一台机器导入 —— 整套环境随身带走。任意对话都能下载为干净的 <b>Markdown</b> 记录。</td></tr>
 </table>
 
 ---
@@ -57,6 +58,8 @@ DvalinCode 的定位是 **Agent 运行时（runtime）**，而不只是又一个
 
 ## ⭐ v0.7.0 新功能 —— 🧪 桌面应用（beta）
 
+- **🧠 记忆与全量数据导出 / 导入** —— 升级后的本地记忆机制,连同所有 Session、配置、Profile、审计日志,现在都能打包成一个文件并在另一台机器上还原。一步迁移整套环境:`dvalincode export` / `dvalincode import`,或 GUI 设置面板里的 **Export / Import** 按钮。
+- **📝 任意 AI 交互都能下载为 Markdown** —— 每段对话都能存成干净的 Markdown 记录(用户消息、助手回复、工具调用 + 结果、决策,全部内联)。用侧栏里每个 Session 的下载图标、`dvalincode session md <id>`,或 `GET /api/sessions/:id/markdown`。
 - **🖥️ 原生桌面应用** —— 一个真正的应用窗口（不是浏览器标签页），跑在同一套内核之上：macOS 的 `DvalinCode.app`，外加 Windows / Linux 版本。基于 [webview-bun](https://github.com/tr1ckydev/webview-bun)，使用系统原生 webview（WKWebView / WebView2 / WebKitGTK）—— 不用 Electron，仍是小巧自包含的二进制。
 - **🧩 第三个前端，同一内核** —— 桌面应用、终端 UI、Web GUI 都驱动同一套共享回合执行器。现有的 `dvalincode` 二进制现在纯粹定位为 **CLI**（终端 + `serve`）。
 - **状态：** 桌面二进制目前**实验性 / 未验证** —— 请从最新的 **pre-release** 下载，并反馈窗口在你系统上的表现。
@@ -216,6 +219,9 @@ dvalincode serve --host 0.0.0.0 --no-open   # 部署到服务器，供远程/浏
 | | 多 Profile 配置 | 保存并切换多组 (provider, model, API key) 命名配置 |
 | **Session** | 自动保存与恢复 | 所有 session 以 JSON 持久化到 `~/.dvalincode/sessions/` |
 | | LLM 摘要记忆 | 跨 session 摘要在重启后保持 Agent 上下文 |
+| **记忆** | 本地用户/项目记忆 | 可搜索的事实、偏好、决策,存于 `~/.dvalincode/memory/`;支持从 Claude/Hermes/Markdown 导入 |
+| **数据可迁移** | 导出 / 导入全部数据 | 记忆 + Session + 配置 + 审计打包成一个文件 —— `dvalincode export` / `import`,或 GUI 设置 → Export / Import |
+| | Markdown 记录 | 任意对话下载为 Markdown —— 侧栏下载图标、`dvalincode session md <id>`,或 `/api/sessions/:id/markdown` |
 
 ---
 
@@ -290,7 +296,7 @@ RESTORE → COMPACT → COMMAND → BUILD → RUN → SAVE → RESPOND → DONE
 npm test
 ```
 
-**81 个测试 · 14 个文件 · 全部通过。**
+**95 个测试 · 18 个文件 · 全部通过。**
 
 ---
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -9,6 +9,7 @@ import { registerToolsCommand } from './commands/tools.js';
 import { registerReportCommand } from './commands/report.js';
 import { registerServeCommand } from './commands/serve.js';
 import { registerTuiCommand } from './commands/tui.js';
+import { registerDataCommands } from './commands/data.js';
 import { createDefaultToolRegistry } from './tools/registry.js';
 
 export function buildProgram(): Command {
@@ -30,6 +31,7 @@ export function buildProgram(): Command {
   registerReportCommand(program);
   registerServeCommand(program);
   registerTuiCommand(program);
+  registerDataCommands(program);
 
   // Bare invocation: launch the terminal agent in an interactive TTY,
   // otherwise fall back to help (e.g. piped or non-interactive contexts).

--- a/src/commands/data.ts
+++ b/src/commands/data.ts
@@ -1,0 +1,69 @@
+import path from 'node:path';
+import { readFile, writeFile } from 'node:fs/promises';
+import type { Command } from 'commander';
+import { exportData, importData, isDataBundle, type DataBundle } from '../data/archive.js';
+import { loadSession } from '../sessions/store.js';
+import { renderSessionMarkdown } from '../sessions/markdown.js';
+
+export function registerDataCommands(program: Command): void {
+  program
+    .command('export')
+    .description('Export all local DvalinCode data (config, sessions, memory, audit) to a portable file')
+    .option('--out <file>', 'output path (default: dvalincode-export-<timestamp>.json)')
+    .option('--no-audit', 'exclude the audit/ run logs from the bundle')
+    .action(async (opts: { out?: string; audit: boolean }) => {
+      const bundle = await exportData({ includeAudit: opts.audit });
+      const fileCount = Object.keys(bundle.files).length;
+      const out = opts.out ?? `dvalincode-export-${bundle.exportedAt.replace(/[:.]/g, '-')}.json`;
+      const target = path.resolve(process.cwd(), out);
+      await writeFile(target, JSON.stringify(bundle), 'utf-8');
+      console.log(`Exported ${fileCount} files → ${target}`);
+    });
+
+  program
+    .command('import')
+    .description('Restore local DvalinCode data from a file created by `dvalincode export`')
+    .argument('<file>', 'bundle file to import')
+    .option('--no-overwrite', 'keep existing files instead of overwriting them')
+    .action(async (file: string, opts: { overwrite: boolean }) => {
+      const raw = await readFile(path.resolve(process.cwd(), file), 'utf-8');
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(raw);
+      } catch {
+        throw new Error('File is not valid JSON — expected a DvalinCode export bundle.');
+      }
+      if (!isDataBundle(parsed)) {
+        throw new Error('Not a DvalinCode export bundle.');
+      }
+      const result = await importData(parsed as DataBundle, { overwrite: opts.overwrite });
+      console.log(
+        `Imported ${result.written} files (skipped ${result.skipped} of ${result.total}). Restart DvalinCode to pick up changes.`,
+      );
+    });
+
+  const session = program
+    .command('session')
+    .description('Work with saved sessions');
+
+  session
+    .command('md')
+    .description('Render a saved session as a Markdown transcript')
+    .argument('<id>', 'session id')
+    .option('--out <file>', 'write to a file instead of stdout')
+    .action(async (id: string, opts: { out?: string }) => {
+      const loaded = await loadSession(id);
+      if (!loaded) {
+        console.error(`Session not found: ${id}`);
+        process.exit(1);
+      }
+      const md = renderSessionMarkdown(loaded);
+      if (opts.out) {
+        const target = path.resolve(process.cwd(), opts.out);
+        await writeFile(target, md, 'utf-8');
+        console.log(`Wrote transcript → ${target}`);
+      } else {
+        process.stdout.write(md);
+      }
+    });
+}

--- a/src/data/archive.ts
+++ b/src/data/archive.ts
@@ -1,0 +1,160 @@
+import { mkdir, readFile, readdir, writeFile, stat } from 'node:fs/promises';
+import path from 'node:path';
+import { dvalinHome } from '../memory/store.js';
+
+/**
+ * Portable backup of everything DvalinCode stores locally under ~/.dvalincode
+ * (config, profiles, sessions, memory, audit logs, project metadata). Used to
+ * migrate a setup to another machine: export → copy the file → import.
+ *
+ * All DvalinCode data is UTF-8 text (JSON / JSONL / Markdown), so the bundle is
+ * a simple relative-path → content map — dependency-free and human-inspectable.
+ */
+export const DATA_BUNDLE_VERSION = 1;
+
+export type DataBundle = {
+  app: 'dvalincode';
+  version: number;
+  exportedAt: string;
+  /** Map of paths relative to ~/.dvalincode → UTF-8 file contents. */
+  files: Record<string, string>;
+};
+
+export type ExportOptions = {
+  /** Base dir to export (defaults to ~/.dvalincode). */
+  home?: string;
+  /** Include the audit/ run logs (can be large). Default: true. */
+  includeAudit?: boolean;
+};
+
+export type ImportOptions = {
+  /** Base dir to restore into (defaults to ~/.dvalincode). */
+  home?: string;
+  /** Overwrite files that already exist. Default: true (it's a restore). */
+  overwrite?: boolean;
+};
+
+export type ImportResult = {
+  written: number;
+  skipped: number;
+  total: number;
+};
+
+const MAX_FILE_BYTES = 25 * 1024 * 1024; // skip anything implausibly large
+
+/** Collect all local data into a portable bundle. */
+export async function exportData(options: ExportOptions = {}): Promise<DataBundle> {
+  const home = options.home ?? dvalinHome();
+  const includeAudit = options.includeAudit ?? true;
+  const files: Record<string, string> = {};
+
+  for await (const rel of walk(home, '')) {
+    const top = rel.split('/')[0];
+    if (!includeAudit && top === 'audit') continue;
+
+    const abs = path.join(home, rel);
+    let info;
+    try {
+      info = await stat(abs);
+    } catch {
+      continue;
+    }
+    if (!info.isFile() || info.size > MAX_FILE_BYTES) continue;
+
+    try {
+      // utf-8 read; binary files (none expected) would round-trip lossily, so skip.
+      const content = await readFile(abs, 'utf-8');
+      files[rel] = content;
+    } catch {
+      // unreadable / non-text — skip rather than abort the whole export
+    }
+  }
+
+  return {
+    app: 'dvalincode',
+    version: DATA_BUNDLE_VERSION,
+    exportedAt: new Date().toISOString(),
+    files,
+  };
+}
+
+/** Validate a parsed object is a DvalinCode data bundle. */
+export function isDataBundle(value: unknown): value is DataBundle {
+  if (!value || typeof value !== 'object') return false;
+  const b = value as Partial<DataBundle>;
+  return b.app === 'dvalincode' && typeof b.version === 'number' && !!b.files && typeof b.files === 'object';
+}
+
+/** Restore a bundle into ~/.dvalincode. Paths are sanitized to stay inside home. */
+export async function importData(bundle: DataBundle, options: ImportOptions = {}): Promise<ImportResult> {
+  if (!isDataBundle(bundle)) {
+    throw new Error('Not a valid DvalinCode data bundle.');
+  }
+  if (bundle.version > DATA_BUNDLE_VERSION) {
+    throw new Error(`Bundle version ${bundle.version} is newer than this build supports (${DATA_BUNDLE_VERSION}).`);
+  }
+
+  const home = options.home ?? dvalinHome();
+  const overwrite = options.overwrite ?? true;
+  const entries = Object.entries(bundle.files);
+  let written = 0;
+  let skipped = 0;
+
+  for (const [rel, content] of entries) {
+    const safeRel = sanitizeRelPath(rel);
+    if (!safeRel) {
+      skipped++;
+      continue;
+    }
+    const abs = path.join(home, safeRel);
+
+    if (!overwrite && (await exists(abs))) {
+      skipped++;
+      continue;
+    }
+
+    await mkdir(path.dirname(abs), { recursive: true });
+    await writeFile(abs, content, 'utf-8');
+    written++;
+  }
+
+  return { written, skipped, total: entries.length };
+}
+
+/** Reject absolute paths and `..` traversal; normalize separators. */
+function sanitizeRelPath(rel: string): string | null {
+  const normalized = rel.replace(/\\/g, '/').replace(/^\/+/, '');
+  if (!normalized || normalized.includes('\0')) return null;
+  const parts = normalized.split('/');
+  if (parts.some(p => p === '..' || p === '.')) return null;
+  return parts.join(path.sep);
+}
+
+async function exists(p: string): Promise<boolean> {
+  try {
+    await stat(p);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Recursively yield file paths relative to `base`, skipping dotfiles like .DS_Store. */
+async function* walk(base: string, rel: string): AsyncGenerator<string> {
+  const dir = path.join(base, rel);
+  let dirents;
+  try {
+    dirents = await readdir(dir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  for (const dirent of dirents) {
+    if (dirent.name === '.DS_Store') continue;
+    const childRel = rel ? `${rel}/${dirent.name}` : dirent.name;
+    if (dirent.isDirectory()) {
+      yield* walk(base, childRel);
+    } else if (dirent.isFile()) {
+      yield childRel;
+    }
+  }
+}

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -12,6 +12,7 @@ import { configRouter } from './routes/config.js';
 import { filesRouter } from './routes/files.js';
 import { gitRouter } from './routes/git.js';
 import { projectsRouter } from './routes/projects.js';
+import { dataRouter } from './routes/data.js';
 import { getPlaybook, savePlaybook } from './playbookHandler.js';
 import { handleWebSocket } from './wsHandler.js';
 import { isAllowedRequestOrigin } from './security.js';
@@ -50,7 +51,8 @@ app.use((req, res, next) => {
   next();
 });
 app.use(cors());
-app.use(express.json());
+// Larger limit: data import accepts a full local-data bundle (sessions + audit).
+app.use(express.json({ limit: '64mb' }));
 
 app.use('/api/sessions', sessionsRouter);
 app.use('/api/tools', toolsRouter);
@@ -58,6 +60,7 @@ app.use('/api/config', configRouter);
 app.use('/api/files', filesRouter);
 app.use('/api/git', gitRouter);
 app.use('/api/projects', projectsRouter);
+app.use('/api/data', dataRouter);
 app.get('/api/playbook', (req, res) => void getPlaybook(req, res));
 app.post('/api/playbook', (req, res) => void savePlaybook(req, res));
 

--- a/src/server/routes/data.ts
+++ b/src/server/routes/data.ts
@@ -1,0 +1,30 @@
+import { Router } from 'express';
+import { exportData, importData, isDataBundle } from '../../data/archive.js';
+
+export const dataRouter = Router();
+
+// Download a portable bundle of all local data. `?audit=0` excludes audit logs.
+dataRouter.get('/export', async (req, res) => {
+  const includeAudit = req.query.audit !== '0' && req.query.audit !== 'false';
+  const bundle = await exportData({ includeAudit });
+  const filename = `dvalincode-export-${bundle.exportedAt.replace(/[:.]/g, '-')}.json`;
+  res.setHeader('Content-Type', 'application/json');
+  res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
+  res.send(JSON.stringify(bundle));
+});
+
+// Restore from a bundle posted as JSON. `?overwrite=0` keeps existing files.
+dataRouter.post('/import', async (req, res) => {
+  const bundle = req.body;
+  if (!isDataBundle(bundle)) {
+    res.status(400).json({ error: 'Request body is not a DvalinCode export bundle.' });
+    return;
+  }
+  const overwrite = req.query.overwrite !== '0' && req.query.overwrite !== 'false';
+  try {
+    const result = await importData(bundle, { overwrite });
+    res.json(result);
+  } catch (err) {
+    res.status(400).json({ error: err instanceof Error ? err.message : String(err) });
+  }
+});

--- a/src/server/routes/sessions.ts
+++ b/src/server/routes/sessions.ts
@@ -1,5 +1,6 @@
 import { Router } from 'express';
 import { listSessions, loadSession, deleteSession } from '../../sessions/store.js';
+import { renderSessionMarkdown } from '../../sessions/markdown.js';
 
 export const sessionsRouter = Router();
 
@@ -25,6 +26,18 @@ sessionsRouter.get('/:id', async (req, res) => {
     return;
   }
   res.json(session);
+});
+
+// Download the conversation as a Markdown transcript.
+sessionsRouter.get('/:id/markdown', async (req, res) => {
+  const session = await loadSession(req.params.id);
+  if (!session) {
+    res.status(404).json({ error: 'Session not found' });
+    return;
+  }
+  res.setHeader('Content-Type', 'text/markdown; charset=utf-8');
+  res.setHeader('Content-Disposition', `attachment; filename="${session.id}.md"`);
+  res.send(renderSessionMarkdown(session));
 });
 
 sessionsRouter.delete('/:id', async (req, res) => {

--- a/src/sessions/markdown.ts
+++ b/src/sessions/markdown.ts
@@ -1,0 +1,75 @@
+import type { Session } from './store.js';
+import type { ChatMessage } from '../providers/types.js';
+
+/**
+ * Render a session's conversation as a portable Markdown transcript — a
+ * downloadable record of an AI interaction (files, decisions, tool calls and
+ * results all inline). Pure function over the session, so it's trivially
+ * testable and reused by both the CLI and the web "Download Markdown" button.
+ */
+export function renderSessionMarkdown(session: Session): string {
+  const lines: string[] = [];
+  lines.push(`# DvalinCode session — \`${session.id}\``);
+  lines.push('');
+  lines.push(`- Created: ${session.createdAt}`);
+  lines.push(`- Updated: ${session.updatedAt}`);
+  lines.push(`- Workspace: \`${session.cwd}\``);
+  if (session.goal) lines.push(`- Goal: ${session.goal}`);
+  if (session.summary) lines.push(`- Summary: ${session.summary}`);
+  lines.push('');
+  lines.push('---');
+  lines.push('');
+
+  const turns = session.messages.filter(m => m.role !== 'system');
+  if (turns.length === 0) {
+    lines.push('_No messages in this session._');
+    return lines.join('\n') + '\n';
+  }
+
+  for (const msg of turns) {
+    lines.push(...renderMessage(msg));
+    lines.push('');
+  }
+
+  return lines.join('\n') + '\n';
+}
+
+function renderMessage(msg: ChatMessage): string[] {
+  switch (msg.role) {
+    case 'user':
+      return [`## 🧑 User`, '', msg.content.trim() || '_(empty)_'];
+
+    case 'assistant': {
+      const out = [`## 🤖 Assistant`, ''];
+      if (msg.content.trim()) out.push(msg.content.trim());
+      for (const call of msg.tool_calls ?? []) {
+        out.push('', `**Tool call:** \`${call.name}\``, '', '```json', prettyArgs(call.arguments), '```');
+      }
+      if (!msg.content.trim() && (!msg.tool_calls || msg.tool_calls.length === 0)) {
+        out.push('_(empty)_');
+      }
+      return out;
+    }
+
+    case 'tool': {
+      const label = msg.name ? `🔧 Tool result — \`${msg.name}\`` : '🔧 Tool result';
+      // Strip the "[Tool x result]:\n" / "[Tool x error]: " framing the runner adds.
+      const body = msg.content
+        .replace(/^\[Tool \w+ result\]:\n?/, '')
+        .replace(/^\[Tool \w+ error\]:\s?/, '')
+        .trimEnd();
+      return [`### ${label}`, '', '```', body || '(no output)', '```'];
+    }
+
+    default:
+      return [`## ${msg.role}`, '', msg.content.trim()];
+  }
+}
+
+function prettyArgs(args: string): string {
+  try {
+    return JSON.stringify(JSON.parse(args), null, 2);
+  } catch {
+    return args;
+  }
+}

--- a/tests/data/archive.test.ts
+++ b/tests/data/archive.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { exportData, importData, isDataBundle, DATA_BUNDLE_VERSION } from '../../src/data/archive.js';
+
+let src: string;
+let dest: string;
+
+beforeEach(() => {
+  src = mkdtempSync(path.join(tmpdir(), 'dvalin-src-'));
+  dest = mkdtempSync(path.join(tmpdir(), 'dvalin-dest-'));
+  // Seed a representative ~/.dvalincode tree.
+  writeFileSync(path.join(src, 'config.json'), '{"llm":{"provider":"deepseek"}}');
+  mkdirSync(path.join(src, 'sessions'), { recursive: true });
+  writeFileSync(path.join(src, 'sessions', 'dc_1.json'), '{"id":"dc_1","messages":[]}');
+  mkdirSync(path.join(src, 'memory', 'user'), { recursive: true });
+  writeFileSync(path.join(src, 'memory', 'user', 'entries.json'), '[{"id":"mem_1"}]');
+  mkdirSync(path.join(src, 'audit'), { recursive: true });
+  writeFileSync(path.join(src, 'audit', 'run-x.jsonl'), '{"seq":0}\n');
+});
+
+afterEach(() => {
+  rmSync(src, { recursive: true, force: true });
+  rmSync(dest, { recursive: true, force: true });
+});
+
+describe('data archive', () => {
+  it('exports all local files into a bundle', async () => {
+    const bundle = await exportData({ home: src });
+    expect(bundle.app).toBe('dvalincode');
+    expect(bundle.version).toBe(DATA_BUNDLE_VERSION);
+    expect(Object.keys(bundle.files).sort()).toEqual([
+      'audit/run-x.jsonl',
+      'config.json',
+      'memory/user/entries.json',
+      'sessions/dc_1.json',
+    ]);
+    expect(isDataBundle(bundle)).toBe(true);
+  });
+
+  it('can exclude audit logs', async () => {
+    const bundle = await exportData({ home: src, includeAudit: false });
+    expect(Object.keys(bundle.files)).not.toContain('audit/run-x.jsonl');
+    expect(Object.keys(bundle.files)).toContain('sessions/dc_1.json');
+  });
+
+  it('round-trips export → import into a fresh home', async () => {
+    const bundle = await exportData({ home: src });
+    const result = await importData(bundle, { home: dest });
+    expect(result.written).toBe(4);
+    expect(result.total).toBe(4);
+    expect(readFileSync(path.join(dest, 'config.json'), 'utf-8')).toContain('deepseek');
+    expect(readFileSync(path.join(dest, 'memory/user/entries.json'), 'utf-8')).toContain('mem_1');
+    expect(existsSync(path.join(dest, 'audit/run-x.jsonl'))).toBe(true);
+  });
+
+  it('skips existing files when overwrite is false', async () => {
+    writeFileSync(path.join(dest, 'config.json'), 'OLD');
+    const bundle = await exportData({ home: src });
+    const result = await importData(bundle, { home: dest, overwrite: false });
+    expect(result.skipped).toBe(1);
+    expect(readFileSync(path.join(dest, 'config.json'), 'utf-8')).toBe('OLD');
+  });
+
+  it('rejects path traversal in bundle keys', async () => {
+    const evil = { app: 'dvalincode' as const, version: 1, exportedAt: 'x', files: { '../escape.txt': 'pwn' } };
+    const result = await importData(evil, { home: dest });
+    expect(result.skipped).toBe(1);
+    expect(result.written).toBe(0);
+    expect(existsSync(path.join(path.dirname(dest), 'escape.txt'))).toBe(false);
+  });
+
+  it('rejects non-bundles', async () => {
+    expect(isDataBundle({ foo: 1 })).toBe(false);
+    await expect(importData({ foo: 1 } as never, { home: dest })).rejects.toThrow();
+  });
+});

--- a/tests/sessions/markdown.test.ts
+++ b/tests/sessions/markdown.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { renderSessionMarkdown } from '../../src/sessions/markdown.js';
+import type { Session } from '../../src/sessions/store.js';
+
+function session(messages: Session['messages']): Session {
+  return {
+    id: 'dc_test',
+    createdAt: '2026-06-16T00:00:00.000Z',
+    updatedAt: '2026-06-16T01:00:00.000Z',
+    cwd: '/repo',
+    messages,
+  };
+}
+
+describe('renderSessionMarkdown', () => {
+  it('renders header metadata', () => {
+    const md = renderSessionMarkdown(session([]));
+    expect(md).toContain('# DvalinCode session — `dc_test`');
+    expect(md).toContain('Workspace: `/repo`');
+    expect(md).toContain('_No messages in this session._');
+  });
+
+  it('renders user / assistant / tool turns and skips system', () => {
+    const md = renderSessionMarkdown(session([
+      { role: 'system', content: 'you are a bot' },
+      { role: 'user', content: 'add a test' },
+      {
+        role: 'assistant',
+        content: 'On it.',
+        tool_calls: [{ id: 't1', name: 'write_file', arguments: '{"filePath":"a.ts"}' }],
+      },
+      { role: 'tool', name: 'write_file', content: '[Tool write_file result]:\nCreated a.ts', tool_call_id: 't1' },
+    ]));
+
+    expect(md).not.toContain('you are a bot');
+    expect(md).toContain('## 🧑 User');
+    expect(md).toContain('add a test');
+    expect(md).toContain('## 🤖 Assistant');
+    expect(md).toContain('**Tool call:** `write_file`');
+    expect(md).toContain('"filePath": "a.ts"'); // pretty-printed args
+    expect(md).toContain('🔧 Tool result — `write_file`');
+    expect(md).toContain('Created a.ts');
+    expect(md).not.toContain('[Tool write_file result]'); // framing stripped
+  });
+});

--- a/web/src/components/SettingsPanel.tsx
+++ b/web/src/components/SettingsPanel.tsx
@@ -1,7 +1,8 @@
-import { useState } from 'react';
-import { X, Settings, Monitor, Sun, Moon } from 'lucide-react';
+import { useRef, useState } from 'react';
+import { X, Settings, Monitor, Sun, Moon, Download, Upload } from 'lucide-react';
 import type { ApprovalMode } from '../types.ts';
 import { getStoredTheme, setTheme, type Theme } from '../lib/theme.ts';
+import { downloadDataExport, importDataBundle } from '../lib/client.ts';
 
 const THEME_OPTIONS: { value: Theme; label: string; icon: typeof Monitor }[] = [
   { value: 'system', label: 'System', icon: Monitor },
@@ -39,6 +40,62 @@ function ThemeSwitcher() {
           );
         })}
       </div>
+    </div>
+  );
+}
+
+function DataSection() {
+  const fileInput = useRef<HTMLInputElement>(null);
+  const [status, setStatus] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  const onImportFile = async (file: File) => {
+    setBusy(true);
+    setStatus(null);
+    try {
+      const bundle = JSON.parse(await file.text());
+      const result = await importDataBundle(bundle);
+      setStatus(`Imported ${result.written} files (skipped ${result.skipped}). Reload to see changes.`);
+    } catch (err) {
+      setStatus(`Import failed: ${err instanceof Error ? err.message : String(err)}`);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-1.5">
+      <span className="text-xs text-muted-fg font-medium">Data (sessions, memory, config, audit)</span>
+      <div className="flex gap-2">
+        <button
+          onClick={() => downloadDataExport()}
+          className="flex-1 flex items-center justify-center gap-1.5 px-3 py-2 text-xs rounded-lg bg-elevated border border-border text-fg hover:bg-surface-2 transition-colors"
+        >
+          <Download size={13} /> Export all
+        </button>
+        <button
+          onClick={() => fileInput.current?.click()}
+          disabled={busy}
+          className="flex-1 flex items-center justify-center gap-1.5 px-3 py-2 text-xs rounded-lg bg-elevated border border-border text-fg hover:bg-surface-2 transition-colors disabled:opacity-50"
+        >
+          <Upload size={13} /> {busy ? 'Importing…' : 'Import'}
+        </button>
+        <input
+          ref={fileInput}
+          type="file"
+          accept="application/json,.json"
+          className="hidden"
+          onChange={(e) => {
+            const file = e.target.files?.[0];
+            if (file) void onImportFile(file);
+            e.target.value = '';
+          }}
+        />
+      </div>
+      <p className="text-[11px] text-muted-fg/70">
+        Export bundles everything in <code>~/.dvalincode</code> into one file for moving to another machine. Import restores it.
+      </p>
+      {status && <p className="text-[11px] text-muted-fg">{status}</p>}
     </div>
   );
 }
@@ -121,6 +178,8 @@ export function SettingsPanel({ settings, onChange }: Props) {
               <p className="text-xs text-muted-fg/60 bg-elevated border border-border rounded px-2.5 py-2">
                 Approval mode is controlled by the switcher in the top bar.
               </p>
+
+              <DataSection />
             </div>
 
             <div className="flex justify-end gap-2 px-5 py-4 border-t border-border">

--- a/web/src/components/SidebarChat.tsx
+++ b/web/src/components/SidebarChat.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
-import { Plus, MessageSquare, Trash2, ChevronRight, BookOpen, Search, GitPullRequest, FlaskConical, Sparkles } from 'lucide-react';
+import { Plus, MessageSquare, Trash2, ChevronRight, BookOpen, Search, GitPullRequest, FlaskConical, Sparkles, Download } from 'lucide-react';
+import { downloadSessionMarkdown } from '../lib/client.ts';
 import type { SessionMeta } from '../types.ts';
 
 // ── Templates ────────────────────────────────────────────────────────────────
@@ -83,6 +84,13 @@ function SessionRow({
           {timeAgo(session.updatedAt)} · {session.messageCount} msg
         </div>
       </div>
+      <button
+        onClick={(e) => { e.stopPropagation(); downloadSessionMarkdown(session.id); }}
+        title="Download Markdown transcript"
+        className="opacity-0 group-hover:opacity-100 p-0.5 rounded hover:text-accent transition-all flex-shrink-0"
+      >
+        <Download size={11} />
+      </button>
       <button
         onClick={onDelete}
         className="opacity-0 group-hover:opacity-100 p-0.5 rounded hover:text-red-400 transition-all flex-shrink-0"

--- a/web/src/components/SidebarCode.tsx
+++ b/web/src/components/SidebarCode.tsx
@@ -3,7 +3,7 @@ import {
   Plus, MessageSquare, Trash2, Zap, ChevronRight, X, Check, Download,
 } from 'lucide-react';
 import type { SessionMeta } from '../types.ts';
-import { fetchPlaybook, savePlaybook } from '../lib/client.ts';
+import { fetchPlaybook, savePlaybook, downloadSessionMarkdown } from '../lib/client.ts';
 
 // ── Local-storage routines ────────────────────────────────────────────────────
 
@@ -77,6 +77,13 @@ function SessionRow({
           {timeAgo(session.updatedAt)} · {session.messageCount} msg
         </div>
       </div>
+      <button
+        onClick={(e) => { e.stopPropagation(); downloadSessionMarkdown(session.id); }}
+        title="Download Markdown transcript"
+        className="opacity-0 group-hover:opacity-100 p-0.5 rounded hover:text-accent transition-all flex-shrink-0"
+      >
+        <Download size={11} />
+      </button>
       <button
         onClick={onDelete}
         className="opacity-0 group-hover:opacity-100 p-0.5 rounded hover:text-red-400 transition-all flex-shrink-0"

--- a/web/src/components/SidebarCowork.tsx
+++ b/web/src/components/SidebarCowork.tsx
@@ -1,7 +1,8 @@
 import { useState } from 'react';
 import {
-  Plus, Trash2, FolderOpen, ChevronRight, ClipboardList,
+  Plus, Trash2, FolderOpen, ChevronRight, ClipboardList, Download,
 } from 'lucide-react';
+import { downloadSessionMarkdown } from '../lib/client.ts';
 import type { SessionMeta } from '../types.ts';
 
 function timeAgo(iso: string): string {
@@ -48,6 +49,13 @@ function TaskRow({
           {timeAgo(session.updatedAt)} · {session.messageCount} msg
         </div>
       </div>
+      <button
+        onClick={(e) => { e.stopPropagation(); downloadSessionMarkdown(session.id); }}
+        title="Download Markdown transcript"
+        className="opacity-0 group-hover:opacity-100 p-0.5 rounded hover:text-accent transition-all flex-shrink-0"
+      >
+        <Download size={11} />
+      </button>
       <button
         onClick={onDelete}
         className="opacity-0 group-hover:opacity-100 p-0.5 rounded hover:text-red-400 transition-all flex-shrink-0"

--- a/web/src/lib/client.ts
+++ b/web/src/lib/client.ts
@@ -116,6 +116,42 @@ export async function deleteSession(id: string): Promise<void> {
   await fetch(`/api/sessions/${id}`, { method: 'DELETE' });
 }
 
+/** Trigger a browser download of a URL that sets Content-Disposition. */
+function triggerDownload(url: string): void {
+  const a = document.createElement('a');
+  a.href = url;
+  a.rel = 'noopener';
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+}
+
+/** Download a session's conversation as a Markdown transcript. */
+export function downloadSessionMarkdown(id: string): void {
+  triggerDownload(`/api/sessions/${encodeURIComponent(id)}/markdown`);
+}
+
+/** Download a portable bundle of all local data (for migrating machines). */
+export function downloadDataExport(includeAudit = true): void {
+  triggerDownload(`/api/data/export${includeAudit ? '' : '?audit=0'}`);
+}
+
+export type ImportResult = { written: number; skipped: number; total: number };
+
+/** Restore local data from a bundle previously exported. */
+export async function importDataBundle(bundle: unknown, overwrite = true): Promise<ImportResult> {
+  const res = await fetch(`/api/data/import${overwrite ? '' : '?overwrite=0'}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(bundle),
+  });
+  if (!res.ok) {
+    const err = (await res.json().catch(() => ({}))) as { error?: string };
+    throw new Error(err.error ?? `HTTP ${res.status}`);
+  }
+  return res.json() as Promise<ImportResult>;
+}
+
 export async function fetchConfig(): Promise<AppConfig> {
   const res = await fetch('/api/config');
   if (!res.ok) throw new Error(`HTTP ${res.status}`);


### PR DESCRIPTION
Two related capabilities the user asked for: **migrate a DvalinCode setup between machines**, and **download any AI interaction as Markdown**.

## 🧠 Memory & data portability
Bundle **everything** under `~/.dvalincode` (config, profiles, sessions, local memory, audit logs, project metadata) into one portable file and restore it elsewhere.

- `src/data/archive.ts` — `exportData()` / `importData()`. All DvalinCode data is UTF-8 text, so the bundle is a relative-path → content map: dependency-free, human-inspectable. Path-traversal-safe; `..`/absolute keys rejected. Audit logs optional (`--no-audit` / `?audit=0`).
- **CLI:** `dvalincode export [--out <file>] [--no-audit]`, `dvalincode import <file> [--no-overwrite]`.
- **Server:** `GET /api/data/export`, `POST /api/data/import` (JSON body limit raised to 64 MB).
- **GUI:** Settings → **Export all** / **Import** buttons.

## 📝 Markdown transcript of any interaction
- `src/sessions/markdown.ts` — renders a session (user / assistant / tool turns, tool calls + pretty-printed args, results, decisions) into a clean Markdown transcript.
- **CLI:** `dvalincode session md <id> [--out <file>]`.
- **Server:** `GET /api/sessions/:id/markdown` (Content-Disposition download).
- **GUI:** a download icon on every session row in all three sidebars (Chat / Cowork / Code).

## Tests & validation
- `tests/data/archive.test.ts` (export, exclude-audit, round-trip into a fresh home, skip-on-no-overwrite, path-traversal guard, non-bundle rejection) + `tests/sessions/markdown.test.ts`.
- **95/95 tests green**, `tsc` clean, `web` build clean.
- CLI smoke (real `~/.dvalincode`): `export` → 12-file bundle; `import --no-overwrite` → non-destructive (skips all); `session md <id>` → correct transcript.

## Docs
READMEs (EN + zh-CN): new **What's New** bullets (portable memory/data + Markdown download), a feature card, a **Data portability / Memory** Features section, test badge 81 → 95.

🤖 Generated with [Claude Code](https://claude.com/claude-code)