### PR TITLE
Durable Session v1 (v0.8.1)

### DIFF
--- a/docs/DURABLE-SESSION.md
+++ b/docs/DURABLE-SESSION.md
@@ -1,0 +1,123 @@
+# Durable Session v1 Design
+
+## Scope
+
+Today a turn is only persisted once, at the very end: `runAgentTurn` calls
+`loop.processMessage(...)` and then overwrites the whole-session JSON snapshot
+(`src/sessions/store.ts`). If the process dies mid-turn, the user's input and
+any progress are lost, and there is no record that a turn was ever attempted.
+There is also no idempotency: re-submitting the same logical message runs it
+again.
+
+Durable Session v1 adds a small, demonstrable vertical slice on top of the
+existing snapshot, mirroring the audit log's append-only design:
+
+1. An append-only **session journal** (one JSONL file per session) that records
+   a turn's *intent* before it runs and its *outcome* after.
+2. **Message idempotency** keyed by a caller-supplied `messageId`.
+3. **Crash recovery**: a turn that started but never finished is detectable on
+   the next load, and the user's input is preserved rather than lost.
+4. An **audit anchor**: every turn is linked to its audit run by stable ids in
+   both directions, and the journal records the audit chain head hash as a
+   checkpoint.
+
+This version does **not** add an input queue/inbox, cross-session scheduling, a
+new storage engine (SQLite), or steering. Those are deferred (see Non-goals).
+
+## Trust boundary
+
+The journal is **session state**, the same trust level as the existing
+`<id>.json` snapshot: it may contain the user's raw message text, because
+recovering that text intact is the whole point. This is deliberately distinct
+from the **audit chain**, which is minimized (hashes, not content). The two are
+linked by ids, never by copying content across the boundary.
+
+## Storage layout
+
+```
+~/.dvalincode/sessions/<id>.json            # existing snapshot (fast load projection)
+~/.dvalincode/sessions/<id>.journal.jsonl   # new append-only journal
+```
+
+The snapshot remains the canonical fast-load view and is still written at turn
+end, so every existing reader keeps working unchanged. The journal is additive.
+
+## Journal records
+
+Append-only JSONL; each record carries `seq` and `ts`.
+
+| Record | Fields | When |
+|--------|--------|------|
+| `turn_start` | `messageId`, `content`, `cwd`, `mode` | before `loop.processMessage` |
+| `turn_end` | `messageId`, `status` (`done`/`error`/`interrupted`), `runId`, `auditHead`, `iterations` | after the turn settles (success or failure) |
+| `turn_interrupted` | `messageId`, `reason` | when recovery closes a turn that crashed before `turn_end` |
+
+`auditHead` is the audit sink's hash-chain head after `run_end` — the checkpoint
+that ties this turn to a specific, verifiable point in the audit log.
+
+## Status projection
+
+Session status is derived from the journal tail (it is not stored):
+
+- empty journal, or last record is `turn_end`/`turn_interrupted` → **idle**
+- a `turn_start` with no matching terminal record → **interrupted**
+  (observed only across process boundaries; a live in-process turn is `running`
+  in memory and never written as a dangling start)
+
+## Idempotency
+
+`messageId` is supplied by the caller. When omitted, `runAgentTurn` generates a
+fresh id per invocation, so default behavior is unchanged. A transport that
+wants safe retransmits (e.g. the WebSocket handler reusing a client message id)
+opts in by passing a stable `messageId`. Before running, `runAgentTurn` looks up
+the journal:
+
+- a `turn_end` with `status: done` for this `messageId` already exists →
+  **replay**: return the current session state with `replayed: true`, without
+  re-executing the model.
+- otherwise → run normally.
+
+A fresh, unique `messageId` (the default when none is supplied) always runs;
+idempotency only engages when a caller deliberately reuses an id (e.g. a
+retransmit after a dropped connection).
+
+## Crash recovery
+
+`recoverSession(id)` scans the journal for dangling `turn_start` records (no
+terminal record), returns them — preserving each interrupted turn's `messageId`
+and `content` — and appends a `turn_interrupted` record so the journal becomes
+consistent and the same turn is not reported as interrupted forever. The caller
+decides whether to re-run or discard; v1 surfaces them, it does not auto-resume.
+
+## Audit anchor (bidirectional link)
+
+- audit `run_start` gains an optional `sessionId` (audit → session).
+- journal `turn_end` records `runId` and `auditHead` (session → audit, plus the
+  verifiable checkpoint hash).
+
+No content crosses the boundary; only ids and a hash. `dvalincode report verify
+<runId>` still verifies the audit chain independently; the `auditHead` in the
+journal lets a reviewer confirm which audit run a given turn produced.
+
+## Acceptance matrix
+
+| Case | Expected result |
+|------|-----------------|
+| New turn, no `messageId` | Runs; journal has `turn_start` then `turn_end:done`; snapshot updated |
+| Same `messageId` after a completed turn | Replayed; model not re-invoked; `replayed: true` |
+| Turn throws/interrupted | `turn_end` recorded with `status: error`/`interrupted`, not left dangling |
+| Process crash mid-turn (no `turn_end`) | `recoverSession` returns the turn with its original input; appends `turn_interrupted` |
+| Status of a session whose last record is `turn_start` (prior process) | `interrupted` |
+| Status of a clean session | `idle` |
+| `turn_end` of a successful turn | Carries the same `runId` returned to the caller and a non-empty `auditHead` |
+| audit `run_start` for a turn | Carries the turn's `sessionId` |
+| No journal present (pre-upgrade session) | Loads from snapshot as before; first new turn starts a journal |
+| Audit chain | `verifyChain` still passes; minimization unchanged |
+
+## Non-goals (deferred)
+
+- Input queue / inbox and `steer`/`queue` semantics.
+- Automatic resume of an interrupted turn (v1 surfaces, caller decides).
+- SQLite or any new storage engine.
+- Cross-session parallelism or a run coordinator.
+- Storing model/tool intermediate state for fine-grained resume inside a turn.

