### PR TITLE
[codex] Fix local runtime smoke test issues

### DIFF
--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -66,7 +66,7 @@ app.post('/api/playbook', (req, res) => void savePlaybook(req, res));
 
 // Serve built frontend
 app.use(express.static(webDist));
-app.get('*', (_req, res) => {
+app.get(/.*/, (_req, res) => {
   res.sendFile(path.join(webDist, 'index.html'));
 });
 

--- a/web/src/hooks/useChat.ts
+++ b/web/src/hooks/useChat.ts
@@ -15,6 +15,21 @@ export type UsageStats = {
   outputTokens: number;
 };
 
+function updateLastPendingAssistant(
+  messages: ChatMessage[],
+  update: (message: Extract<ChatMessage, { role: 'assistant' }>) => Extract<ChatMessage, { role: 'assistant' }>,
+): ChatMessage[] {
+  for (let i = messages.length - 1; i >= 0; i -= 1) {
+    const msg = messages[i];
+    if (msg?.role === 'assistant' && msg.pending) {
+      const next = [...messages];
+      next[i] = update(msg);
+      return next;
+    }
+  }
+  return messages;
+}
+
 /** Convert saved backend messages into UI chat messages for session restore */
 function mapBackendMessages(raw: BackendChatMessage[]): ChatMessage[] {
   const result: ChatMessage[] = [];
@@ -182,13 +197,7 @@ export function useChat(opts: UseChatOptions = {}) {
             break;
 
           case 'done':
-            setMessages((prev) => {
-              const last = prev[prev.length - 1];
-              if (last?.role === 'assistant' && last.pending) {
-                return [...prev.slice(0, -1), { ...last, pending: false }];
-              }
-              return prev;
-            });
+            setMessages((prev) => updateLastPendingAssistant(prev, (msg) => ({ ...msg, pending: false })));
             if (event.usage) setLastUsage(event.usage);
             pendingToolCallsRef.current.clear();
             setPendingApprovals([]);
@@ -196,14 +205,11 @@ export function useChat(opts: UseChatOptions = {}) {
             break;
 
           case 'interrupted':
-            setMessages((prev) => {
-              const last = prev[prev.length - 1];
-              if (last?.role === 'assistant' && last.pending) {
-                const content = last.content || '*(interrupted)*';
-                return [...prev.slice(0, -1), { ...last, content, pending: false }];
-              }
-              return prev;
-            });
+            setMessages((prev) => updateLastPendingAssistant(prev, (msg) => ({
+              ...msg,
+              content: msg.content || '*(interrupted)*',
+              pending: false,
+            })));
             pendingToolCallsRef.current.clear();
             setPendingApprovals([]);
             setSending(false);
@@ -211,9 +217,13 @@ export function useChat(opts: UseChatOptions = {}) {
 
           case 'error':
             setMessages((prev) => {
-              const last = prev[prev.length - 1];
-              if (last?.role === 'assistant' && last.pending) {
-                return [...prev.slice(0, -1), { ...last, content: `**Error:** ${event.message}`, pending: false }];
+              const next = updateLastPendingAssistant(prev, (msg) => ({
+                ...msg,
+                content: `**Error:** ${event.message}`,
+                pending: false,
+              }));
+              if (next !== prev) {
+                return next;
               }
               return [...prev, { role: 'assistant', content: `**Error:** ${event.message}`, toolCalls: [], pending: false }];
             });


### PR DESCRIPTION
## Summary

Fixes two issues found while running the app locally with DeepSeek configured.

## What changed

- Replaced the Express 5-incompatible `app.get('*')` SPA fallback with a regex fallback so the backend can start under the current Express/path-to-regexp stack.
- Fixed the web chat completion state when `run_report` arrives before `done`; the UI now clears the nearest pending assistant message instead of only checking the final message.

## Testing

- Configured local app for DeepSeek (`deepseek-chat`) and verified `/api/config` returns `apiKeySet: true` with the key masked.
- Started the app with `npm run dev:all`.
- Sent `Reply with exactly one word: PONG` through the Web GUI and received `PONG`.
- Verified the audit run recorded `run_start`, `provider_request`, `run_end` with provider `deepseek`, model `deepseek-chat`, status `done`.
- Confirmed the UI no longer leaves `thinking…` visible after completion.
- `npm run check` passed: 23 test files, 142 tests.
- `npm run web:build` passed.

## Notes

The DeepSeek API key is stored only in the local `~/.dvalincode/config.json` and is masked in browser/API responses. It is not committed.
