### PR TITLE
[codex] Add OpenSSF and ISO 42001 governance docs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default reviewers for security, release, and governance-sensitive changes.
+* @arthurpanhku

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -8,3 +8,6 @@
 
 ## Environment
 
+## Security / AI Governance Impact
+
+Does this involve agent permissions, model/provider behavior, data exposure, audit logs, or release/build security?

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,5 +2,10 @@
 
 ## Testing
 
-## Notes
+## Security and AI Governance
 
+- [ ] This change does not expand file, shell, network, model, or approval permissions.
+- [ ] If it changes agent behavior, prompts, policy, providers, audit logging, or release/build security, I updated the relevant governance evidence in `docs/`.
+- [ ] If it introduces a new model/provider/tool or new data flow, I completed `docs/governance/AI-CHANGE-IMPACT-ASSESSMENT.md`.
+
+## Notes

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,45 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: '09:00'
+      timezone: Asia/Hong_Kong
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - security
+    groups:
+      node-runtime:
+        patterns:
+          - '*'
+
+  - package-ecosystem: npm
+    directory: /web
+    schedule:
+      interval: weekly
+      day: monday
+      time: '09:30'
+      timezone: Asia/Hong_Kong
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - security
+    groups:
+      web-runtime:
+        patterns:
+          - '*'
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: '10:00'
+      timezone: Asia/Hong_Kong
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - security

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,12 +5,19 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      # actions/checkout v7.0.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
+      # actions/setup-node v6.4.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version: 22
           cache: npm

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,37 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  schedule:
+    - cron: '17 4 * * 2'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze JavaScript and TypeScript
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      # actions/checkout v7.0.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
+
+      - name: Initialize CodeQL
+        # github/codeql-action/init v4.36.2
+        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e
+        with:
+          languages: javascript-typescript
+
+      - name: Perform CodeQL analysis
+        # github/codeql-action/analyze v4.36.2
+        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e
+        with:
+          category: '/language:javascript-typescript'

--- a/.github/workflows/release-gui.yml
+++ b/.github/workflows/release-gui.yml
@@ -41,10 +41,12 @@ jobs:
       HAS_NOTARY_CREDS: ${{ secrets.APPLE_ID != '' }}
 
     steps:
-      - uses: actions/checkout@v4
+      # actions/checkout v7.0.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        # actions/setup-node v6.4.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version: 22
           cache: npm
@@ -59,7 +61,8 @@ jobs:
         run: npm run check
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        # oven-sh/setup-bun v2.2.0
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
         with:
           bun-version: latest
 