--- a/docs/EGRESS-THREAT-MODEL.md
+++ b/docs/EGRESS-THREAT-MODEL.md
@@ -51,6 +51,13 @@ it does not defend against a malicious provider adapter that bypasses the
 bundled request path, DNS rebinding after validation, or another library that
 opens a socket directly.
 
+> **Forward guardrail.** Coverage is complete today only because every provider
+> funnels through the bundled OpenAI-compatible adapter and its
+> `governedProviderFetch`. Any future adapter (native Anthropic, a Responses
+> API, Bedrock, etc.) **must** route its outbound HTTP through
+> `governedProviderFetch` as well. An adapter that calls `fetch` directly is a
+> new, ungoverned egress path and must be treated as a release blocker.
+
 ### Agent-launched subprocesses
 
 A subprocess launch is not itself treated as network egress. When policy denies
@@ -71,6 +78,15 @@ requested command.
 With `network: on`, current behavior is preserved. macOS continues to use its
 existing default Seatbelt wrapper when available; other platforms may run the
 child without a network sandbox.
+
+**`shell` vs `run_check` asymmetry under `network: on`.** `shell` preserves its
+legacy default of always wrapping in Seatbelt on macOS (network denied) even
+when policy is `on`; `run_check` does not opt into that default and therefore
+runs unsandboxed under `on`. This is deliberate — `shell` is the stricter of
+the two and the difference only narrows blast radius — but it means a trust
+report can show `shell: enforced` next to `run_check: unrestricted` at the same
+`network: on` level. Under `endpoint-only` or `off` both are isolated or fail
+closed identically.
 
 ## Audit Data Policy
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dvalincode",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "A local-first, provider-neutral CLI foundation for agentic coding workflows.",
   "type": "module",
   "license": "MIT",

