### PR TITLE
[codex] add governed network enforcement

### DIFF
--- a/docs/AUDIT-TRAIL.md
+++ b/docs/AUDIT-TRAIL.md
@@ -24,19 +24,21 @@ Each line is one JSON record: an event plus chain metadata
 
 | Event | Captures |
 |-------|----------|
-| `run_start` | task, mode, provider, model, cwd, git HEAD |
-| `tool_call` | tool name, arg summary, `ok`/`error`, duration |
+| `run_start` | task fingerprint/size, mode, provider, model, cwd, git HEAD |
+| `provider_request` | provider/model, endpoint origin, outcome, status, duration |
+| `tool_call` | tool name, minimized structural arg summary, `ok`/`error`, duration |
 | `file_read` | path, content SHA-256 |
 | `file_write` | path, `+added`/`−removed` lines, before/after content hash |
 | `file_delete` | path, before hash |
-| `shell_exec` | command, exit code, sandbox (`seatbelt`/`bwrap`/`none`) |
+| `shell_exec` | executable, exit code, sandbox (`seatbelt`/`bwrap`/`none`) |
 | `approval` | tool, approved/rejected |
 | `policy_violation` | blocked rule, tool, target (reserved for the Policy Engine, P0-2) |
 | `run_end` | status, iterations, token usage, write warnings |
 
-**Size policy:** file *contents* are never stored — only their SHA-256 hash plus
-`+added/−removed` line counts. Long argument summaries and commands are truncated
-to 512 characters.
+**Data policy:** task text, file contents, replacement text, memory contents, shell
+arguments, prompts, provider headers, and provider bodies are never stored. Sensitive
+inputs are represented by SHA-256 plus byte length. File paths and executable names
+remain visible because they are required for an actionable run report.
 
 ## The hash chain
 

--- a/docs/EGRESS-THREAT-MODEL.md
+++ b/docs/EGRESS-THREAT-MODEL.md
@@ -1,0 +1,114 @@
+# Governed Network v1 Threat Model
+
+## Scope
+
+Governed Network v1 connects the existing resolved policy to the two network
+boundaries that already exist:
+
+1. OpenAI-compatible provider HTTP requests.
+2. Agent-launched subprocesses from the `shell` and `run_check` tools.
+
+The goal is a small, demonstrable vertical slice. This version does not add
+remote MCP, OAuth, a general proxy, or a second policy engine.
+
+## Policy Semantics
+
+The existing `network` field remains unchanged:
+
+| Value | Provider HTTP | Agent-managed subprocess |
+|-------|---------------|------------------|
+| `on` | Allowed | Existing platform behavior |
+| `endpoint-only` | Only the configured model endpoint | Runs only with OS-enforced network isolation |
+| `off` | Blocked | Runs only with OS-enforced network isolation |
+
+`network` remains the enum `off | endpoint-only | on`. Governed Network v1
+does not migrate it to an object and does not introduce a host allowlist.
+Provider requests reuse `checkEgress(policy, true)`. Shell isolation decisions
+reuse `checkEgress(policy, false)`.
+
+Machine and repository policies continue to resolve by narrowing:
+
+`off` is stricter than `endpoint-only`, which is stricter than `on`.
+
+The canonical resolved-policy hash is unchanged. A future detailed network
+rule must be an additional restriction whose merge operation is intersection
+or another monotonic narrowing operation. It must not reinterpret or widen the
+existing enum.
+
+## Enforcement Boundaries
+
+### Provider HTTP
+
+The provider adapter validates egress before sending a request. With
+`endpoint-only`, the request origin must match the configured provider origin.
+Redirects are handled manually and revalidated before the next request.
+
+This control is **enforced in process** for HTTP requests made by the bundled
+provider adapter.
+
+It does not claim to provide process-wide socket containment. In particular,
+it does not defend against a malicious provider adapter that bypasses the
+bundled request path, DNS rebinding after validation, or another library that
+opens a socket directly.
+
+### Agent-launched subprocesses
+
+A subprocess launch is not itself treated as network egress. When policy denies
+non-model egress, DvalinCode may still run the command if the child process is
+started inside an OS-enforced network-isolation boundary.
+
+| Platform | Mechanism | Restricted-policy status |
+|----------|-----------|--------------------------|
+| macOS | `/usr/bin/sandbox-exec` with `(deny network*)` | `enforced` when available; otherwise launch is blocked |
+| Linux | Bubblewrap with `--unshare-net` | `enforced` when available; otherwise launch is blocked |
+| Windows | No v1 mechanism | `unavailable`; launch is blocked |
+| Other | No v1 mechanism | `unavailable`; launch is blocked |
+
+There is no advisory fallback for `off` or `endpoint-only`. If DvalinCode
+cannot establish the required isolation, it fails closed before launching the
+requested command.
+
+With `network: on`, current behavior is preserved. macOS continues to use its
+existing default Seatbelt wrapper when available; other platforms may run the
+child without a network sandbox.
+
+## Audit Data Policy
+
+Audit data is minimized before persistence:
+
+- User task text is replaced by byte length and SHA-256.
+- Tool arguments are summarized by safe structural metadata and SHA-256.
+- Shell arguments are not stored; the executable, argument count, and input
+  hash are recorded.
+- Provider events record provider/model, endpoint origin, outcome, HTTP status,
+  and duration. Prompts, response bodies, headers, API keys, paths, and query
+  strings are not recorded.
+
+This is a data-minimization guarantee. Any later secret scanner is
+best-effort defense in depth and must not be described as complete redaction.
+
+## Acceptance Matrix
+
+| Case | Expected result |
+|------|-----------------|
+| No policy file | Provider calls behave as before; `network` resolves to `on` |
+| Configured provider with `endpoint-only` | Request is sent to the configured origin |
+| Provider with `off` | Request is blocked before `fetch` |
+| Cross-origin provider redirect with `endpoint-only` | Redirect is blocked before the second request |
+| Provider request with `on` | Configured endpoint and redirects are allowed |
+| `shell` or `run_check` with `endpoint-only` or `off` on supported macOS | Child starts under Seatbelt with network denied |
+| `shell` or `run_check` with `endpoint-only` or `off` on Linux with Bubblewrap | Child starts in an unshared network namespace |
+| Agent subprocess with restricted policy and no supported sandbox | Child is not started and a policy violation is recorded |
+| Audit log for a provider call | Contains no prompt, response body, headers, API key, path, or query |
+| Audit log for a tool call | Contains no file content, replacement text, memory content, or shell arguments |
+| Policy resolution | Existing narrowing tests and canonical hash behavior remain unchanged |
+| Trust report | States the actual provider and shell enforcement status for this platform |
+
+## Non-goals
+
+- Containing arbitrary third-party in-process code.
+- Remote MCP, OAuth, or dynamic client registration.
+- Host allowlists beyond the configured provider origin.
+- Network policy for processes DvalinCode did not launch.
+- Claiming transport confidentiality for a configured plain-HTTP endpoint.
+- Claiming tamper-proof audit custody against a hostile local administrator.