@@ -118,7 +121,8 @@ jobs:
         run: ls -lh release-gui/
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        # actions/upload-artifact v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: dvalincode-gui-${{ github.sha }}
           path: release-gui/*
@@ -127,7 +131,8 @@ jobs:
       # ── Publish as a PRE-RELEASE (tag push only) ─────────────────
       - name: Publish GitHub pre-release
         if: startsWith(github.ref, 'refs/tags/')
-        uses: softprops/action-gh-release@v2
+        # softprops/action-gh-release v3.0.1
+        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b
         with:
           prerelease: true
           generate_release_notes: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,10 +50,12 @@ jobs:
       HAS_NOTARY_CREDS: ${{ secrets.APPLE_ID != '' }}
 
     steps:
-      - uses: actions/checkout@v4
+      # actions/checkout v7.0.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        # actions/setup-node v6.4.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version: 22
           cache: npm
@@ -68,7 +70,8 @@ jobs:
         run: npm run check
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        # oven-sh/setup-bun v2.2.0
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
         with:
           bun-version: latest
 
@@ -126,7 +129,8 @@ jobs:
       # Always upload the archives so they can be downloaded and inspected
       # before a tag is pushed (manual run) and kept as a record (tag run).
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        # actions/upload-artifact v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: dvalincode-cli-${{ github.sha }}
           path: release/*
@@ -135,7 +139,8 @@ jobs:
       # ── Publish GitHub Release (tag push only) ───────────────────
       - name: Publish GitHub Release
         if: startsWith(github.ref, 'refs/tags/')
-        uses: softprops/action-gh-release@v2
+        # softprops/action-gh-release v3.0.1
+        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b
         with:
           generate_release_notes: true
           files: |

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,49 @@
+name: OpenSSF Scorecard
+
+on:
+  branch_protection_rule:
+  push:
+    branches: [main]
+  schedule:
+    - cron: '23 3 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+      id-token: write
+    steps:
+      # actions/checkout v7.0.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
+
+      - name: Run OpenSSF Scorecard
+        # ossf/scorecard-action v2.4.3
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a
+        with:
+          results_file: scorecard-results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload Scorecard SARIF
+        # github/codeql-action/upload-sarif v4.36.2
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e
+        with:
+          sarif_file: scorecard-results.sarif
+
+      - name: Upload Scorecard artifact
+        # actions/upload-artifact v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: openssf-scorecard-${{ github.sha }}
+          path: scorecard-results.sarif
+          if-no-files-found: error
+          retention-days: 7

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
   <a href="https://github.com/arthurpanhku/dvalincode/releases"><img src="https://img.shields.io/github/downloads/arthurpanhku/dvalincode/total?style=for-the-badge&color=blue&label=Downloads" alt="Downloads"></a>
   <a href="#-tests"><img src="https://img.shields.io/badge/Tests-95%20%2F%2095%20%E2%9C%93-success?style=for-the-badge" alt="Tests"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-green?style=for-the-badge" alt="License"></a>
+  <a href="https://scorecard.dev/viewer/?uri=github.com/arthurpanhku/dvalincode"><img src="https://api.scorecard.dev/projects/github.com/arthurpanhku/dvalincode/badge" alt="OpenSSF Scorecard"></a>
   <a href="#-quick-install"><img src="https://img.shields.io/badge/Platforms-macOS%20·%20Windows%20·%20Linux-blue?style=for-the-badge" alt="Platforms"></a>
   <a href="#-providers"><img src="https://img.shields.io/badge/LLM-OpenAI%20·%20Claude%20·%20DeepSeek%20·%20Ollama%20·%20Groq-7C3AED?style=for-the-badge" alt="LLM Support"></a>
   <a href="README.zh-CN.md"><img src="https://img.shields.io/badge/i18n-EN%20·%20中文-orange?style=for-the-badge" alt="English / 中文"></a>
@@ -37,6 +38,7 @@
 <tr><td><b>⚡ Code mode</b></td><td>Autonomous agent with full tool access. Run tests, type-check, build, lint — one click via the <b>Routines</b> panel. macOS shell calls run inside a <code>sandbox-exec</code> profile with network denied.</td></tr>
 <tr><td><b>🛡️ Audit trail</b></td><td>Every run emits a tamper-evident, hash-chained JSONL log — every file read/written, every command, every approval. A Run Report renders it as Markdown; <code>dvalincode report verify</code> proves the chain is intact. <a href="docs/AUDIT-TRAIL.md">Threat model →</a></td></tr>
 <tr><td><b>🔒 Org policy &amp; <code>trust</code></b></td><td>A company — not the developer — bounds the agent. A <code>dvalin.policy.json</code> constrains modes, shell commands, file paths, tools, and models; a repo policy can only ever <i>narrow</i> the machine-level one, never widen it. Each run records the governing policy's hash. <code>dvalincode trust</code> prints the install's live security posture — active policy + hashes, audit status, runtime — so a reviewer can verify it directly. <a href="docs/APPROVABILITY-PLAN.md">Approvability plan →</a></td></tr>
+<tr><td><b>🏛️ Governance evidence</b></td><td>OpenSSF Scorecard, CodeQL, Dependabot, pinned GitHub Actions, CODEOWNERS, and ISO/IEC 42001 AIMS alignment docs are maintained as reviewable project evidence. <a href="docs/security/OPENSSF-SCORECARD.md">Scorecard map →</a> · <a href="docs/governance/ISO-42001-AIMS.md">ISO 42001 alignment →</a></td></tr>
 <tr><td><b>🖥️ First-class GUI</b></td><td>Modern web UI with code highlighting, file <code>@</code>-references, <code>/</code> slash commands, Git branch indicator, live token + cost counter, multi-profile LLM config, and a dark / light / system theme switcher.</td></tr>
 <tr><td><b>🖥️ Terminal or web — one binary</b></td><td>Run it bare for an interactive <b>terminal agent</b> (like Claude Code — streaming, inline approvals, red/green diffs), or <code>dvalincode serve</code> to host the <b>web GUI</b> for browser/remote use. Both frontends drive the same agent core.</td></tr>
 <tr><td><b>🪶 Zero-dependency binary</b></td><td>Single ~25MB executable per platform. No Node, no Python, no Docker.</td></tr>
@@ -59,6 +61,26 @@ DvalinCode is built as an **agent runtime**, not just another agent app:
 - **Approvable by any company** — governance is built in, not bolted on. An org policy bounds the blast radius (**可控 / controllable**), `dvalincode trust` makes the posture self-verifiable (**透明 / transparent**), and the hash-chained log proves what every run did (**可审计 / auditable**). Those three together are exactly what a security review needs to say yes — and what cloud, closed, mutable-log agents structurally can't offer. [Approvability plan →](docs/APPROVABILITY-PLAN.md)
 
 The bundled **web GUI is the runtime's reference implementation and showcase** — the first consumer of that public API, demonstrating everything the runtime can do.
+
+---
+
+## 🛡️ Security & Governance
+
+DvalinCode now maintains project-level governance evidence for open-source and
+enterprise review:
+
+- **OpenSSF Scorecard support** — scheduled Scorecard workflow, SARIF upload,
+  CodeQL, Dependabot, CODEOWNERS, least-privilege workflow permissions, and
+  SHA-pinned GitHub Actions. [Control map →](docs/security/OPENSSF-SCORECARD.md)
+- **ISO/IEC 42001 alignment** — an AI management system scope, AI policy, role
+  map, risk register, AI change classification, required records, and review
+  cadence. [AIMS alignment →](docs/governance/ISO-42001-AIMS.md)
+- **AI change impact assessment** — a reusable template for changes that affect
+  model/provider behavior, prompts, permissions, tools, audit logs, or release
+  security. [Template →](docs/governance/AI-CHANGE-IMPACT-ASSESSMENT.md)
+
+These documents are implementation evidence and operating procedures; they do
+not claim third-party ISO certification.
 
 ---
 
@@ -215,6 +237,7 @@ Both share the same config and sessions in `~/.dvalincode/`.
 | **Modes** | Chat / Cowork / Code | Each with a distinct sidebar (Templates / Projects / Routines) and tool-access policy |
 | **Code permissions** | Ask Permissions / Plan Mode / Auto Mode / Bypass permissions | Verified behavior: Ask requests approval before writes/commands, Plan is read-only and does not write files, Auto runs operations automatically, Bypass runs without confirmation prompts |
 | **Workspaces** | Open folder / Import Git / Add worktree | Cowork and Code can switch to a local folder, clone a Git project, or create a Git worktree from the UI |
+| **Governance** | OpenSSF Scorecard / ISO 42001 AIMS alignment | Scorecard, CodeQL, Dependabot, pinned Actions, AI impact assessment, risk register, and review cadence are documented under `docs/security/` and `docs/governance/` |
 | **Composer** | `@` file references | Type `@` for a fuzzy file search; selected files get inlined into the prompt |
 | | `/` slash commands | `/clear` `/compact` `/git` `/plan` `/undo` `/help` |
 | | Multiline + interrupt | <kbd>Shift</kbd>+<kbd>Enter</kbd> for newline, stop button to abort mid-stream |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -11,6 +11,7 @@
   <a href="https://github.com/arthurpanhku/dvalincode/releases"><img src="https://img.shields.io/github/downloads/arthurpanhku/dvalincode/total?style=for-the-badge&color=blue&label=Downloads" alt="Downloads"></a>
   <a href="#-测试"><img src="https://img.shields.io/badge/Tests-95%20%2F%2095%20%E2%9C%93-success?style=for-the-badge" alt="Tests"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-green?style=for-the-badge" alt="License"></a>
+  <a href="https://scorecard.dev/viewer/?uri=github.com/arthurpanhku/dvalincode"><img src="https://api.scorecard.dev/projects/github.com/arthurpanhku/dvalincode/badge" alt="OpenSSF Scorecard"></a>
   <a href="#-一行安装"><img src="https://img.shields.io/badge/Platforms-macOS%20·%20Windows%20·%20Linux-blue?style=for-the-badge" alt="Platforms"></a>
   <a href="#-providers"><img src="https://img.shields.io/badge/LLM-OpenAI%20·%20Claude%20·%20DeepSeek%20·%20Ollama%20·%20Groq-7C3AED?style=for-the-badge" alt="LLM Support"></a>
   <a href="README.md"><img src="https://img.shields.io/badge/i18n-EN%20·%20中文-orange?style=for-the-badge" alt="English / 中文"></a>
@@ -37,6 +38,7 @@
 <tr><td><b>⚡ Code 模式</b></td><td>自主代理，全工具权限。一键运行测试、类型检查、构建、Lint（侧栏 <b>Routines</b> 面板）。macOS shell 调用在 <code>sandbox-exec</code> 沙箱内执行，网络被禁用。</td></tr>
 <tr><td><b>🛡️ 审计日志</b></td><td>每次运行都生成防篡改、哈希链式的 JSONL 日志 —— 每次文件读写、每条命令、每次审批都被记录。Run Report 将其渲染为 Markdown；<code>dvalincode report verify</code> 可验证链条完好。<a href="docs/AUDIT-TRAIL.md">威胁模型 →</a></td></tr>
 <tr><td><b>🔒 组织级策略 &amp; <code>trust</code></b></td><td>由公司、而非开发者来约束 Agent。一个 <code>dvalin.policy.json</code> 限定模式、shell 命令、文件路径、工具与模型；仓库级策略只能让机器级策略<i>更严</i>、永不放宽。每次运行都记录所遵循策略的哈希。<code>dvalincode trust</code> 直接打印本机的实时安全态势 —— 生效策略 + 哈希、审计状态、运行时 —— 让审批人自行核验。<a href="docs/APPROVABILITY-PLAN.md">可审批性方案 →</a></td></tr>
+<tr><td><b>🏛️ 治理证据</b></td><td>仓库维护 OpenSSF Scorecard、CodeQL、Dependabot、固定 SHA 的 GitHub Actions、CODEOWNERS，以及 ISO/IEC 42001 AIMS 对齐文档，作为可审查的项目治理证据。<a href="docs/security/OPENSSF-SCORECARD.md">Scorecard 映射 →</a> · <a href="docs/governance/ISO-42001-AIMS.md">ISO 42001 对齐 →</a></td></tr>
 <tr><td><b>🖥️ 一流的 GUI</b></td><td>现代化 Web UI，包含代码语法高亮、<code>@</code> 文件引用、<code>/</code> 斜杠命令、Git 分支显示、实时 Token 与费用统计、多 LLM Profile，以及暗色 / 浅色 / 跟随系统的主题切换。</td></tr>
 <tr><td><b>🖥️ 终端或 Web，同一个二进制</b></td><td>直接运行进入交互式<b>终端代理</b>（像 Claude Code —— 流式输出、行内审批、红绿 diff）；或 <code>dvalincode serve</code> 启动 <b>Web GUI</b> 供浏览器/远程使用。两个前端共用同一套 agent 内核。</td></tr>
 <tr><td><b>🪶 零依赖二进制</b></td><td>每平台单文件可执行程序 ~25MB。无需 Node、Python、Docker。</td></tr>
@@ -59,6 +61,22 @@ DvalinCode 的定位是 **Agent 运行时（runtime）**，而不只是又一个
 - **任何公司都能批准** —— 治理是内建的，而非事后附加：组织级策略约束影响面（**可控**），`dvalincode trust` 让安全态势可自证（**透明**），哈希链日志证明每次运行做了什么（**可审计**）。这三者正是安全评审说"yes"所需要的 —— 也是上云、闭源、日志可改的 Agent 在结构上给不了的。[可审批性方案 →](docs/APPROVABILITY-PLAN.md)
 
 自带的 **Web GUI 是这个运行时的参考实现与展示窗** —— 它是这套公开 API 的第一个消费者，演示运行时的全部能力。
+
+---
+
+## 🛡️ 安全与治理
+
+DvalinCode 现在维护项目级治理证据，便于开源用户和企业安全评审：
+
+- **OpenSSF Scorecard 支持** —— 定时 Scorecard workflow、SARIF 上传、
+  CodeQL、Dependabot、CODEOWNERS、最小权限 workflow permissions，以及固定
+  SHA 的 GitHub Actions。[控制映射 →](docs/security/OPENSSF-SCORECARD.md)
+- **ISO/IEC 42001 对齐** —— AI 管理体系范围、AI policy、角色映射、风险登记、
+  AI 变更分级、必留记录和审查节奏。[AIMS 对齐 →](docs/governance/ISO-42001-AIMS.md)
+- **AI 变更影响评估** —— 面向模型/provider 行为、prompt、权限、工具、审计日志
+  或发布安全变更的可复用模板。[模板 →](docs/governance/AI-CHANGE-IMPACT-ASSESSMENT.md)
+
+这些文档是实现证据和运行流程，不代表项目已经获得第三方 ISO 认证。
 
 ---
 
@@ -215,6 +233,7 @@ dvalincode serve --host 0.0.0.0 --no-open   # 部署到服务器，供远程/浏
 | **模式** | Chat / Cowork / Code | 各自独立的侧边栏（Templates / Projects / Routines）与工具权限策略 |
 | **Code 权限** | Ask Permissions / Plan Mode / Auto Mode / Bypass permissions | 已验证行为：Ask 在写入/命令前请求批准，Plan 只读且不写文件，Auto 自动执行操作，Bypass 不再弹出确认 |
 | **工作区** | 打开文件夹 / 导入 Git / 添加 worktree | Cowork 与 Code 可在 UI 中切换到本地文件夹、克隆 Git 项目，或创建 Git worktree |
+| **治理** | OpenSSF Scorecard / ISO 42001 AIMS 对齐 | Scorecard、CodeQL、Dependabot、固定 SHA 的 Actions、AI 影响评估、风险登记和审查节奏记录在 `docs/security/` 与 `docs/governance/` |
 | **输入框** | `@` 文件引用 | 输入 `@` 触发模糊文件搜索，选中文件自动插入到 prompt |
 | | `/` 斜杠命令 | `/clear` `/compact` `/git` `/plan` `/undo` `/help` |
 | | 多行输入 + 中断 | <kbd>Shift</kbd>+<kbd>Enter</kbd> 换行，Stop 按钮中断生成 |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,6 +14,24 @@ For sensitive issues, contact the repository owner privately through GitHub.
 - File access should remain inside the active workspace.
 - Process execution must require explicit permission.
 - Future provider adapters should treat model output as untrusted input.
+- GitHub Actions must use least-privilege `permissions` and pinned action SHAs.
+- Security-sensitive pull requests should document their approval, audit, privacy,
+  and model/provider impact.
+
+## Supply Chain Baseline
+
+DvalinCode maintains an OpenSSF Scorecard workflow, CodeQL analysis, Dependabot
+updates, CODEOWNERS review routing, and SHA-pinned GitHub Actions. See
+[docs/security/OPENSSF-SCORECARD.md](docs/security/OPENSSF-SCORECARD.md) for
+the current control map and the GitHub repository settings that must be enabled
+outside the git tree.
+
+## AI Governance Baseline
+
+AI governance evidence is tracked under `docs/governance/`, including ISO/IEC
+42001 AIMS alignment and an AI change impact assessment template. These
+documents are project governance artifacts; they do not claim third-party ISO
+certification.
 
 ## Audit Trail
 
@@ -22,4 +40,3 @@ Every agent run emits a tamper-evident, hash-chained JSONL log under
 post-hoc forensics and accountability, not cryptographic custody against a local
 root attacker. See [docs/AUDIT-TRAIL.md](docs/AUDIT-TRAIL.md) for the format and
 full threat model. Verify a run's chain with `dvalincode report verify <run-id>`.
-

--- a/docs/governance/AI-CHANGE-IMPACT-ASSESSMENT.md
+++ b/docs/governance/AI-CHANGE-IMPACT-ASSESSMENT.md
@@ -1,0 +1,86 @@
+# AI Change Impact Assessment
+
+Use this template for high-risk AI/system changes, including changes to:
+
+- Agent permissions, approval modes, shell/file/network tools, or policy
+  enforcement.
+- Prompt behavior, context selection, model/provider defaults, or provider
+  request handling.
+- Audit logs, report generation, data minimization, or release security.
+
+Copy the template into the pull request description or into a dated file under
+`docs/governance/assessments/` when the assessment needs to be retained as a
+standalone record.
+
+## Change Summary
+
+- PR / issue:
+- Owner:
+- Date:
+- Change class: A2 / A3
+- Components changed:
+
+## Intended Use
+
+- What user workflow does this change support?
+- Which modes are affected: Chat / Cowork / Code / terminal / web / server?
+- Does the change alter default behavior?
+
+## Stakeholders
+
+- Maintainer:
+- User or organization admin:
+- Security reviewer:
+- Affected third-party providers:
+
+## Data and Privacy
+
+- What user data can be read, transformed, stored, or sent to a provider?
+- Are prompts, provider responses, file contents, API keys, or secrets stored?
+- Does `.dvalincodeignore` or policy enforcement still apply?
+- Does audit logging remain minimized?
+
+## Autonomy and Permission Impact
+
+- Does the change expand file write, delete, shell, network, model, or tool
+  access?
+- Does it change when user approval is required?
+- Does it change Plan/Ask/Auto/Bypass behavior?
+- What prevents prompt injection from escalating permissions?
+
+## Model and Supplier Impact
+
+- Are new model providers, endpoints, SDKs, or hosted services introduced?
+- Are provider requests routed through the governed egress path?
+- Are provider errors, rate limits, and retries safe and observable?
+
+## Security and Supply Chain
+
+- Are dependencies added or updated?
+- Are GitHub Actions pinned to commit SHAs?
+- Do CI, CodeQL, Scorecard, and release verification still run?
+- Are new secrets required? If yes, where are they stored and scoped?
+
+## Testing and Evidence
+
+- Unit tests:
+- Integration or e2e tests:
+- Manual verification:
+- Audit/report verification:
+- Screenshots or logs:
+
+## Residual Risk
+
+- Remaining risks:
+- Accepted exceptions:
+- Owner:
+- Review date:
+
+## Decision
+
+- [ ] Approved
+- [ ] Approved with conditions
+- [ ] Rejected
+
+Reviewer:
+Date:

--- a/docs/governance/ISO-42001-AIMS.md
+++ b/docs/governance/ISO-42001-AIMS.md
@@ -1,0 +1,122 @@
+# ISO/IEC 42001 AIMS Alignment
+
+This document describes how DvalinCode aligns its project governance with
+ISO/IEC 42001, the AI management system standard. It is an internal control map
+and evidence plan, not a claim of ISO certification.
+
+## References
+
+- ISO/IEC 42001 standard page: https://www.iso.org/standard/81230.html
+- ISO AI management systems overview: https://www.iso.org/artificial-intelligence/ai-management-systems
+
+## Scope
+
+The AI management system scope covers:
+
+- DvalinCode source code, build workflows, release artifacts, and security docs.
+- Agent behavior exposed through Chat, Cowork, Code, terminal, web, and server
+  interfaces.
+- Model/provider integrations, prompts, tool execution, audit logs, local data,
+  and policy enforcement.
+- Governance evidence for maintainers and users evaluating enterprise adoption.
+
+Out of scope:
+
+- The internal controls of third-party model providers.
+- A user's private prompts, repositories, API keys, and local runtime
+  configuration after installation.
+- Formal ISO certification activities performed by an accredited certification
+  body.
+
+## AI Policy
+
+DvalinCode's AI policy is:
+
+1. Keep the user or organization in control of model, tool, file, shell, and
+   network permissions.
+2. Treat model output as untrusted input.
+3. Minimize data captured in audit records and never store prompt bodies,
+   provider bodies, API keys, or file contents in audit logs.
+4. Make AI behavior reviewable through open source code, tests, policy files,
+   and tamper-evident run logs.
+5. Preserve local-first operation and avoid hidden vendor lock-in.
+6. Record material AI behavior changes through a pull request checklist and, for
+   higher-risk changes, an AI change impact assessment.
+
+## Roles
+
+| Role | Responsibility | Evidence |
+|---|---|---|
+| AIMS owner | Maintains this control map and review cadence | This document |
+| Security owner | Maintains Scorecard, CodeQL, security policy, and release checks | `SECURITY.md`, `.github/workflows/` |
+| Release owner | Verifies build outputs, checksums, and release notes | `release.yml`, `scripts/build-release.sh` |
+| AI behavior owner | Reviews prompts, tools, policy enforcement, provider changes, and mode behavior | PR checklist, tests |
+| Incident owner | Coordinates security or AI behavior incidents | `SECURITY.md`, issue template |
+
+For this public repository, these roles may be held by the same maintainer. For
+enterprise forks, assign named people or teams.
+
+## Control Map
+
+| Management-system need | DvalinCode implementation | Evidence |
+|---|---|---|
+| Context and interested parties | Enterprise approval goal and threat models are documented | `docs/APPROVABILITY-PLAN.md`, `docs/EGRESS-THREAT-MODEL.md` |
+| Leadership and policy | AI policy and security expectations are documented | This document, `SECURITY.md` |
+| Risk planning | AI risks are tracked with controls and review triggers | Risk register below, impact assessment template |
+| Support and competence | Contributor expectations and PR checklist guide maintainers | `CONTRIBUTING.md`, PR template |
+| Operation | Tool permissions, policies, audit logs, and release workflows govern behavior | `src/core/`, `src/audit/`, `.github/workflows/` |
+| Data governance | Audit data minimization and local-first storage are documented | `docs/AUDIT-TRAIL.md`, `docs/EGRESS-THREAT-MODEL.md` |
+| Supplier and model governance | Provider changes require impact review | PR template, impact assessment template |
+| Performance evaluation | CI, tests, Scorecard, CodeQL, and release verification provide recurring checks | `.github/workflows/` |
+| Improvement | Issues, incidents, and Scorecard findings feed back into docs, tests, and policy | Issue template, Scorecard doc |
+
+## Risk Register
+
+| Risk | Impact | Baseline control | Review trigger |
+|---|---|---|---|
+| Prompt injection causes unauthorized write or command | User code or data may be changed unexpectedly | Approval modes, diff preview, policy engine, audit trail | Any tool permission or mode change |
+| Sensitive data reaches a model provider | Confidential data may leave the workspace or machine | Local-first design, `.dvalincodeignore`, audit minimization, egress policy | New provider, file selection, or context ingestion change |
+| Provider or model behavior changes unexpectedly | Agent quality, privacy, or safety posture may change | Provider profiles, local model support, impact assessment | New provider, default model, endpoint, or prompt policy |
+| Supply-chain compromise in build or CI | Release artifacts may be untrusted | Pinned Actions, CodeQL, Dependabot, release checksums | Workflow, dependency, or release script change |
+| Audit evidence is incomplete or misleading | Users cannot reconstruct agent behavior | Hash-chained logs and report verification | Audit schema, minimization, or report change |
+| Users overestimate ISO/Scorecard meaning | Misplaced trust or compliance claims | Clear non-certification language | README, release, or marketing claim change |
+
+## AI Change Classification
+
+Use this lightweight classification in pull requests:
+
+| Class | Examples | Required evidence |
+|---|---|---|
+| A0 documentation-only | README typo, screenshots | Normal review |
+| A1 low-risk implementation | UI styling, test-only changes | Tests or rationale |
+| A2 behavior-affecting AI change | Prompt, mode behavior, provider config, context selection | Tests plus PR governance checklist |
+| A3 high-risk AI/system change | Permission model, shell/file/network tools, audit, release, default provider | AI impact assessment plus maintainer review |
+
+Use `docs/governance/AI-CHANGE-IMPACT-ASSESSMENT.md` for A3 changes and for any
+A2 change where data exposure, autonomy, or user approval behavior is uncertain.
+
+## Required Records
+
+Keep these records in git or GitHub:
+
+- Pull requests and reviews for security or AI behavior changes.
+- Completed AI impact assessments for A3 changes.
+- Scorecard and CodeQL run history.
+- Release notes, checksums, and build logs.
+- Security incidents and corrective actions.
+- Exceptions where a control is knowingly deferred, including owner and review
+  date.
+
+## Review Cadence
+
+- Review this AIMS document every quarter or after any A3 change.
+- Review Scorecard and CodeQL findings weekly via scheduled workflows.
+- Review the risk register before each major release.
+- Review incidents within seven days of closure and capture corrective actions.
+
+## Certification Note
+
+ISO/IEC 42001 certification requires a formal audit against the full standard
+and organizational evidence beyond this repository. This repository provides
+implementation evidence and operating procedures that can support such an audit,
+but it does not by itself establish certification.

--- a/docs/security/OPENSSF-SCORECARD.md
+++ b/docs/security/OPENSSF-SCORECARD.md
@@ -1,0 +1,78 @@
+# OpenSSF Scorecard Support
+
+DvalinCode uses OpenSSF Scorecard as a supply-chain security signal for the
+repository. The workflow is implemented in `.github/workflows/scorecard.yml`
+and publishes SARIF so findings can appear in GitHub code scanning.
+
+This document is the operating map for keeping the score meaningful. It is not a
+promise of a perfect score, because some checks depend on GitHub repository
+settings outside the git tree.
+
+## References
+
+- OpenSSF Scorecard: https://github.com/ossf/scorecard
+- Scorecard GitHub Action: https://github.com/ossf/scorecard-action
+- Scorecard results viewer: https://scorecard.dev/viewer/
+
+## Implemented Controls
+
+| Scorecard area | DvalinCode control | Evidence |
+|---|---|---|
+| Security-Policy | Public vulnerability reporting policy | `SECURITY.md` |
+| License | MIT license | `LICENSE` |
+| CI-Tests | CI runs type-check and tests | `.github/workflows/ci.yml` |
+| SAST | CodeQL analysis for JavaScript/TypeScript | `.github/workflows/codeql.yml` |
+| Token-Permissions | Workflows declare least-privilege permissions | `.github/workflows/*.yml` |
+| Pinned-Dependencies | GitHub Actions are pinned to commit SHAs | `.github/workflows/*.yml` |
+| Dependency-Update-Tool | Dependabot for npm and GitHub Actions | `.github/dependabot.yml` |
+| Code-Review | CODEOWNERS and PR governance checklist | `.github/CODEOWNERS`, `.github/PULL_REQUEST_TEMPLATE.md` |
+| Packaging | Release workflow verifies checksums and uploads release assets | `.github/workflows/release.yml` |
+
+## Required GitHub Repository Settings
+
+These controls cannot be fully represented in git. Enable them in GitHub
+repository settings:
+
+1. Branch protection or repository ruleset for `main`.
+2. Require pull request review before merging.
+3. Require CI and CodeQL checks to pass before merging.
+4. Dismiss stale approvals when new commits are pushed.
+5. Require CODEOWNERS review for protected paths.
+6. Enable Dependency graph and Dependabot alerts.
+7. Enable secret scanning and push protection when available.
+8. Enable private vulnerability reporting or GitHub security advisories.
+
+## Operating Procedure
+
+1. Scorecard runs on pushes to `main`, weekly, when branch protection changes,
+   and on manual dispatch.
+2. Review SARIF findings in GitHub code scanning.
+3. Treat new high-severity findings as release blockers unless a maintainer
+   records a documented exception.
+4. Keep action SHAs pinned. Dependabot should open updates; maintainers should
+   verify the upstream release notes before merging.
+5. Do not relax workflow permissions without recording the reason in the pull
+   request.
+
+## Local Triage Commands
+
+```sh
+gh workflow run scorecard.yml
+gh run list --workflow scorecard.yml --limit 5
+gh run view --log
+```
+
+To inspect the public score after the first run is indexed, open:
+
+```text
+https://scorecard.dev/viewer/?uri=github.com/arthurpanhku/dvalincode
+```
+
+## Known Gaps
+
+- Branch protection, security advisories, dependency graph, Dependabot alerts,
+  and secret scanning are GitHub settings and must be verified by a repository
+  administrator.
+- OpenSSF Scorecard is a signal, not a certification. Use it alongside code
+  review, release verification, and the AI governance evidence in
+  `docs/governance/`.


### PR DESCRIPTION
## Summary

Adds project-level governance support for OpenSSF Scorecard and ISO/IEC 42001 alignment.

## What changed

- Added OpenSSF Scorecard workflow with SARIF upload and public result publishing.
- Added CodeQL, Dependabot, and CODEOWNERS configuration.
- Pinned GitHub Actions in CI and release workflows to commit SHAs.
- Added OpenSSF Scorecard control map under `docs/security/`.
- Added ISO/IEC 42001 AIMS alignment and AI change impact assessment template under `docs/governance/`.
- Updated README, SECURITY, issue template, and PR template with visible governance guidance.

## Impact

This improves supply-chain security posture and creates maintainable AI governance evidence for enterprise review. The ISO/IEC 42001 material is documented as alignment/evidence, not a certification claim.

## Testing

- `npm run check` passed: 23 test files, 142 tests.
- Parsed all workflow and Dependabot YAML files successfully.
- Verified all GitHub workflow `uses:` references are pinned to 40-character commit SHAs.

## Notes

Repository-level settings still need to be enabled by an administrator: branch protection/rulesets, required checks, CODEOWNERS review, Dependabot alerts, dependency graph, secret scanning, and private vulnerability reporting when available.