--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -19,6 +19,8 @@ export type AuditOptions = {
   model?: string;
   /** Resolved org policy + provenance, recorded in run_start for tamper-evidence. */
   policy?: LoadedPolicy;
+  /** Session id recorded in run_start, linking the audit chain to the session journal. */
+  sessionId?: string;
 };
 
 export type AgentLoopOptions = {
@@ -126,6 +128,7 @@ export class AgentLoop {
     let iterationsUsed = 0;
     let usage: { inputTokens: number; outputTokens: number } | undefined;
     let runId: string | undefined;
+    let auditHead: string | undefined;
 
     while (state !== TurnState.DONE) {
       switch (state) {
@@ -189,6 +192,7 @@ export class AgentLoop {
               model: this.auditOptions.model ?? 'unknown',
               cwd: this.context.cwd,
               gitHead: await resolveGitHead(this.context.cwd),
+              sessionId: this.auditOptions.sessionId,
               policyHash: this.auditOptions.policy?.hash ?? policyHash(this.context.policy),
               policySources: this.auditOptions.policy?.sources,
             });
@@ -211,6 +215,7 @@ export class AgentLoop {
             iterationsUsed = result.iterationsUsed;
             usage = result.usage;
             this.finishRun(sink, 'done', iterationsUsed, usage);
+            auditHead = sink?.head();
           } catch (err) {
             const status = err instanceof Error && err.message === 'interrupted' ? 'interrupted' : 'error';
             this.finishRun(sink, status, iterationsUsed, usage);
@@ -232,7 +237,7 @@ export class AgentLoop {
       }
     }
 
-    return { messages, output, iterationsUsed, usage, runId };
+    return { messages, output, iterationsUsed, usage, runId, auditHead };
   }
 
   /** Emit the terminal run_end event, folding in any best-effort write warnings. */

--- a/src/agent/session.ts
+++ b/src/agent/session.ts
@@ -31,6 +31,7 @@ import { ProviderPool } from '../providers/pool.js';
 import type { ProviderAdapter } from '../providers/types.js';
 import { readConfig } from '../server/configStore.js';
 import { createSession, loadSession, saveSession, summarizeSession } from '../sessions/store.js';
+import { appendJournal, completedTurn, readJournal, recoverSession } from '../sessions/journal.js';
 import { renderReport } from '../audit/report.js';
 import { renderRelevantMemory } from '../memory/store.js';
 
@@ -69,8 +70,17 @@ export type RunTurnInput = {
   codePermissionMode?: CodePermissionMode;
   /** Override the configured provider by name. */
   providerOverride?: string;
+  /**
+   * Stable id for this logical message. Reusing an id whose turn already
+   * completed replays the prior result instead of re-running the model
+   * (idempotency). Omit to always run a fresh turn.
+   */
+  messageId?: string;
   signal?: AbortSignal;
 };
+
+/** A turn that crashed before completing, surfaced on the next resume with its input intact. */
+export type RecoveredTurn = { messageId: string; content: string };
 
 export type RunTurnHooks = {
   /** Fired once the session id is known (before the LLM runs). */
@@ -90,6 +100,10 @@ export type RunTurnResult = {
   reportMarkdown?: string;
   providerId: string;
   model: string;
+  /** True when the turn was served from the journal (idempotent replay) without re-running. */
+  replayed?: boolean;
+  /** Turns that had crashed mid-execution and were closed out on this resume. */
+  recovered?: RecoveredTurn[];
 };
 
 /**
@@ -107,14 +121,19 @@ export async function runAgentTurn(input: RunTurnInput, hooks: RunTurnHooks = {}
 
   // ── Session ────────────────────────────────────────────────────────────
   let session;
+  let recovered: RecoveredTurn[] = [];
   if (input.sessionId) {
     const loaded = await loadSession(input.sessionId);
     if (!loaded) throw new Error(`Session not found: ${input.sessionId}`);
     session = loaded;
+    // Close out any turn that crashed before completing; its input is preserved.
+    recovered = recoverSession(session.id).map(t => ({ messageId: t.messageId, content: t.content }));
   } else {
     session = createSession(cwd);
   }
   hooks.onSessionId?.(session.id);
+
+  const messageId = input.messageId ?? newMessageId();
 
   // Resolve policy before selecting or calling a provider. With no policy file
   // this remains permissive and preserves existing behavior.
@@ -131,6 +150,27 @@ export async function runAgentTurn(input: RunTurnInput, hooks: RunTurnHooks = {}
   enforceRunPolicy(checkProvider(loadedPolicy.policy, providerId), 'provider', providerId);
   enforceRunPolicy(checkModel(loadedPolicy.policy, model), 'model', model);
   hooks.onProviderSelected?.(providerId, model);
+
+  // Idempotency: a turn already completed for this messageId is replayed, not re-run.
+  if (input.messageId) {
+    const prior = completedTurn(readJournal(session.id), input.messageId);
+    if (prior) {
+      return {
+        sessionId: session.id,
+        result: {
+          messages: session.messages,
+          output: '(replayed: this message was already processed)',
+          iterationsUsed: 0,
+          runId: prior.runId,
+          auditHead: prior.auditHead,
+        },
+        providerId,
+        model,
+        replayed: true,
+        recovered,
+      };
+    }
+  }
 
   // ── Prompt assembly ──────────────────────────────────────────────────────
   const userContent = await expandAtMentions(content, cwd);
@@ -164,16 +204,36 @@ export async function runAgentTurn(input: RunTurnInput, hooks: RunTurnHooks = {}
       policy: loadedPolicy.policy,
     }),
     systemPrompt,
-    audit: { model, policy: loadedPolicy },
+    audit: { model, policy: loadedPolicy, sessionId: session.id },
   });
 
-  const result = await loop.processMessage(turnMessage, session.messages, hooks.onEvent, signal);
+  // Record the turn's intent before running so a crash mid-turn is recoverable.
+  appendJournal(session.id, { type: 'turn_start', messageId, content, cwd, mode });
+
+  let result: LoopResult;
+  try {
+    result = await loop.processMessage(turnMessage, session.messages, hooks.onEvent, signal);
+  } catch (err) {
+    const status = err instanceof Error && err.message === 'interrupted' ? 'interrupted' : 'error';
+    appendJournal(session.id, { type: 'turn_end', messageId, status });
+    throw err;
+  }
 
   // ── Persist ──────────────────────────────────────────────────────────────
   session.messages = result.messages;
   session.updatedAt = new Date().toISOString();
   session.summary = summarizeSession(session);
   await saveSession(session);
+
+  // Anchor the completed turn to its audit run (runId + chain head checkpoint).
+  appendJournal(session.id, {
+    type: 'turn_end',
+    messageId,
+    status: 'done',
+    runId: result.runId,
+    auditHead: result.auditHead,
+    iterations: result.iterationsUsed,
+  });
 
   // ── Run Report (best-effort) ─────────────────────────────────────────────
   let reportMarkdown: string | undefined;
@@ -185,7 +245,12 @@ export async function runAgentTurn(input: RunTurnInput, hooks: RunTurnHooks = {}
     }
   }
 
-  return { sessionId: session.id, result, reportMarkdown, providerId, model };
+  return { sessionId: session.id, result, reportMarkdown, providerId, model, recovered };
+}
+
+/** Generate a stable-per-call message id used to key turn idempotency. */
+function newMessageId(): string {
+  return `msg_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
 }
 
 // ── Helpers ───────────────────────────────────────────────────────────────

--- a/src/agent/types.ts
+++ b/src/agent/types.ts
@@ -49,6 +49,8 @@ export type LoopResult = {
   usage?: { inputTokens: number; outputTokens: number };
   /** Audit run id for this turn, when auditing is enabled. */
   runId?: string;
+  /** Audit chain head hash after run_end — the checkpoint the session journal anchors to. */
+  auditHead?: string;
 };
 
 export type ToolResult = {

--- a/src/audit/log.ts
+++ b/src/audit/log.ts
@@ -17,6 +17,8 @@ export type AuditEvent =
       model: string;
       cwd: string;
       gitHead: string | null;
+      /** Session this run belongs to — links the audit chain back to the session journal. */
+      sessionId?: string;
       /** SHA-256 of the resolved org policy governing this run (tamper-evidence). */
       policyHash?: string;
       /** Which policy files contributed, with their hashes and any load errors. */
@@ -118,6 +120,15 @@ export class AuditSink {
   /** Warnings accumulated from failed writes — fold into the run_end event. */
   getWarnings(): string[] {
     return [...this.warnings];
+  }
+
+  /**
+   * Current hash-chain head (the `prevHash` the next record would link to). The
+   * session journal records this after run_end as a verifiable checkpoint that
+   * ties a turn to an exact point in this audit log.
+   */
+  head(): string {
+    return this.prevHash;
   }
 }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -20,7 +20,7 @@ export function buildProgram(): Command {
   program
     .name('dvalincode')
     .description('Local-first coding agent — terminal UI by default, `serve` for the web GUI')
-    .version('0.8.0');
+    .version('0.8.1');
 
   registerScanCommand(program);
   registerToolsCommand(program, registry);

--- a/src/core/trust.ts
+++ b/src/core/trust.ts
@@ -25,7 +25,7 @@ import {
  */
 
 /** Keep in lockstep with the version in src/cli.ts. */
-const VERSION = '0.8.0';
+const VERSION = '0.8.1';
 
 export type TrustReport = {
   version: string;

--- a/src/sessions/journal.ts
+++ b/src/sessions/journal.ts
@@ -1,0 +1,143 @@
+import { appendFileSync, mkdirSync, readFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { sessionsDir } from './store.js';
+
+/**
+ * Durable session journal — an append-only JSONL record of every turn's intent
+ * and outcome, one file per session (see docs/DURABLE-SESSION.md). It mirrors the
+ * audit log's append-only shape, but it is **session state**, not the audit
+ * chain: it may hold the user's raw message text so an interrupted turn can be
+ * recovered intact. It is linked to the audit chain only by ids and the audit
+ * checkpoint hash, never by copying content across that boundary.
+ */
+
+export type JournalTurnStart = {
+  type: 'turn_start';
+  messageId: string;
+  /** Raw user message — preserved so a crashed turn is not lost. */
+  content: string;
+  cwd: string;
+  mode: string;
+};
+
+export type JournalTurnEnd = {
+  type: 'turn_end';
+  messageId: string;
+  status: 'done' | 'error' | 'interrupted';
+  /** Audit run this turn produced, if any. */
+  runId?: string;
+  /** Audit chain head hash after run_end — the checkpoint anchor. */
+  auditHead?: string;
+  iterations?: number;
+};
+
+export type JournalTurnInterrupted = {
+  type: 'turn_interrupted';
+  messageId: string;
+  reason: string;
+};
+
+export type JournalEvent = JournalTurnStart | JournalTurnEnd | JournalTurnInterrupted;
+
+/** A persisted journal record: an event plus ordering metadata. */
+export type JournalRecord = JournalEvent & { seq: number; ts: string };
+
+/** Status derived from the journal tail. `running` is in-memory only and never persisted. */
+export type SessionStatus = 'idle' | 'interrupted';
+
+function journalPath(sessionId: string, dir: string = sessionsDir()): string {
+  return join(dir, `${sessionId}.journal.jsonl`);
+}
+
+/** Read a session's journal, oldest record first. Returns [] when absent or unreadable. */
+export function readJournal(sessionId: string, dir: string = sessionsDir()): JournalRecord[] {
+  const file = journalPath(sessionId, dir);
+  if (!existsSync(file)) return [];
+  let text: string;
+  try {
+    text = readFileSync(file, 'utf8');
+  } catch {
+    return [];
+  }
+  const records: JournalRecord[] = [];
+  for (const line of text.split('\n')) {
+    if (!line.trim()) continue;
+    try {
+      records.push(JSON.parse(line) as JournalRecord);
+    } catch {
+      // Skip a corrupt line rather than failing the whole read.
+    }
+  }
+  return records;
+}
+
+/**
+ * Append one event to a session's journal. Best-effort and never throws — a
+ * failed write must not break the turn (it degrades durability, like the audit
+ * sink). The next `seq` is derived from the existing record count.
+ */
+export function appendJournal(sessionId: string, event: JournalEvent, dir: string = sessionsDir()): void {
+  try {
+    mkdirSync(dir, { recursive: true });
+    const seq = readJournal(sessionId, dir).length;
+    const record: JournalRecord = { ...event, seq, ts: new Date().toISOString() } as JournalRecord;
+    appendFileSync(journalPath(sessionId, dir), JSON.stringify(record) + '\n', 'utf8');
+  } catch {
+    // Durability is best-effort; the snapshot remains the canonical projection.
+  }
+}
+
+/** Message ids that have reached a terminal record (turn_end or turn_interrupted). */
+function closedMessageIds(records: JournalRecord[]): Set<string> {
+  const closed = new Set<string>();
+  for (const r of records) {
+    if (r.type === 'turn_end' || r.type === 'turn_interrupted') closed.add(r.messageId);
+  }
+  return closed;
+}
+
+/** The successful `turn_end` for a message id, if the turn already completed. */
+export function completedTurn(records: JournalRecord[], messageId: string): JournalTurnEnd | undefined {
+  return records.find(
+    (r): r is JournalTurnEnd & { seq: number; ts: string } =>
+      r.type === 'turn_end' && r.messageId === messageId && r.status === 'done',
+  );
+}
+
+/** Turn starts that never reached a terminal record — i.e. crashed mid-turn. */
+export function danglingTurns(records: JournalRecord[]): JournalTurnStart[] {
+  const closed = closedMessageIds(records);
+  const seen = new Set<string>();
+  const dangling: JournalTurnStart[] = [];
+  for (const r of records) {
+    if (r.type !== 'turn_start') continue;
+    if (closed.has(r.messageId) || seen.has(r.messageId)) continue;
+    seen.add(r.messageId);
+    dangling.push(r);
+  }
+  return dangling;
+}
+
+/** Derive session status from its journal. */
+export function projectStatus(records: JournalRecord[]): SessionStatus {
+  return danglingTurns(records).length > 0 ? 'interrupted' : 'idle';
+}
+
+/**
+ * Close out any turn that started but never finished (a hard crash before
+ * `turn_end`). Returns the dangling turns — with their original `messageId` and
+ * `content` preserved — so the caller can choose to re-run or discard. Appends a
+ * `turn_interrupted` record for each so the journal becomes consistent and the
+ * same turn is not reported as interrupted forever.
+ */
+export function recoverSession(sessionId: string, dir: string = sessionsDir()): JournalTurnStart[] {
+  const dangling = danglingTurns(readJournal(sessionId, dir));
+  for (const turn of dangling) {
+    appendJournal(
+      sessionId,
+      { type: 'turn_interrupted', messageId: turn.messageId, reason: 'no turn_end on load (process ended mid-turn)' },
+      dir,
+    );
+  }
+  return dangling;
+}

--- a/src/sessions/store.ts
+++ b/src/sessions/store.ts
@@ -26,8 +26,13 @@ export type Session = {
 
 const STORE_VERSION = 2;
 
+/** Sessions directory: ~/.dvalincode/sessions (overridable for tests). */
+export function sessionsDir(): string {
+  return process.env.DVALINCODE_SESSIONS_DIR ?? join(homedir(), '.dvalincode', 'sessions');
+}
+
 function sessionDir(): string {
-  return join(homedir(), '.dvalincode', 'sessions');
+  return sessionsDir();
 }
 
 export async function ensureSessionDir(): Promise<string> {

--- a/tests/agent.test.ts
+++ b/tests/agent.test.ts
@@ -230,6 +230,30 @@ describe('AgentLoop', () => {
     }
   });
 
+  it('records sessionId in run_start and returns an audit checkpoint head', async () => {
+    const { AgentLoop } = await import('../src/agent/loop.js');
+    const { readRecords } = await import('../src/audit/log.js');
+
+    const dir = mkdtempSync(path.join(tmpdir(), 'dvalin-anchor-'));
+    const registry = new ToolRegistry();
+    registry.register(createEchoTool());
+    const loop = new AgentLoop({
+      provider: createEchoProvider('done'),
+      registry,
+      context: createDvalinContext(),
+      systemPrompt: 'x',
+      audit: { dir, model: 'm', sessionId: 'dc_sess_42' },
+    });
+
+    const result = await loop.processMessage('hi', []);
+
+    // The audit chain head is returned so the session journal can anchor to it.
+    expect(result.auditHead).toMatch(/^[a-f0-9]{64}$/);
+    const records = readRecords(result.runId!, dir);
+    const start = records.find(r => r.type === 'run_start');
+    expect(start && start.type === 'run_start' ? start.sessionId : undefined).toBe('dc_sess_42');
+  });
+
   it("AgentLoop's /compact command reduces message count", async () => {
     const { AgentLoop } = await import('../src/agent/loop.js');
     const provider = createEchoProvider('dummy');

--- a/tests/sessions/journal.test.ts
+++ b/tests/sessions/journal.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  appendJournal,
+  completedTurn,
+  danglingTurns,
+  projectStatus,
+  readJournal,
+  recoverSession,
+} from '../../src/sessions/journal.js';
+
+describe('session journal', () => {
+  let dir: string;
+  const sid = 'dc_test_session';
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'dc-journal-'));
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('appends and reads records in order with monotonic seq', () => {
+    appendJournal(sid, { type: 'turn_start', messageId: 'm1', content: 'hi', cwd: '/w', mode: 'chat' }, dir);
+    appendJournal(sid, { type: 'turn_end', messageId: 'm1', status: 'done', runId: 'r1', auditHead: 'abc', iterations: 2 }, dir);
+    const records = readJournal(sid, dir);
+    expect(records.map(r => r.seq)).toEqual([0, 1]);
+    expect(records[0].type).toBe('turn_start');
+    expect(records[1].type).toBe('turn_end');
+  });
+
+  it('reports idle when the last turn completed', () => {
+    appendJournal(sid, { type: 'turn_start', messageId: 'm1', content: 'hi', cwd: '/w', mode: 'chat' }, dir);
+    appendJournal(sid, { type: 'turn_end', messageId: 'm1', status: 'done', runId: 'r1' }, dir);
+    expect(projectStatus(readJournal(sid, dir))).toBe('idle');
+    expect(danglingTurns(readJournal(sid, dir))).toEqual([]);
+  });
+
+  it('detects an interrupted turn and preserves its input', () => {
+    appendJournal(sid, { type: 'turn_start', messageId: 'm1', content: 'do the thing', cwd: '/w', mode: 'code' }, dir);
+    // process dies — no turn_end is written
+    const records = readJournal(sid, dir);
+    expect(projectStatus(records)).toBe('interrupted');
+    const dangling = danglingTurns(records);
+    expect(dangling).toHaveLength(1);
+    expect(dangling[0].content).toBe('do the thing');
+  });
+
+  it('recoverSession returns the dangling turn and closes it', () => {
+    appendJournal(sid, { type: 'turn_start', messageId: 'm1', content: 'lost work', cwd: '/w', mode: 'chat' }, dir);
+    const recovered = recoverSession(sid, dir);
+    expect(recovered).toHaveLength(1);
+    expect(recovered[0].messageId).toBe('m1');
+    // After recovery the journal is consistent: no longer interrupted, idempotent on re-run.
+    const after = readJournal(sid, dir);
+    expect(projectStatus(after)).toBe('idle');
+    expect(after.at(-1)?.type).toBe('turn_interrupted');
+    expect(recoverSession(sid, dir)).toEqual([]);
+  });
+
+  it('completedTurn enables idempotent replay only for finished turns', () => {
+    appendJournal(sid, { type: 'turn_start', messageId: 'm1', content: 'hi', cwd: '/w', mode: 'chat' }, dir);
+    expect(completedTurn(readJournal(sid, dir), 'm1')).toBeUndefined();
+    appendJournal(sid, { type: 'turn_end', messageId: 'm1', status: 'done', runId: 'r1', auditHead: 'h1' }, dir);
+    const hit = completedTurn(readJournal(sid, dir), 'm1');
+    expect(hit?.runId).toBe('r1');
+    expect(completedTurn(readJournal(sid, dir), 'other')).toBeUndefined();
+  });
+
+  it('an errored turn is terminal, not dangling, and not replayable', () => {
+    appendJournal(sid, { type: 'turn_start', messageId: 'm1', content: 'boom', cwd: '/w', mode: 'chat' }, dir);
+    appendJournal(sid, { type: 'turn_end', messageId: 'm1', status: 'error', runId: 'r1' }, dir);
+    const records = readJournal(sid, dir);
+    expect(projectStatus(records)).toBe('idle');
+    expect(completedTurn(records, 'm1')).toBeUndefined();
+  });
+
+  it('returns empty for a session with no journal', () => {
+    expect(readJournal('missing', dir)).toEqual([]);
+    expect(projectStatus(readJournal('missing', dir))).toBe('idle');
+  });
+});


### PR DESCRIPTION
Append-only session journal on top of the existing snapshot, plus the version bump to **0.8.1**. Builds on the Governed Network v1 work already merged via #32. All 142 tests pass; `tsc` clean.

## Durable Session v1
The snapshot stays canonical; the journal is additive (one JSONL per session).

- **Crash recovery**: a turn that started but never finished is detected on resume with its input preserved, then closed out (`turn_interrupted`).
- **Idempotent replay**: reusing a `messageId` whose turn already completed returns the prior result instead of re-running the model. Omitting `messageId` (default) always runs — behavior unchanged.
- **Audit anchor** (bidirectional, ids + hash only, no content crosses the boundary): audit `run_start` carries `sessionId`; journal `turn_end` records `runId` + the audit chain head checkpoint (new `AuditSink.head()`).
- Trust boundary kept distinct: the journal is *session state* (may hold raw input, same level as the snapshot), separate from the *minimized audit chain*.
- Design + acceptance matrix: `docs/DURABLE-SESSION.md`. Queue/inbox, auto-resume, and SQLite are explicit non-goals (deferred).

Also closes out two Governed Network v1 doc notes (`docs/EGRESS-THREAT-MODEL.md`): the forward guardrail that future provider adapters must route through `governedProviderFetch`, and the `shell`/`run_check` sandbox asymmetry under `network: on`.

## Verification
- `npm run check` (typecheck + tests): **142 passed** (+8: 7 journal unit tests, 1 loop-level audit-anchor test).
- Runtime smoke test confirmed the journal cycle end-to-end on the compiled build: crash → `interrupted` → recover (input preserved) → `idle`; completed turn exposes idempotent replay with `runId` + anchored `auditHead`.

## Follow-ups (out of scope here)
- Transports don't yet pass a stable `messageId` or surface `recovered` turns in the UI — durability is real at the engine level; wiring the WebSocket handler + UI is the next increment.
- GitHub Release `v0.8.1` / `gui-v0.8.1` to be tagged on `main` after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)