--- a/src/agent/compact.ts
+++ b/src/agent/compact.ts
@@ -1,4 +1,4 @@
-import type { ChatMessage, ProviderAdapter } from '../providers/types.js';
+import type { ChatMessage, ChatRequest, ProviderAdapter } from '../providers/types.js';
 
 export function estimateTokens(messages: ChatMessage[]): number {
   const total = messages.reduce((acc, m) => acc + (m.content?.length ?? 0), 0);
@@ -24,6 +24,7 @@ Be concise. Each bullet is one line. Omit sections with no content.`;
 export async function summarizeWithLLM(
   messages: ChatMessage[],
   provider: ProviderAdapter,
+  runtime?: ChatRequest['runtime'],
 ): Promise<string> {
   const transcript = messages
     .filter((m) => m.role === 'user' || m.role === 'assistant')
@@ -34,6 +35,7 @@ export async function summarizeWithLLM(
     messages: [{ role: 'user', content: `${COMPACT_PROMPT}\n\n---\n${transcript}` }],
     maxTokens: 600,
     temperature: 0.3,
+    runtime,
   });
   return resp.content;
 }

--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -2,6 +2,7 @@ import { TurnState, type TurnConfig, type LoopResult, type SlashCommand, type Ag
 import { AgentRunner } from './runner.js';
 import { estimateTokens } from './compact.js';
 import { AuditSink, newRunId, resolveGitHead } from '../audit/log.js';
+import { minimizedDescriptor } from '../audit/minimize.js';
 import { policyHash, type LoadedPolicy } from '../core/policy.js';
 import type { ChatMessage } from '../providers/types.js';
 import type { ProviderAdapter } from '../providers/types.js';
@@ -182,7 +183,7 @@ export class AgentLoop {
             sink = new AuditSink(runId, this.auditOptions.dir);
             sink.append({
               type: 'run_start',
-              task: userMessage,
+              task: minimizedDescriptor(userMessage),
               mode: this.context.approvalMode,
               provider: this.provider.name,
               model: this.auditOptions.model ?? 'unknown',
@@ -272,6 +273,11 @@ export class AgentLoop {
             content: `Summarize this conversation into a structured summary with these sections:\n1. Goal\n2. Completed\n3. Decisions\n4. CurrentState\n5. Pending\n\nConversation:\n${conversationText}`,
           },
         ],
+        runtime: {
+          policy: this.context.policy,
+          audit: this.context.audit,
+          model: this.auditOptions.model,
+        },
       });
 
       const systemMsg = messages.find(m => m.role === 'system');

--- a/src/agent/runner.ts
+++ b/src/agent/runner.ts
@@ -91,6 +91,10 @@ export class AgentRunner {
         tools: toolDefs.length > 0 ? toolDefs : undefined,
         signal,
         onDelta: onEvent ? (delta) => onEvent({ type: 'token_delta', content: delta }) : undefined,
+        runtime: {
+          policy: this.context.policy,
+          audit: this.context.audit,
+        },
       });
 
       // Accumulate token usage across all iterations

--- a/src/agent/session.ts
+++ b/src/agent/session.ts
@@ -14,7 +14,14 @@ import {
   type CodePermissionMode,
 } from './modes.js';
 import { createDvalinContext } from '../core/context.js';
-import { loadPolicy } from '../core/policy.js';
+import {
+  checkMode,
+  checkModel,
+  checkProvider,
+  loadPolicy,
+  PolicyViolationError,
+  type Decision,
+} from '../core/policy.js';
 import { scanProject } from '../core/projectScanner.js';
 import { loadIgnorePatterns } from '../core/ignorefile.js';
 import { resolveInsideWorkspace } from '../core/workspace.js';
@@ -109,8 +116,20 @@ export async function runAgentTurn(input: RunTurnInput, hooks: RunTurnHooks = {}
   }
   hooks.onSessionId?.(session.id);
 
+  // Resolve policy before selecting or calling a provider. With no policy file
+  // this remains permissive and preserves existing behavior.
+  const loadedPolicy = loadPolicy(cwd);
+  for (const source of loadedPolicy.sources) {
+    if (source.error) {
+      console.warn(`⚠ Ignored malformed policy at ${source.path}: ${source.error}`);
+    }
+  }
+  enforceRunPolicy(checkMode(loadedPolicy.policy, mode), 'mode', mode);
+
   // ── Provider ───────────────────────────────────────────────────────────
   const { provider, providerId, model } = await resolveProvider(input.providerOverride);
+  enforceRunPolicy(checkProvider(loadedPolicy.policy, providerId), 'provider', providerId);
+  enforceRunPolicy(checkModel(loadedPolicy.policy, model), 'model', model);
   hooks.onProviderSelected?.(providerId, model);
 
   // ── Prompt assembly ──────────────────────────────────────────────────────
@@ -135,17 +154,6 @@ export async function runAgentTurn(input: RunTurnInput, hooks: RunTurnHooks = {}
       : userContent;
 
   // ── Run ──────────────────────────────────────────────────────────────────
-  // Resolve the org policy once per turn (machine + repo layers, narrowed). With no
-  // policy file this is permissive — identical to the prior behavior.
-  const loadedPolicy = loadPolicy(cwd);
-  // Fail-safe: a policy file that exists but could not be parsed is skipped, not
-  // treated as "allow everything". Surface it so the user knows it didn't apply.
-  for (const source of loadedPolicy.sources) {
-    if (source.error) {
-      console.warn(`⚠ Ignored malformed policy at ${source.path}: ${source.error}`);
-    }
-  }
-
   const loop = new AgentLoop({
     provider,
     registry,
@@ -181,6 +189,12 @@ export async function runAgentTurn(input: RunTurnInput, hooks: RunTurnHooks = {}
 }
 
 // ── Helpers ───────────────────────────────────────────────────────────────
+
+function enforceRunPolicy(decision: Decision, targetType: string, target: string): void {
+  if (!decision.allowed) {
+    throw new PolicyViolationError(targetType, decision.rule, target);
+  }
+}
 
 async function buildSystemPrompt(opts: {
   cwd: string;

--- a/src/audit/log.ts
+++ b/src/audit/log.ts
@@ -23,10 +23,27 @@ export type AuditEvent =
       policySources?: { layer: 'machine' | 'repo'; path: string; present: boolean; hash: string | null; error?: string }[];
     }
   | { type: 'tool_call'; tool: string; argsSummary: string; status: 'ok' | 'error'; durationMs: number }
+  | {
+      type: 'provider_request';
+      provider: string;
+      model: string;
+      origin: string;
+      outcome: 'ok' | 'blocked' | 'error';
+      durationMs: number;
+      statusCode?: number;
+    }
   | { type: 'file_read'; path: string; sha256: string }
   | { type: 'file_write'; path: string; added: number; removed: number; beforeHash: string | null; afterHash: string }
   | { type: 'file_delete'; path: string; beforeHash: string | null }
-  | { type: 'shell_exec'; command: string; exitCode: number | null; sandbox: 'seatbelt' | 'bwrap' | 'none' }
+  | {
+      type: 'shell_exec';
+      /** Executable only. Arguments are intentionally excluded. */
+      command: string;
+      argsCount?: number;
+      inputHash?: string;
+      exitCode: number | null;
+      sandbox: 'seatbelt' | 'bwrap' | 'none';
+    }
   | { type: 'approval'; toolName: string; approved: boolean; diffHash?: string }
   | { type: 'policy_violation'; rule: string; tool: string; target: string }
   | {

--- a/src/audit/minimize.ts
+++ b/src/audit/minimize.ts
@@ -1,0 +1,73 @@
+import { canonicalJSON, sha256 } from './hash.js';
+
+export type Fingerprint = {
+  sha256: string;
+  bytes: number;
+};
+
+/** Hash sensitive input before it crosses the persistence boundary. */
+export function fingerprint(value: unknown): Fingerprint {
+  const serialized = serialize(value);
+  return {
+    sha256: sha256(serialized),
+    bytes: Buffer.byteLength(serialized, 'utf8'),
+  };
+}
+
+/** A stable descriptor that proves identity without retaining the original text. */
+export function minimizedDescriptor(value: unknown): string {
+  const fp = fingerprint(value);
+  return `minimized sha256:${fp.sha256} bytes:${fp.bytes}`;
+}
+
+/** Tool-specific summaries retain useful structure but never content-bearing values. */
+export function summarizeToolInput(tool: string, input: unknown): string {
+  const fp = fingerprint(input);
+  const record = isRecord(input) ? input : {};
+  const base = { sha256: fp.sha256, bytes: fp.bytes };
+
+  if (tool === 'shell' || tool === 'run_check') {
+    return JSON.stringify({
+      ...base,
+      executable: stringValue(record.command) ?? stringValue(record.script) ?? 'unknown',
+      argsCount: Array.isArray(record.args) ? record.args.length : 0,
+    });
+  }
+
+  const filePath = stringValue(record.filePath) ?? stringValue(record.path);
+  if (filePath) {
+    return JSON.stringify({
+      ...base,
+      filePath,
+      contentBytes: byteLength(record.content),
+      oldBytes: byteLength(record.oldString),
+      newBytes: byteLength(record.newString),
+    });
+  }
+
+  return JSON.stringify({
+    ...base,
+    fields: Object.keys(record).sort(),
+  });
+}
+
+function serialize(value: unknown): string {
+  if (typeof value === 'string') return value;
+  try {
+    return canonicalJSON(value) ?? String(value);
+  } catch {
+    return String(value);
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === 'string' ? value : undefined;
+}
+
+function byteLength(value: unknown): number | undefined {
+  return typeof value === 'string' ? Buffer.byteLength(value, 'utf8') : undefined;
+}

--- a/src/audit/taps.ts
+++ b/src/audit/taps.ts
@@ -1,5 +1,6 @@
 import type { DvalinContext } from '../core/context.js';
 import type { ToolAccess, ToolResult } from '../tools/types.js';
+import { fingerprint, summarizeToolInput } from './minimize.js';
 
 /**
  * Translate one tool execution into audit events on the context's sink. Emits a
@@ -18,7 +19,7 @@ export function emitToolAudit(
   const sink = context.audit;
   if (!sink) return;
 
-  sink.append({ type: 'tool_call', tool: name, argsSummary: summarize(input), status, durationMs });
+  sink.append({ type: 'tool_call', tool: name, argsSummary: summarizeToolInput(name, input), status, durationMs });
 
   // Derived events only make sense for a successful call with metadata.
   if (status !== 'ok' || !result) return;
@@ -55,11 +56,15 @@ export function emitToolAudit(
       }
       break;
     }
-    case 'shell': {
+    case 'shell':
+    case 'run_check': {
       if (typeof meta.command === 'string') {
+        const fp = fingerprint(input);
         sink.append({
           type: 'shell_exec',
           command: meta.command,
+          argsCount: typeof meta.argsCount === 'number' ? meta.argsCount : undefined,
+          inputHash: fp.sha256,
           exitCode: typeof meta.exitCode === 'number' ? meta.exitCode : null,
           sandbox: meta.sandbox === 'seatbelt' || meta.sandbox === 'bwrap' ? meta.sandbox : 'none',
         });
@@ -71,12 +76,4 @@ export function emitToolAudit(
 
 function numOr0(v: unknown): number {
   return typeof v === 'number' ? v : 0;
-}
-
-function summarize(input: unknown): string {
-  try {
-    return typeof input === 'string' ? input : JSON.stringify(input);
-  } catch {
-    return String(input);
-  }
 }

--- a/src/commands/chat.ts
+++ b/src/commands/chat.ts
@@ -6,6 +6,7 @@ import { AgentLoop } from '../agent/loop.js';
 import { createDvalinContext } from '../core/context.js';
 import { createSession, saveSession, loadSession, summarizeSession } from '../sessions/store.js';
 import { readConfig } from '../server/configStore.js';
+import { checkModel, checkProvider, loadPolicy, PolicyViolationError } from '../core/policy.js';
 
 export function registerChatCommand(program: Command, registry: ToolRegistry): void {
   program
@@ -47,6 +48,12 @@ export function registerChatCommand(program: Command, registry: ToolRegistry): v
         }
       }
       const provider = manager.get(providerName);
+      const loadedPolicy = loadPolicy(cwd);
+      const providerDecision = checkProvider(loadedPolicy.policy, providerName);
+      if (!providerDecision.allowed) throw new PolicyViolationError('provider', providerDecision.rule, providerName);
+      const modelName = options.model ?? provider.name;
+      const modelDecision = checkModel(loadedPolicy.policy, modelName);
+      if (!modelDecision.allowed) throw new PolicyViolationError('model', modelDecision.rule, modelName);
 
       // Scan workspace for context
       const summary = await scanProject(cwd);
@@ -108,9 +115,10 @@ export function registerChatCommand(program: Command, registry: ToolRegistry): v
           // Default: read-only for safety. User can opt in with --yes or config.
           allowWrite: false,
           allowExecute: false,
+          policy: loadedPolicy.policy,
         }),
         systemPrompt,
-        audit: { model: options.model ?? provider.name },
+        audit: { model: modelName, policy: loadedPolicy },
       });
 
       // Process message through the state machine

--- a/src/core/subprocessSandbox.ts
+++ b/src/core/subprocessSandbox.ts
@@ -1,0 +1,187 @@
+import { spawn } from 'node:child_process';
+import { accessSync, constants, existsSync } from 'node:fs';
+import path from 'node:path';
+import type { AuditSink } from '../audit/log.js';
+import { checkEgress, PolicyViolationError, type ResolvedPolicy } from './policy.js';
+
+export type SubprocessSandbox = 'seatbelt' | 'bwrap' | 'none';
+export type SubprocessSandboxCapabilities = { seatbeltPath?: string; bwrapPath?: string };
+export type SubprocessSandboxPlan =
+  | { allowed: true; sandbox: SubprocessSandbox; executable?: string }
+  | { allowed: false; sandbox: 'none'; reason: string };
+
+export type GovernedProcessResult = {
+  output: string;
+  exitCode: number | null;
+  timedOut: boolean;
+  sandbox: SubprocessSandbox;
+};
+
+export type GovernedProcessOptions = {
+  command: string;
+  args: string[];
+  cwd: string;
+  timeoutMs: number;
+  policy: ResolvedPolicy;
+  audit?: AuditSink;
+  toolName: string;
+  /** Preserve shell's existing default Seatbelt behavior when network is unrestricted. */
+  preferSandboxWhenUnrestricted?: boolean;
+};
+
+export async function runGovernedProcess(options: GovernedProcessOptions): Promise<GovernedProcessResult> {
+  const egress = checkEgress(options.policy, false);
+  const plan = selectSubprocessSandbox(
+    process.platform,
+    !egress.allowed,
+    detectSubprocessSandboxCapabilities(),
+    options.preferSandboxWhenUnrestricted,
+  );
+  if (!plan.allowed) {
+    const rule = egress.allowed ? plan.reason : `${egress.rule}; ${plan.reason}`;
+    options.audit?.append({
+      type: 'policy_violation',
+      rule,
+      tool: options.toolName,
+      target: 'subprocess network isolation',
+    });
+    throw new PolicyViolationError(options.toolName, rule, 'subprocess network isolation');
+  }
+
+  const launch = buildLaunch(options.command, options.args, options.cwd, plan);
+  const result = await spawnProcess(launch.command, launch.args, options.cwd, options.timeoutMs);
+  return { ...result, sandbox: plan.sandbox };
+}
+
+export function selectSubprocessSandbox(
+  platform: NodeJS.Platform,
+  requiresNetworkIsolation: boolean,
+  capabilities: SubprocessSandboxCapabilities,
+  preferSandboxWhenUnrestricted = false,
+): SubprocessSandboxPlan {
+  if (platform === 'darwin') {
+    if (capabilities.seatbeltPath && (requiresNetworkIsolation || preferSandboxWhenUnrestricted)) {
+      return { allowed: true, sandbox: 'seatbelt', executable: capabilities.seatbeltPath };
+    }
+    return requiresNetworkIsolation
+      ? { allowed: false, sandbox: 'none', reason: 'macOS sandbox-exec is unavailable; restricted subprocess launch fails closed' }
+      : { allowed: true, sandbox: 'none' };
+  }
+
+  if (platform === 'linux') {
+    if (requiresNetworkIsolation && capabilities.bwrapPath) {
+      return { allowed: true, sandbox: 'bwrap', executable: capabilities.bwrapPath };
+    }
+    return requiresNetworkIsolation
+      ? { allowed: false, sandbox: 'none', reason: 'Bubblewrap is unavailable; restricted subprocess launch fails closed' }
+      : { allowed: true, sandbox: 'none' };
+  }
+
+  return requiresNetworkIsolation
+    ? { allowed: false, sandbox: 'none', reason: `${platform} has no supported subprocess network sandbox in Governed Network v1` }
+    : { allowed: true, sandbox: 'none' };
+}
+
+export function detectSubprocessSandboxCapabilities(): SubprocessSandboxCapabilities {
+  return {
+    seatbeltPath: existsSync('/usr/bin/sandbox-exec') ? '/usr/bin/sandbox-exec' : undefined,
+    bwrapPath: findExecutable('bwrap'),
+  };
+}
+
+function buildLaunch(
+  command: string,
+  args: string[],
+  cwd: string,
+  plan: Extract<SubprocessSandboxPlan, { allowed: true }>,
+): { command: string; args: string[] } {
+  if (plan.sandbox === 'seatbelt') {
+    const profile = [
+      '(version 1)',
+      '(allow default)',
+      '(deny network*)',
+      '(allow file-read*)',
+      `(allow file-write* (subpath "${escapeSeatbeltPath(cwd)}")(subpath "/tmp")(subpath "/var"))`,
+    ].join('');
+    return { command: plan.executable!, args: ['-p', profile, command, ...args] };
+  }
+
+  if (plan.sandbox === 'bwrap') {
+    return {
+      command: plan.executable!,
+      args: [
+        '--ro-bind', '/', '/',
+        '--bind', cwd, cwd,
+        '--tmpfs', '/tmp',
+        '--unshare-net',
+        '--die-with-parent',
+        '--proc', '/proc',
+        '--dev', '/dev',
+        '--chdir', cwd,
+        '--',
+        command,
+        ...args,
+      ],
+    };
+  }
+
+  return { command, args };
+}
+
+function spawnProcess(
+  command: string,
+  args: string[],
+  cwd: string,
+  timeoutMs: number,
+): Promise<Omit<GovernedProcessResult, 'sandbox'>> {
+  return new Promise(resolve => {
+    const child = spawn(command, args, {
+      cwd,
+      shell: false,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    let output = '';
+    let timedOut = false;
+    const append = (chunk: Buffer) => {
+      output += chunk.toString('utf8');
+      if (output.length > 32_000) {
+        output = `${output.slice(0, 32_000)}\n[output truncated]`;
+      }
+    };
+
+    const timer = setTimeout(() => {
+      timedOut = true;
+      child.kill('SIGTERM');
+    }, timeoutMs);
+
+    child.stdout.on('data', append);
+    child.stderr.on('data', append);
+    child.on('error', error => {
+      clearTimeout(timer);
+      resolve({ output: error.message, exitCode: 1, timedOut });
+    });
+    child.on('close', code => {
+      clearTimeout(timer);
+      resolve({ output: output.trimEnd(), exitCode: code, timedOut });
+    });
+  });
+}
+
+function findExecutable(name: string): string | undefined {
+  for (const dir of (process.env.PATH ?? '').split(path.delimiter)) {
+    if (!dir) continue;
+    const candidate = path.join(dir, name);
+    try {
+      accessSync(candidate, constants.X_OK);
+      return candidate;
+    } catch {
+      // Continue searching PATH.
+    }
+  }
+  return undefined;
+}
+
+function escapeSeatbeltPath(value: string): string {
+  return value.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+}

--- a/src/core/trust.ts
+++ b/src/core/trust.ts
@@ -4,11 +4,16 @@ import path from 'node:path';
 import { defaultAuditDir, listRuns } from '../audit/log.js';
 import {
   loadPolicy,
+  checkEgress,
   permissivePolicy,
   policyHash,
   type PolicySource,
   type ResolvedPolicy,
 } from './policy.js';
+import {
+  detectSubprocessSandboxCapabilities,
+  selectSubprocessSandbox,
+} from './subprocessSandbox.js';
 
 /**
  * `dvalincode trust` — the product embodiment of the North Star: the tool issues its
@@ -33,6 +38,11 @@ export type TrustReport = {
     resolved: ResolvedPolicy;
   };
   audit: { dir: string; runCount: number };
+  networkEnforcement: {
+    provider: { status: 'blocked' | 'enforced' | 'unrestricted'; mechanism: string };
+    shell: { status: 'enforced' | 'unavailable' | 'unrestricted'; mechanism: string };
+    runCheck: { status: 'enforced' | 'unavailable' | 'unrestricted'; mechanism: string };
+  };
   /** dvalincode's own runtime dependencies; omitted when not resolvable (e.g. in a compiled binary). */
   dependencies?: Record<string, string>;
 };
@@ -40,6 +50,19 @@ export type TrustReport = {
 export function buildTrustReport(cwd: string = process.cwd()): TrustReport {
   const loaded = loadPolicy(cwd);
   const engine: 'bun' | 'node' = process.versions.bun ? 'bun' : 'node';
+  const capabilities = detectSubprocessSandboxCapabilities();
+  const requiresSubprocessIsolation = !checkEgress(loaded.policy, false).allowed;
+  const shellPlan = selectSubprocessSandbox(
+    process.platform,
+    requiresSubprocessIsolation,
+    capabilities,
+    true,
+  );
+  const runCheckPlan = selectSubprocessSandbox(
+    process.platform,
+    requiresSubprocessIsolation,
+    capabilities,
+  );
   return {
     version: VERSION,
     runtime: {
@@ -55,6 +78,11 @@ export function buildTrustReport(cwd: string = process.cwd()): TrustReport {
       resolved: loaded.policy,
     },
     audit: { dir: defaultAuditDir(), runCount: listRuns().length },
+    networkEnforcement: {
+      provider: providerEnforcement(loaded.policy.network),
+      shell: shellEnforcement(shellPlan),
+      runCheck: shellEnforcement(runCheckPlan),
+    },
     dependencies: readOwnDependencies(),
   };
 }
@@ -103,6 +131,12 @@ export function renderTrustReport(r: TrustReport): string {
   lines.push(`    paths        ${describePaths(p)}`);
   lines.push(`    tools        ${p.tools.deny.length ? `deny: ${p.tools.deny.join(', ')}` : 'all allowed'}`);
   lines.push(`    maxToolCalls ${p.maxToolCalls ?? 'unlimited'}`);
+  lines.push('  enforcement');
+  lines.push(
+    `    provider     ${r.networkEnforcement.provider.status} — ${r.networkEnforcement.provider.mechanism}`,
+  );
+  lines.push(`    shell        ${r.networkEnforcement.shell.status} — ${r.networkEnforcement.shell.mechanism}`);
+  lines.push(`    run_check    ${r.networkEnforcement.runCheck.status} — ${r.networkEnforcement.runCheck.mechanism}`);
   lines.push('');
 
   lines.push('可审计 / Audit');
@@ -139,4 +173,31 @@ function describePaths(p: ResolvedPolicy): string {
 
 function short(hash: string | null): string {
   return hash ? hash.slice(0, 12) : '—';
+}
+
+function providerEnforcement(
+  network: ResolvedPolicy['network'],
+): TrustReport['networkEnforcement']['provider'] {
+  if (network === 'off') {
+    return { status: 'blocked', mechanism: 'bundled provider request gate' };
+  }
+  if (network === 'endpoint-only') {
+    return { status: 'enforced', mechanism: 'configured-origin check with redirect revalidation' };
+  }
+  return { status: 'unrestricted', mechanism: 'policy permits provider egress' };
+}
+
+function shellEnforcement(
+  plan: ReturnType<typeof selectSubprocessSandbox>,
+): TrustReport['networkEnforcement']['shell'] {
+  if (!plan.allowed) {
+    return { status: 'unavailable', mechanism: plan.reason };
+  }
+  if (plan.sandbox === 'seatbelt') {
+    return { status: 'enforced', mechanism: 'macOS sandbox-exec deny network*' };
+  }
+  if (plan.sandbox === 'bwrap') {
+    return { status: 'enforced', mechanism: 'Bubblewrap unshared network namespace' };
+  }
+  return { status: 'unrestricted', mechanism: 'no shell network sandbox active' };
 }

--- a/src/providers/egress.ts
+++ b/src/providers/egress.ts
@@ -1,0 +1,126 @@
+import { checkEgress, permissivePolicy, PolicyViolationError } from '../core/policy.js';
+import type { ChatRequest } from './types.js';
+
+const MAX_REDIRECTS = 5;
+
+export async function governedProviderFetch(
+  target: string,
+  init: RequestInit,
+  request: ChatRequest,
+  provider: string,
+  configuredBaseUrl: string,
+  model: string,
+): Promise<Response> {
+  const policy = request.runtime?.policy ?? permissivePolicy();
+  const audit = request.runtime?.audit;
+  const configuredOrigin = parseOrigin(configuredBaseUrl);
+  let current = new URL(target);
+  let currentInit = { ...init, redirect: 'manual' as const };
+  const started = Date.now();
+
+  for (let redirects = 0; redirects <= MAX_REDIRECTS; redirects++) {
+    const isConfiguredEndpoint = current.origin === configuredOrigin;
+    const decision = checkEgress(policy, isConfiguredEndpoint);
+    if (!decision.allowed) {
+      audit?.append({
+        type: 'provider_request',
+        provider,
+        model,
+        origin: current.origin,
+        outcome: 'blocked',
+        durationMs: Date.now() - started,
+      });
+      audit?.append({
+        type: 'policy_violation',
+        rule: decision.rule,
+        tool: 'provider',
+        target: current.origin,
+      });
+      throw new PolicyViolationError('provider', decision.rule, current.origin);
+    }
+
+    let response: Response;
+    try {
+      response = await fetch(current, currentInit);
+    } catch (error) {
+      audit?.append({
+        type: 'provider_request',
+        provider,
+        model,
+        origin: current.origin,
+        outcome: 'error',
+        durationMs: Date.now() - started,
+      });
+      throw error;
+    }
+
+    if (!isRedirect(response.status)) {
+      audit?.append({
+        type: 'provider_request',
+        provider,
+        model,
+        origin: current.origin,
+        outcome: response.ok ? 'ok' : 'error',
+        durationMs: Date.now() - started,
+        statusCode: response.status,
+      });
+      return response;
+    }
+
+    const location = response.headers.get('location');
+    if (!location) {
+      audit?.append({
+        type: 'provider_request',
+        provider,
+        model,
+        origin: current.origin,
+        outcome: 'error',
+        durationMs: Date.now() - started,
+        statusCode: response.status,
+      });
+      throw new Error(`Provider redirect ${response.status} did not include a Location header`);
+    }
+    if (redirects === MAX_REDIRECTS) {
+      throw new Error(`Provider exceeded ${MAX_REDIRECTS} redirects`);
+    }
+
+    const next = new URL(location, current);
+    await response.body?.cancel().catch(() => undefined);
+    currentInit = redirectInit(response.status, currentInit, current, next);
+    current = next;
+  }
+
+  throw new Error('Provider redirect handling failed');
+}
+
+function parseOrigin(value: string): string {
+  try {
+    return new URL(value).origin;
+  } catch {
+    throw new Error(`Invalid provider base URL: ${value}`);
+  }
+}
+
+function isRedirect(status: number): boolean {
+  return status === 301 || status === 302 || status === 303 || status === 307 || status === 308;
+}
+
+function redirectInit(
+  status: number,
+  init: RequestInit & { redirect: 'manual' },
+  previous: URL,
+  next: URL,
+): RequestInit & { redirect: 'manual' } {
+  const headers = new Headers(init.headers);
+  if (previous.origin !== next.origin) {
+    headers.delete('authorization');
+    headers.delete('cookie');
+    headers.delete('proxy-authorization');
+  }
+  if (status === 303 || ((status === 301 || status === 302) && init.method?.toUpperCase() === 'POST')) {
+    headers.delete('content-length');
+    headers.delete('content-type');
+    return { ...init, method: 'GET', body: undefined, headers };
+  }
+  return { ...init, headers };
+}

--- a/src/providers/openaiCompatible.ts
+++ b/src/providers/openaiCompatible.ts
@@ -1,4 +1,5 @@
 import type { ProviderAdapter, ChatRequest, ChatResponse, ProviderConfig, ToolCall } from './types.js';
+import { governedProviderFetch } from './egress.js';
 
 export type OpenAIConfig = ProviderConfig & {
   name?: string;
@@ -56,12 +57,12 @@ export function createOpenAICompatibleProvider(config: OpenAIConfig): ProviderAd
   }
 
   async function chatStreaming(request: ChatRequest): Promise<ChatResponse> {
-    const response = await fetch(`${baseUrl}/chat/completions`, {
+    const response = await governedProviderFetch(`${baseUrl}/chat/completions`, {
       method: 'POST',
       headers: makeHeaders(),
       body: buildBody(request, true),
       signal: request.signal,
-    });
+    }, request, config.name ?? 'openai-compatible', baseUrl, model);
 
     if (!response.ok) {
       const text = await response.text();
@@ -151,12 +152,12 @@ export function createOpenAICompatibleProvider(config: OpenAIConfig): ProviderAd
   }
 
   async function chatNonStreaming(request: ChatRequest): Promise<ChatResponse> {
-    const response = await fetch(`${baseUrl}/chat/completions`, {
+    const response = await governedProviderFetch(`${baseUrl}/chat/completions`, {
       method: 'POST',
       headers: makeHeaders(),
       body: buildBody(request, false),
       signal: request.signal,
-    });
+    }, request, config.name ?? 'openai-compatible', baseUrl, model);
 
     if (!response.ok) {
       const text = await response.text();

--- a/src/providers/types.ts
+++ b/src/providers/types.ts
@@ -1,4 +1,6 @@
 import type { z } from 'zod';
+import type { AuditSink } from '../audit/log.js';
+import type { ResolvedPolicy } from '../core/policy.js';
 
 export type ProviderConfig = {
   apiKey?: string;
@@ -42,6 +44,12 @@ export type ChatRequest = {
   onDelta?: (delta: string) => void;
   /** AbortSignal to cancel the request mid-flight */
   signal?: AbortSignal;
+  /** Per-run governance state. Provider adapters must not persist its contents. */
+  runtime?: {
+    policy?: ResolvedPolicy;
+    audit?: AuditSink;
+    model?: string;
+  };
 };
 
 export type ChatResponse = {

--- a/src/server/wsHandler.ts
+++ b/src/server/wsHandler.ts
@@ -5,6 +5,7 @@ import { estimateTokens, summarizeWithLLM, buildCompactedHistory } from '../agen
 import type { AgentEvent } from '../agent/types.js';
 import type { AgentMode, CodePermissionMode } from '../agent/modes.js';
 import { resolveAllowedCwd } from './security.js';
+import { checkModel, checkProvider, loadPolicy, PolicyViolationError } from '../core/policy.js';
 
 type ClientMessage =
   | {
@@ -84,20 +85,30 @@ export function handleWebSocket(ws: WebSocket): void {
         return;
       }
       let provider;
+      let providerId: string;
+      let model: string;
       try {
-        ({ provider } = await resolveProvider());
+        ({ provider, providerId, model } = await resolveProvider());
+        const loadedPolicy = loadPolicy(session.cwd);
+        const providerDecision = checkProvider(loadedPolicy.policy, providerId);
+        if (!providerDecision.allowed) {
+          throw new PolicyViolationError('provider', providerDecision.rule, providerId);
+        }
+        const modelDecision = checkModel(loadedPolicy.policy, model);
+        if (!modelDecision.allowed) {
+          throw new PolicyViolationError('model', modelDecision.rule, model);
+        }
+        const tokensBefore = estimateTokens(session.messages);
+        const summary = await summarizeWithLLM(session.messages, provider, { policy: loadedPolicy.policy, model });
+        const compacted = buildCompactedHistory(summary);
+        const tokensAfter = estimateTokens(compacted);
+        session.messages = compacted;
+        session.updatedAt = new Date().toISOString();
+        await saveSession(session);
+        send(ws, { type: 'compact_done', tokensBefore, tokensAfter, summary });
       } catch (err) {
         send(ws, { type: 'error', message: `Provider error: ${err instanceof Error ? err.message : String(err)}` });
-        return;
       }
-      const tokensBefore = estimateTokens(session.messages);
-      const summary = await summarizeWithLLM(session.messages, provider);
-      const compacted = buildCompactedHistory(summary);
-      const tokensAfter = estimateTokens(compacted);
-      session.messages = compacted;
-      session.updatedAt = new Date().toISOString();
-      await saveSession(session);
-      send(ws, { type: 'compact_done', tokensBefore, tokensAfter, summary });
       return;
     }
 

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -2,6 +2,7 @@ import { assertToolPermission } from '../core/permissions.js';
 import { checkTool, checkCommand, checkPath, PolicyViolationError } from '../core/policy.js';
 import type { DvalinContext } from '../core/context.js';
 import { emitToolAudit } from '../audit/taps.js';
+import { minimizedDescriptor } from '../audit/minimize.js';
 import { editFileTool } from './editFile.js';
 import { gitDiffTool } from './gitDiff.js';
 import { listFilesTool } from './listFiles.js';
@@ -67,7 +68,13 @@ export class ToolRegistry {
       const decision =
         target.kind === 'command' ? checkCommand(context.policy, target.value) : checkPath(context.policy, target.value);
       if (!decision.allowed) {
-        this.denyByPolicy(context, name, decision.rule, target.value);
+        this.denyByPolicy(
+          context,
+          name,
+          decision.rule,
+          target.value,
+          target.kind === 'command' ? minimizedDescriptor(target.value) : target.value,
+        );
       }
     }
 
@@ -95,8 +102,14 @@ export class ToolRegistry {
   }
 
   /** Record a policy denial in the audit trail and throw a structured error. */
-  private denyByPolicy(context: DvalinContext, tool: string, rule: string, target: string): never {
-    context.audit?.append({ type: 'policy_violation', rule, tool, target });
+  private denyByPolicy(
+    context: DvalinContext,
+    tool: string,
+    rule: string,
+    target: string,
+    auditTarget: string = target,
+  ): never {
+    context.audit?.append({ type: 'policy_violation', rule, tool, target: auditTarget });
     throw new PolicyViolationError(tool, rule, target);
   }
 }

--- a/src/tools/runCheck.ts
+++ b/src/tools/runCheck.ts
@@ -1,8 +1,10 @@
-import { spawn } from 'node:child_process';
 import { stat } from 'node:fs/promises';
 import path from 'node:path';
 import { z } from 'zod';
 import { detectScripts } from './projectScripts.js';
+import { checkCommand, PolicyViolationError } from '../core/policy.js';
+import { runGovernedProcess } from '../core/subprocessSandbox.js';
+import { minimizedDescriptor } from '../audit/minimize.js';
 import type { Tool } from './types.js';
 
 const inputSchema = z
@@ -37,7 +39,27 @@ export const runCheckTool: Tool<Input> = {
       };
     }
 
-    const result = await runProcess(picked.command, picked.args, context.cwd, input.timeoutMs);
+    const commandLine = [picked.command, ...picked.args].join(' ');
+    const commandDecision = checkCommand(context.policy, commandLine);
+    if (!commandDecision.allowed) {
+      context.audit?.append({
+        type: 'policy_violation',
+        rule: commandDecision.rule,
+        tool: 'run_check',
+        target: minimizedDescriptor(commandLine),
+      });
+      throw new PolicyViolationError('run_check', commandDecision.rule, commandLine);
+    }
+
+    const result = await runGovernedProcess({
+      command: picked.command,
+      args: picked.args,
+      cwd: context.cwd,
+      timeoutMs: input.timeoutMs,
+      policy: context.policy,
+      audit: context.audit,
+      toolName: 'run_check',
+    });
     return {
       title: `run_check ${input.kind}`,
       output: result.output || '(no output)',
@@ -45,8 +67,11 @@ export const runCheckTool: Tool<Input> = {
         kind: input.kind,
         command: picked.command,
         args: picked.args,
+        argsCount: picked.args.length,
         exitCode: result.exitCode,
         timedOut: result.timedOut,
+        sandbox: result.sandbox,
+        networkEnforcement: result.sandbox === 'none' ? 'unrestricted' : 'enforced',
       },
     };
   },
@@ -99,46 +124,6 @@ async function detectPackageManager(cwd: string): Promise<'npm' | 'pnpm' | 'yarn
   if (await exists(path.join(cwd, 'pnpm-lock.yaml'))) return 'pnpm';
   if (await exists(path.join(cwd, 'yarn.lock'))) return 'yarn';
   return 'npm';
-}
-
-function runProcess(
-  command: string,
-  args: string[],
-  cwd: string,
-  timeoutMs: number,
-): Promise<{ output: string; exitCode: number | null; timedOut: boolean }> {
-  return new Promise(resolve => {
-    const child = spawn(command, args, {
-      cwd,
-      shell: false,
-      stdio: ['ignore', 'pipe', 'pipe'],
-    });
-
-    let output = '';
-    let timedOut = false;
-    const append = (chunk: Buffer) => {
-      output += chunk.toString('utf8');
-      if (output.length > 32_000) {
-        output = `${output.slice(0, 32_000)}\n[output truncated]`;
-      }
-    };
-
-    const timer = setTimeout(() => {
-      timedOut = true;
-      child.kill('SIGTERM');
-    }, timeoutMs);
-
-    child.stdout.on('data', append);
-    child.stderr.on('data', append);
-    child.on('error', error => {
-      clearTimeout(timer);
-      resolve({ output: error.message, exitCode: 1, timedOut });
-    });
-    child.on('close', code => {
-      clearTimeout(timer);
-      resolve({ output: output.trimEnd(), exitCode: code, timedOut });
-    });
-  });
 }
 
 async function exists(filePath: string): Promise<boolean> {

--- a/src/tools/shell.ts
+++ b/src/tools/shell.ts
@@ -1,13 +1,6 @@
-import { spawn, execFile } from 'node:child_process';
-import { promisify } from 'node:util';
 import { z } from 'zod';
+import { runGovernedProcess } from '../core/subprocessSandbox.js';
 import type { Tool } from './types.js';
-
-const execAsync = promisify(execFile);
-
-async function isSandboxExecAvailable(): Promise<boolean> {
-  try { await execAsync('which', ['sandbox-exec']); return true; } catch { return false; }
-}
 
 const inputSchema = z
   .object({
@@ -27,77 +20,27 @@ export const shellTool: Tool<Input> = {
   isConcurrencySafe: () => false,
   policyTargets: input => [{ kind: 'command', value: [input.command, ...input.args].join(' ') }],
   async run(input, context) {
-    const sandboxEnabled = process.platform === 'darwin' && await isSandboxExecAvailable();
-    const result = await runProcess(input.command, input.args, context.cwd, input.timeoutMs, sandboxEnabled);
+    const result = await runGovernedProcess({
+      command: input.command,
+      args: input.args,
+      cwd: context.cwd,
+      timeoutMs: input.timeoutMs,
+      policy: context.policy,
+      audit: context.audit,
+      toolName: 'shell',
+      preferSandboxWhenUnrestricted: true,
+    });
     return {
       title: `Ran ${input.command}`,
       output: result.output || '(no output)',
       metadata: {
         command: input.command,
+        argsCount: input.args.length,
         exitCode: result.exitCode,
         timedOut: result.timedOut,
-        sandbox: sandboxEnabled ? 'seatbelt' : 'none',
+        sandbox: result.sandbox,
+        networkEnforcement: result.sandbox === 'none' ? 'unrestricted' : 'enforced',
       },
     };
   },
 };
-
-function runProcess(
-  command: string,
-  args: string[],
-  cwd: string,
-  timeoutMs: number,
-  sandboxEnabled: boolean,
-): Promise<{ output: string; exitCode: number | null; timedOut: boolean }> {
-  // On macOS, wrap in sandbox-exec to deny network access while allowing file operations
-  let spawnCommand: string;
-  let spawnArgs: string[];
-
-  if (sandboxEnabled) {
-    const profile = [
-      '(version 1)',
-      '(allow default)',
-      '(deny network*)',
-      '(allow file-read*)',
-      `(allow file-write* (subpath "${cwd}")(subpath "/tmp")(subpath "/var"))`,
-    ].join('');
-    spawnCommand = 'sandbox-exec';
-    spawnArgs = ['-p', profile, command, ...args];
-  } else {
-    spawnCommand = command;
-    spawnArgs = args;
-  }
-
-  return new Promise(resolve => {
-    const child = spawn(spawnCommand, spawnArgs, {
-      cwd,
-      shell: false,
-      stdio: ['ignore', 'pipe', 'pipe'],
-    });
-
-    let output = '';
-    let timedOut = false;
-    const append = (chunk: Buffer) => {
-      output += chunk.toString('utf8');
-      if (output.length > 32_000) {
-        output = `${output.slice(0, 32_000)}\n[output truncated]`;
-      }
-    };
-
-    const timer = setTimeout(() => {
-      timedOut = true;
-      child.kill('SIGTERM');
-    }, timeoutMs);
-
-    child.stdout.on('data', append);
-    child.stderr.on('data', append);
-    child.on('error', error => {
-      clearTimeout(timer);
-      resolve({ output: error.message, exitCode: 1, timedOut });
-    });
-    child.on('close', code => {
-      clearTimeout(timer);
-      resolve({ output: output.trimEnd(), exitCode: code, timedOut });
-    });
-  });
-}

--- a/tests/agent.test.ts
+++ b/tests/agent.test.ts
@@ -225,6 +225,8 @@ describe('AgentLoop', () => {
       expect(start.policyHash).toMatch(/^[a-f0-9]{64}$/);
       expect(start.policyHash).toBe(loaded.hash);
       expect(start.policySources).toHaveLength(loaded.sources.length);
+      expect(start.task).toContain('minimized sha256:');
+      expect(start.task).not.toBe('hi');
     }
   });
 

--- a/tests/audit/report.test.ts
+++ b/tests/audit/report.test.ts
@@ -7,6 +7,7 @@ import { renderReport, renderRecords } from '../../src/audit/report.js';
 import { createDefaultToolRegistry } from '../../src/tools/registry.js';
 import { createDvalinContext } from '../../src/core/context.js';
 import type { AuditRecord } from '../../src/audit/log.js';
+import { resolvePolicy } from '../../src/core/policy.js';
 
 let dir: string;
 
@@ -70,6 +71,7 @@ describe('registry → audit integration', () => {
 
     // The Run Report lists the changed file.
     expect(renderReport(runId, dir)).toContain('`f.txt`');
+    expect(JSON.stringify(records)).not.toContain('"content":"a\\nb\\nc"');
 
     rmSync(workspace, { recursive: true, force: true });
   });
@@ -88,7 +90,32 @@ describe('registry → audit integration', () => {
     const calls = readRecords(runId, dir).filter(r => r.type === 'tool_call') as Extract<AuditRecord, { type: 'tool_call' }>[];
     expect(calls).toHaveLength(1);
     expect(calls[0].status).toBe('error');
+    expect(calls[0].argsSummary).not.toContain('"oldString":"x"');
+    expect(calls[0].argsSummary).not.toContain('"newString":"y"');
 
+    rmSync(workspace, { recursive: true, force: true });
+  });
+
+  it('minimizes denied command targets before audit persistence', async () => {
+    const workspace = mkdtempSync(path.join(tmpdir(), 'dvalin-ws-'));
+    const runId = newRunId();
+    const sink = new AuditSink(runId, dir);
+    const registry = createDefaultToolRegistry();
+    const context = createDvalinContext({
+      cwd: workspace,
+      approvalMode: 'full-auto',
+      audit: sink,
+      policy: resolvePolicy([{ commands: { deny: ['blocked-command'] } }]),
+    });
+
+    await expect(registry.run('shell', {
+      command: 'blocked-command',
+      args: ['secret-argument'],
+    }, context)).rejects.toThrow('command matches denylist');
+
+    const serialized = JSON.stringify(readRecords(runId, dir));
+    expect(serialized).toContain('minimized sha256:');
+    expect(serialized).not.toContain('secret-argument');
     rmSync(workspace, { recursive: true, force: true });
   });
 });

--- a/tests/core/trust.test.ts
+++ b/tests/core/trust.test.ts
@@ -23,6 +23,8 @@ describe('trust report', () => {
     expect(report.policy.constrained).toBe(false);
     expect(report.version).toBeTruthy();
     expect(report.runtime.platform).toBe(process.platform);
+    expect(report.networkEnforcement.provider.status).toBe('unrestricted');
+    expect(report.networkEnforcement.runCheck.status).toBe('unrestricted');
 
     const text = renderTrustReport(report);
     expect(text).toContain('permissive');
@@ -42,11 +44,14 @@ describe('trust report', () => {
     expect(report.policy.constrained).toBe(true);
     expect(report.policy.resolved.network).toBe('endpoint-only');
     expect(report.policy.hash).toMatch(/^[a-f0-9]{64}$/);
+    expect(report.networkEnforcement.provider.status).toBe('enforced');
+    expect(report.networkEnforcement.runCheck.status).not.toBe('unrestricted');
 
     const text = renderTrustReport(report);
     expect(text).toContain('constrained');
     expect(text).toContain('endpoint-only');
     expect(text).toContain('deny: shell');
+    expect(text).toContain('configured-origin check');
   });
 
   it('flags an ignored malformed policy in the rendered report', () => {

--- a/tests/providers.test.ts
+++ b/tests/providers.test.ts
@@ -1,6 +1,22 @@
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
 import type { ChatRequest, ProviderAdapter } from '../src/providers/types.js';
 import { ProviderManager } from '../src/providers/manager.js';
+import { resolvePolicy } from '../src/core/policy.js';
+import { AuditSink, readRecords } from '../src/audit/log.js';
+
+function completionResponse(content = 'ok'): Response {
+  return new Response(JSON.stringify({
+    choices: [{ message: { content } }],
+    model: 'test-model',
+    usage: { prompt_tokens: 1, completion_tokens: 1 },
+  }), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  });
+}
 
 describe('ProviderAdapter interface', () => {
   it('defines the contract for a provider', () => {
@@ -27,9 +43,11 @@ describe('ProviderAdapter interface', () => {
   });
 
   it('openai provider rejects with invalid key', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('unauthorized', { status: 401 })));
     const mod = await import('../src/providers/openaiCompatible.js');
     const provider = mod.createOpenAICompatibleProvider({ apiKey: '000000000000000', model: 'gpt-4o' });
     await expect(provider.chat({ messages: [{ role: 'user', content: 'hi' }] })).rejects.toThrow();
+    vi.unstubAllGlobals();
   });
 
   it('openai provider exposes configured model and name', async () => {
@@ -40,6 +58,102 @@ describe('ProviderAdapter interface', () => {
       model: 'deepseek-chat',
     });
     expect(provider.name).toBe('openai-compatible');
+  });
+});
+
+describe('governed provider egress', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('blocks network: off before fetch', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+    const { createOpenAICompatibleProvider } = await import('../src/providers/openaiCompatible.js');
+    const provider = createOpenAICompatibleProvider({ baseUrl: 'https://provider.example/v1', model: 'm' });
+
+    await expect(provider.chat({
+      messages: [{ role: 'user', content: 'secret prompt' }],
+      runtime: { policy: resolvePolicy([{ network: 'off' }]) },
+    })).rejects.toThrow('network egress is disabled');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('allows the configured origin with endpoint-only', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(completionResponse());
+    vi.stubGlobal('fetch', fetchMock);
+    const { createOpenAICompatibleProvider } = await import('../src/providers/openaiCompatible.js');
+    const provider = createOpenAICompatibleProvider({ baseUrl: 'https://provider.example/v1', model: 'm' });
+
+    const response = await provider.chat({
+      messages: [{ role: 'user', content: 'hello' }],
+      runtime: { policy: resolvePolicy([{ network: 'endpoint-only' }]) },
+    });
+
+    expect(response.content).toBe('ok');
+    expect(fetchMock).toHaveBeenCalledOnce();
+  });
+
+  it('blocks a cross-origin redirect with endpoint-only', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(null, { status: 307, headers: { location: 'https://other.example/chat/completions' } }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+    const { createOpenAICompatibleProvider } = await import('../src/providers/openaiCompatible.js');
+    const provider = createOpenAICompatibleProvider({ baseUrl: 'https://provider.example/v1', model: 'm' });
+
+    await expect(provider.chat({
+      messages: [{ role: 'user', content: 'hello' }],
+      runtime: { policy: resolvePolicy([{ network: 'endpoint-only' }]) },
+    })).rejects.toThrow('configured model endpoint');
+    expect(fetchMock).toHaveBeenCalledOnce();
+  });
+
+  it('allows redirects when network policy is on', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(
+        new Response(null, { status: 307, headers: { location: 'https://other.example/chat/completions' } }),
+      )
+      .mockResolvedValueOnce(completionResponse('redirected'));
+    vi.stubGlobal('fetch', fetchMock);
+    const { createOpenAICompatibleProvider } = await import('../src/providers/openaiCompatible.js');
+    const provider = createOpenAICompatibleProvider({ baseUrl: 'https://provider.example/v1', model: 'm' });
+
+    const response = await provider.chat({
+      messages: [{ role: 'user', content: 'hello' }],
+      runtime: { policy: resolvePolicy([{ network: 'on' }]) },
+    });
+
+    expect(response.content).toBe('redirected');
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const secondInit = fetchMock.mock.calls[1][1] as RequestInit;
+    expect(new Headers(secondInit.headers).has('authorization')).toBe(false);
+  });
+
+  it('audits only minimized provider metadata', async () => {
+    const dir = mkdtempSync(path.join(tmpdir(), 'dvalin-provider-audit-'));
+    const sink = new AuditSink('provider-audit', dir);
+    const fetchMock = vi.fn().mockResolvedValue(completionResponse());
+    vi.stubGlobal('fetch', fetchMock);
+    const { createOpenAICompatibleProvider } = await import('../src/providers/openaiCompatible.js');
+    const provider = createOpenAICompatibleProvider({
+      name: 'work',
+      apiKey: 'sk-do-not-log',
+      baseUrl: 'https://provider.example/private/v1',
+      model: 'm',
+    });
+
+    await provider.chat({
+      messages: [{ role: 'user', content: 'prompt-do-not-log' }],
+      runtime: { policy: resolvePolicy([{ network: 'endpoint-only' }]), audit: sink },
+    });
+
+    const serialized = JSON.stringify(readRecords('provider-audit', dir));
+    expect(serialized).toContain('"origin":"https://provider.example"');
+    expect(serialized).not.toContain('prompt-do-not-log');
+    expect(serialized).not.toContain('sk-do-not-log');
+    expect(serialized).not.toContain('/private/v1');
+    rmSync(dir, { recursive: true, force: true });
   });
 });
 

--- a/tests/shellSandbox.test.ts
+++ b/tests/shellSandbox.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import { selectSubprocessSandbox } from '../src/core/subprocessSandbox.js';
+
+describe('shell network sandbox selection', () => {
+  it('uses Seatbelt for restricted macOS policies', () => {
+    expect(selectSubprocessSandbox('darwin', true, {
+      seatbeltPath: '/usr/bin/sandbox-exec',
+    })).toEqual({
+      allowed: true,
+      sandbox: 'seatbelt',
+      executable: '/usr/bin/sandbox-exec',
+    });
+  });
+
+  it('uses Bubblewrap for restricted Linux policies', () => {
+    expect(selectSubprocessSandbox('linux', true, { bwrapPath: '/usr/bin/bwrap' })).toEqual({
+      allowed: true,
+      sandbox: 'bwrap',
+      executable: '/usr/bin/bwrap',
+    });
+  });
+
+  it('fails closed when a restricted platform lacks a sandbox', () => {
+    expect(selectSubprocessSandbox('linux', true, {})).toMatchObject({
+      allowed: false,
+      sandbox: 'none',
+    });
+    expect(selectSubprocessSandbox('win32', true, {})).toMatchObject({
+      allowed: false,
+      sandbox: 'none',
+    });
+  });
+
+  it('preserves unrestricted behavior for network: on', () => {
+    expect(selectSubprocessSandbox('linux', false, {})).toEqual({ allowed: true, sandbox: 'none' });
+    expect(selectSubprocessSandbox('win32', false, {})).toEqual({ allowed: true, sandbox: 'none' });
+  });
+});

--- a/tests/toolsExtras.test.ts
+++ b/tests/toolsExtras.test.ts
@@ -7,6 +7,7 @@ import { createDvalinContext } from '../src/core/context.js';
 import { createDefaultToolRegistry } from '../src/tools/registry.js';
 import { projectScriptsTool } from '../src/tools/projectScripts.js';
 import { runCheckTool } from '../src/tools/runCheck.js';
+import { resolvePolicy } from '../src/core/policy.js';
 
 let tmpDir: string;
 
@@ -54,5 +55,21 @@ describe('extra tools', () => {
     expect(result.output).toContain('check ok');
     expect(result.metadata?.exitCode).toBe(0);
     expect(result.metadata?.kind).toBe('custom');
+    expect(result.metadata?.sandbox).toBe('none');
+  });
+
+  it('enforces command policy inside run_check before spawning', async () => {
+    const context = createDvalinContext({
+      cwd: tmpDir,
+      approvalMode: 'full-auto',
+      policy: resolvePolicy([{ commands: { deny: ['do-not-run'] } }]),
+    });
+
+    await expect(runCheckTool.run({
+      kind: 'custom',
+      command: 'do-not-run',
+      args: ['secret-arg'],
+      timeoutMs: 10_000,
+    }, context)).rejects.toThrow('command matches denylist');
   });
 });


### PR DESCRIPTION
## Summary

- preserve the existing `network: off | endpoint-only | on` schema, narrowing rules, and canonical policy hash
- enforce provider egress before requests and after redirects, including stripping credentials on cross-origin redirects
- route `shell` and `run_check` through a shared OS subprocess sandbox with fail-closed behavior under restricted policies
- minimize audit persistence for tasks, tool inputs, commands, and provider requests
- expose actual provider, shell, and `run_check` enforcement status in `dvalincode trust`
- document the enforced/unavailable boundary and acceptance matrix in the Governed Network v1 threat model

## Why

The policy model and `checkEgress` decision already existed, but provider HTTP and all subprocess launch paths were not consistently connected to it. Tool arguments and task text could also be persisted verbatim in audit events. This change delivers the first governance-focused vertical slice without replacing the existing policy schema or weakening its narrowing semantics.

## Impact

With no policy file, provider behavior remains unchanged. Under `endpoint-only`, the configured provider origin is allowed while cross-origin redirects are blocked. Under `off`, provider requests are blocked before `fetch`. Restricted subprocesses run only when macOS Seatbelt or Linux Bubblewrap can enforce network isolation; unsupported environments fail closed.

Audit logs now retain fingerprints and structural metadata instead of prompt, task, file-content, replacement-text, memory-content, or shell-argument bodies.

## Validation

- `npm run check` (TypeScript plus 134 Vitest tests)
- `npm run test:e2e` (Playwright 1/1)
- `npm run build`
- macOS smoke test: both `shell` and `run_check` used Seatbelt under `endpoint-only`
- live socket probe under Seatbelt returned `EPERM`
