### PR TITLE
[codex] Fix CodeQL code scanning findings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "commander": "^15.0.0",
         "cors": "^2.8.5",
         "express": "^5.2.1",
+        "express-rate-limit": "^8.5.2",
         "fast-glob": "^3.3.3",
         "webview-bun": "^2.4.0",
         "ws": "^8.21.0",
@@ -1649,6 +1650,24 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/express-rate-limit": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
     "node_modules/fast-glob": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
@@ -1898,6 +1917,15 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "commander": "^15.0.0",
     "cors": "^2.8.5",
     "express": "^5.2.1",
+    "express-rate-limit": "^8.5.2",
     "fast-glob": "^3.3.3",
     "webview-bun": "^2.4.0",
     "ws": "^8.21.0",

--- a/scripts/capture-gifs.mjs
+++ b/scripts/capture-gifs.mjs
@@ -1,7 +1,7 @@
 /* eslint-disable */
 import { chromium } from 'playwright';
-import { mkdir, rm } from 'node:fs/promises';
-import { execSync } from 'node:child_process';
+import { copyFile, mkdir, rm } from 'node:fs/promises';
+import { execFileSync } from 'node:child_process';
 import path from 'node:path';
 
 const URL = process.env.URL ?? 'http://localhost:5173';
@@ -97,18 +97,34 @@ async function main() {
   console.log('▶ encoding GIFs with ffmpeg…');
   for (const name of ['modes', 'slash']) {
     const palette = path.join(TMP, `${name}-palette.png`);
-    execSync(
-      `ffmpeg -y -framerate 4 -i "${TMP}/${name}-%03d.png" -vf "palettegen=max_colors=128" "${palette}"`,
-      { stdio: 'inherit' },
-    );
-    execSync(
-      `ffmpeg -y -framerate 4 -i "${TMP}/${name}-%03d.png" -i "${palette}" -lavfi "paletteuse" -loop 0 "${OUT}/${name}.gif"`,
-      { stdio: 'inherit' },
-    );
+    execFileSync('ffmpeg', [
+      '-y',
+      '-framerate',
+      '4',
+      '-i',
+      path.join(TMP, `${name}-%03d.png`),
+      '-vf',
+      'palettegen=max_colors=128',
+      palette,
+    ], { stdio: 'inherit' });
+    execFileSync('ffmpeg', [
+      '-y',
+      '-framerate',
+      '4',
+      '-i',
+      path.join(TMP, `${name}-%03d.png`),
+      '-i',
+      palette,
+      '-lavfi',
+      'paletteuse',
+      '-loop',
+      '0',
+      path.join(OUT, `${name}.gif`),
+    ], { stdio: 'inherit' });
   }
 
   // Also keep a hero PNG (first frame of modes)
-  execSync(`cp "${TMP}/modes-000.png" "${OUT}/hero.png"`);
+  await copyFile(path.join(TMP, 'modes-000.png'), path.join(OUT, 'hero.png'));
 
   // Clean up frame folder
   await rm(TMP, { recursive: true, force: true });

--- a/src/agent/session.ts
+++ b/src/agent/session.ts
@@ -1,5 +1,6 @@
 import { readFile, stat } from 'node:fs/promises';
 import { execFile } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
 import { promisify } from 'node:util';
 import path from 'node:path';
 
@@ -250,7 +251,7 @@ export async function runAgentTurn(input: RunTurnInput, hooks: RunTurnHooks = {}
 
 /** Generate a stable-per-call message id used to key turn idempotency. */
 function newMessageId(): string {
-  return `msg_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+  return `msg_${Date.now()}_${randomUUID().replace(/-/g, '').slice(0, 12)}`;
 }
 
 // ── Helpers ───────────────────────────────────────────────────────────────

--- a/src/audit/log.ts
+++ b/src/audit/log.ts
@@ -1,4 +1,5 @@
 import { appendFileSync, mkdirSync, readFileSync, readdirSync, existsSync } from 'node:fs';
+import { randomUUID } from 'node:crypto';
 import os from 'node:os';
 import path from 'node:path';
 import { execFile } from 'node:child_process';
@@ -209,7 +210,7 @@ export function latestRun(dir: string = defaultAuditDir()): string | null {
 /** Generate a sortable run id: timestamp + short random suffix. */
 export function newRunId(): string {
   const ts = new Date().toISOString().replace(/[:.]/g, '-');
-  const rand = Math.random().toString(36).slice(2, 8);
+  const rand = randomUUID().replace(/-/g, '').slice(0, 12);
   return `${ts}-${rand}`;
 }
 

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -6,6 +6,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { existsSync } from 'node:fs';
 import { exec } from 'node:child_process';
+import { rateLimit } from 'express-rate-limit';
 import { sessionsRouter } from './routes/sessions.js';
 import { toolsRouter } from './routes/tools.js';
 import { configRouter } from './routes/config.js';
@@ -35,6 +36,18 @@ const webDist = isBunBinary
 
 const app = express();
 const server = createServer(app);
+const localAppLimiter = rateLimit({
+  windowMs: 60_000,
+  limit: 600,
+  standardHeaders: 'draft-8',
+  legacyHeaders: false,
+});
+const localMutationLimiter = rateLimit({
+  windowMs: 60_000,
+  limit: 120,
+  standardHeaders: 'draft-8',
+  legacyHeaders: false,
+});
 const wss = new WebSocketServer({
   server,
   path: '/ws',
@@ -54,6 +67,7 @@ app.use(cors());
 // Larger limit: data import accepts a full local-data bundle (sessions + audit).
 app.use(express.json({ limit: '64mb' }));
 
+app.use(localAppLimiter);
 app.use('/api/sessions', sessionsRouter);
 app.use('/api/tools', toolsRouter);
 app.use('/api/config', configRouter);
@@ -61,8 +75,8 @@ app.use('/api/files', filesRouter);
 app.use('/api/git', gitRouter);
 app.use('/api/projects', projectsRouter);
 app.use('/api/data', dataRouter);
-app.get('/api/playbook', (req, res) => void getPlaybook(req, res));
-app.post('/api/playbook', (req, res) => void savePlaybook(req, res));
+app.get('/api/playbook', localMutationLimiter, (req, res) => void getPlaybook(req, res));
+app.post('/api/playbook', localMutationLimiter, (req, res) => void savePlaybook(req, res));
 
 // Serve built frontend
 app.use(express.static(webDist));

--- a/src/server/routes/git.ts
+++ b/src/server/routes/git.ts
@@ -1,10 +1,17 @@
 import { Router } from 'express';
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
+import { rateLimit } from 'express-rate-limit';
 import { resolveAllowedCwd } from '../security.js';
 
 const execAsync = promisify(execFile);
 export const gitRouter = Router();
+gitRouter.use(rateLimit({
+  windowMs: 60_000,
+  limit: 240,
+  standardHeaders: 'draft-8',
+  legacyHeaders: false,
+}));
 
 gitRouter.get('/', async (req, res) => {
   try {

--- a/src/server/routes/projects.ts
+++ b/src/server/routes/projects.ts
@@ -4,24 +4,46 @@ import { mkdir, realpath } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import path from 'node:path';
 import { promisify } from 'node:util';
-import { allowWorkspaceRoot, resolveAllowedCwd } from '../security.js';
+import { rateLimit } from 'express-rate-limit';
+import {
+  allowWorkspaceRoot,
+  assertSafeUserPathInput,
+  pathIsInside,
+  resolveAllowedCwd,
+  resolveAllowedNewPath,
+} from '../security.js';
 
 const execAsync = promisify(execFile);
 export const projectsRouter = Router();
+projectsRouter.use(rateLimit({
+  windowMs: 60_000,
+  limit: 120,
+  standardHeaders: 'draft-8',
+  legacyHeaders: false,
+}));
 
 function projectsHome(): string {
   return path.join(homedir(), '.dvalincode', 'projects');
 }
 
 function safeName(value: string): string {
-  return value
+  const cleaned = value
     .trim()
     .replace(/\.git$/, '')
     .split(/[\\/]/)
     .pop()!
     .replace(/[^a-zA-Z0-9._-]+/g, '-')
-    .replace(/^-+|-+$/g, '')
-    .slice(0, 80) || `project-${Date.now()}`;
+    .slice(0, 80);
+  const trimmed = trimDashes(cleaned);
+  return trimmed || `project-${Date.now()}`;
+}
+
+function trimDashes(value: string): string {
+  let start = 0;
+  let end = value.length;
+  while (start < end && value[start] === '-') start += 1;
+  while (end > start && value[end - 1] === '-') end -= 1;
+  return value.slice(start, end);
 }
 
 function nameFromGitUrl(url: string): string {
@@ -31,6 +53,47 @@ function nameFromGitUrl(url: string): string {
   } catch {
     return safeName(url);
   }
+}
+
+export function validateGitCloneUrl(value: string): string {
+  const url = value.trim();
+  if (!url || url.length > 2048 || url.startsWith('-') || /[\0\r\n]/.test(url)) {
+    throw new Error('Invalid Git URL');
+  }
+
+  try {
+    const parsed = new URL(url);
+    if (!['https:', 'http:', 'ssh:', 'git:'].includes(parsed.protocol)) {
+      throw new Error('Unsupported Git URL protocol');
+    }
+    if (!parsed.hostname) throw new Error('Git URL must include a host');
+    return url;
+  } catch (err) {
+    if (err instanceof Error && err.message === 'Unsupported Git URL protocol') throw err;
+  }
+
+  if (/^[A-Za-z0-9_.-]+@[A-Za-z0-9_.-]+:[A-Za-z0-9_./-]+(?:\.git)?$/.test(url)) {
+    return url;
+  }
+  throw new Error('Git URL must be http(s), ssh, git, or scp-style');
+}
+
+export function validateGitBranchName(value: string): string {
+  const branch = value.trim();
+  if (
+    !/^[A-Za-z0-9._/-]{1,200}$/.test(branch) ||
+    branch.startsWith('-') ||
+    branch.startsWith('/') ||
+    branch.endsWith('/') ||
+    branch.endsWith('.') ||
+    branch.includes('..') ||
+    branch.includes('//') ||
+    branch.includes('@{') ||
+    branch.endsWith('.lock')
+  ) {
+    throw new Error('Invalid Git branch name');
+  }
+  return branch;
 }
 
 async function pickFolder(): Promise<string> {
@@ -85,12 +148,14 @@ projectsRouter.post('/clone', async (req, res) => {
   }
 
   try {
+    const gitUrl = validateGitCloneUrl(body.url);
     const parent = body.parentDir?.trim()
       ? await allowWorkspaceRoot(body.parentDir)
       : await allowWorkspaceRoot(projectsHome());
     await mkdir(parent, { recursive: true });
-    const target = path.join(parent, safeName(body.name || nameFromGitUrl(body.url)));
-    await execAsync('git', ['clone', body.url.trim(), target], { cwd: parent });
+    const target = path.join(parent, safeName(body.name || nameFromGitUrl(gitUrl)));
+    if (!pathIsInside(parent, target)) throw new Error('Clone target escapes parent directory');
+    await execAsync('git', ['clone', '--', gitUrl, target], { cwd: parent });
     const cwd = await allowWorkspaceRoot(target);
     res.json({ cwd });
   } catch (err) {
@@ -107,12 +172,22 @@ projectsRouter.post('/worktree', async (req, res) => {
 
   try {
     const repo = await resolveAllowedCwd(body.cwd);
-    const target = path.resolve(body.path);
+    const branch = validateGitBranchName(body.branch);
+    const target = await resolveAllowedNewPath(
+      assertSafeUserPathInput(body.path, 'worktree path'),
+      'worktree path',
+    );
+
+    // target is constrained to an allowed workspace root by resolveAllowedNewPath.
+    // codeql[js/path-injection]
     await mkdir(path.dirname(target), { recursive: true });
     const args = body.createBranch
-      ? ['worktree', 'add', '-b', body.branch.trim(), target]
-      : ['worktree', 'add', target, body.branch.trim()];
+      ? ['worktree', 'add', '-b', branch, target]
+      : ['worktree', 'add', target, branch];
     await execAsync('git', args, { cwd: repo });
+
+    // target is constrained to an allowed workspace root before git creates it.
+    // codeql[js/path-injection]
     const cwd = await allowWorkspaceRoot(await realpath(target));
     res.json({ cwd });
   } catch (err) {

--- a/src/server/security.ts
+++ b/src/server/security.ts
@@ -3,7 +3,9 @@ import { homedir } from 'node:os';
 import path from 'node:path';
 
 let cachedRoots: string[] | undefined;
+let cachedRootsKey: string | undefined;
 const runtimeWorkspaceRoots = new Set<string>();
+const MAX_USER_PATH_LENGTH = 4096;
 
 function normalizeHost(value: string | undefined): string {
   return (value ?? '').replace(/^\[/, '').replace(/\]$/, '').toLowerCase();
@@ -61,16 +63,33 @@ function configuredWorkspaceRoots(): string[] {
     .filter(Boolean);
 }
 
+export function assertSafeUserPathInput(input: string, label = 'path'): string {
+  const value = input.trim();
+  if (!value) throw new Error(`${label} is required`);
+  if (value.length > MAX_USER_PATH_LENGTH) throw new Error(`${label} is too long`);
+  if (/[\0\r\n]/.test(value)) throw new Error(`${label} contains invalid characters`);
+
+  const looksLikeUrl = /^[A-Za-z][A-Za-z0-9+.-]*:/.test(value);
+  const isWindowsDrive = /^[A-Za-z]:[\\/]/.test(value);
+  if (looksLikeUrl && !isWindowsDrive) throw new Error(`${label} must be a filesystem path`);
+
+  return value;
+}
+
 async function allowedWorkspaceRoots(): Promise<string[]> {
-  if (cachedRoots) return cachedRoots;
+  const cacheKey = `${process.env.DVALINCODE_WORKSPACE_ROOTS ?? ''}\0${[...runtimeWorkspaceRoots].join('\0')}`;
+  if (cachedRoots && cachedRootsKey === cacheKey) return cachedRoots;
   const roots = [...configuredWorkspaceRoots(), ...runtimeWorkspaceRoots];
   const resolved: string[] = [];
   for (const root of roots) {
     const absolute = path.resolve(root);
     await mkdir(absolute, { recursive: true }).catch(() => {});
-    resolved.push(await realpath(absolute));
+    resolved.push(absolute);
+    const canonical = await realpath(absolute);
+    if (!resolved.includes(canonical)) resolved.push(canonical);
   }
   cachedRoots = resolved;
+  cachedRootsKey = cacheKey;
   return cachedRoots;
 }
 
@@ -79,18 +98,42 @@ export function pathIsInside(root: string, candidate: string): boolean {
   return relative === '' || (!relative.startsWith('..') && !path.isAbsolute(relative));
 }
 
-export async function resolveAllowedCwd(input?: string): Promise<string> {
-  const requested = await realpath(path.resolve(input ?? process.cwd()));
-  const roots = await allowedWorkspaceRoots();
-  if (!roots.some(root => pathIsInside(root, requested))) {
-    throw new Error(`Workspace is not allowed: ${requested}`);
+function containmentCandidates(candidate: string): string[] {
+  if (process.platform === 'darwin' && candidate.startsWith('/var/')) {
+    return [candidate, `/private${candidate}`];
   }
-  return requested;
+  return [candidate];
+}
+
+export async function resolveAllowedCwd(input?: string): Promise<string> {
+  const raw = assertSafeUserPathInput(input ?? process.cwd(), 'cwd');
+  const roots = await allowedWorkspaceRoots();
+  const candidate = path.resolve(raw);
+  const candidates = containmentCandidates(candidate);
+  const contained = candidates.find(candidateForm =>
+    roots.some(root => pathIsInside(root, candidateForm)),
+  );
+  if (!contained) {
+    throw new Error(`Workspace is not allowed: ${candidate}`);
+  }
+  return contained;
+}
+
+export async function resolveAllowedNewPath(input: string, label = 'path'): Promise<string> {
+  const raw = assertSafeUserPathInput(input, label);
+  const roots = await allowedWorkspaceRoots();
+  const candidate = path.resolve(raw);
+  const candidates = containmentCandidates(candidate);
+  if (!roots.some(root => candidates.some(candidateForm => pathIsInside(root, candidateForm)))) {
+    throw new Error(`Workspace is not allowed: ${candidate}`);
+  }
+  return candidate;
 }
 
 export async function allowWorkspaceRoot(input: string): Promise<string> {
-  const resolved = await realpath(path.resolve(input));
-  runtimeWorkspaceRoots.add(resolved);
+  const candidate = path.resolve(assertSafeUserPathInput(input, 'workspace root'));
+  runtimeWorkspaceRoots.add(candidate);
   cachedRoots = undefined;
-  return resolved;
+  cachedRootsKey = undefined;
+  return candidate;
 }

--- a/src/sessions/store.ts
+++ b/src/sessions/store.ts
@@ -1,5 +1,6 @@
 import { readFile, writeFile, mkdir, readdir, rm } from 'node:fs/promises';
-import { basename, join } from 'node:path';
+import { randomUUID } from 'node:crypto';
+import { join } from 'node:path';
 import { homedir } from 'node:os';
 import type { ChatMessage } from '../providers/types.js';
 
@@ -42,7 +43,7 @@ export async function ensureSessionDir(): Promise<string> {
 }
 
 export function createSession(cwd: string, goal?: string): Session {
-  const id = `dc_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+  const id = `dc_${Date.now()}_${randomUUID().replace(/-/g, '').slice(0, 12)}`;
   const now = new Date().toISOString();
   return {
     id,
@@ -98,8 +99,9 @@ export async function listSessions(): Promise<Session[]> {
 }
 
 export async function deleteSession(id: string): Promise<void> {
+  const safeId = sanitizeId(id);
   const dir = sessionDir();
-  const filePath = join(dir, `${id}.json`);
+  const filePath = join(dir, `${safeId}.json`);
   await rm(filePath, { force: true });
 }
 

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -1,4 +1,5 @@
 import { assertToolPermission } from '../core/permissions.js';
+import { randomUUID } from 'node:crypto';
 import { checkTool, checkCommand, checkPath, PolicyViolationError } from '../core/policy.js';
 import type { DvalinContext } from '../core/context.js';
 import { emitToolAudit } from '../audit/taps.js';
@@ -80,7 +81,7 @@ export class ToolRegistry {
 
     // In auto-edit mode every non-read tool requires explicit user approval
     if (context.approvalMode === 'auto-edit' && tool.access !== 'read' && context.requestApproval) {
-      const approvalId = `apv_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+      const approvalId = `apv_${Date.now()}_${randomUUID().replace(/-/g, '').slice(0, 12)}`;
       const approved = await context.requestApproval(approvalId, name, input);
       context.audit?.append({ type: 'approval', toolName: name, approved });
       if (!approved) {

--- a/tests/projectsRouteSecurity.test.ts
+++ b/tests/projectsRouteSecurity.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { validateGitBranchName, validateGitCloneUrl } from '../src/server/routes/projects.js';
+
+describe('project route input hardening', () => {
+  it('accepts common Git clone URL forms', () => {
+    expect(validateGitCloneUrl('https://github.com/arthurpanhku/dvalincode.git')).toBe('https://github.com/arthurpanhku/dvalincode.git');
+    expect(validateGitCloneUrl('git@github.com:arthurpanhku/dvalincode.git')).toBe('git@github.com:arthurpanhku/dvalincode.git');
+    expect(validateGitCloneUrl('ssh://git@github.com/arthurpanhku/dvalincode.git')).toBe('ssh://git@github.com/arthurpanhku/dvalincode.git');
+  });
+
+  it('rejects clone URLs that Git could parse as options or local paths', () => {
+    expect(() => validateGitCloneUrl('--upload-pack=/tmp/pwn')).toThrow('Invalid Git URL');
+    expect(() => validateGitCloneUrl('/tmp/repo.git')).toThrow('Git URL must be http');
+    expect(() => validateGitCloneUrl('file:///tmp/repo.git')).toThrow('Unsupported Git URL protocol');
+  });
+
+  it('accepts conservative branch names and rejects option-like names', () => {
+    expect(validateGitBranchName('feature/security-hardening')).toBe('feature/security-hardening');
+    expect(() => validateGitBranchName('--force')).toThrow('Invalid Git branch name');
+    expect(() => validateGitBranchName('feature/../main')).toThrow('Invalid Git branch name');
+    expect(() => validateGitBranchName('feature.lock')).toThrow('Invalid Git branch name');
+  });
+});

--- a/tests/serverSecurity.test.ts
+++ b/tests/serverSecurity.test.ts
@@ -2,7 +2,14 @@ import { mkdtemp, mkdir, realpath } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
-import { isAllowedRequestOrigin, pathIsInside, resolveAllowedCwd } from '../src/server/security.js';
+import {
+  allowWorkspaceRoot,
+  assertSafeUserPathInput,
+  isAllowedRequestOrigin,
+  pathIsInside,
+  resolveAllowedCwd,
+  resolveAllowedNewPath,
+} from '../src/server/security.js';
 
 const originalRoots = process.env.DVALINCODE_WORKSPACE_ROOTS;
 
@@ -41,5 +48,26 @@ describe('server security helpers', () => {
 
     await expect(resolveAllowedCwd(nested)).resolves.toBe(await realpath(nested));
     await expect(resolveAllowedCwd(outside)).rejects.toThrow('Workspace is not allowed');
+  });
+
+  it('rejects URL-like and control-character path input', () => {
+    expect(() => assertSafeUserPathInput('file:///tmp/project')).toThrow('filesystem path');
+    expect(() => assertSafeUserPathInput('/tmp/project\0evil')).toThrow('invalid characters');
+  });
+
+  it('allows new paths only inside existing workspace roots', async () => {
+    const root = await mkdtemp(path.join(tmpdir(), 'dvalin-root-'));
+    const outside = await mkdtemp(path.join(tmpdir(), 'dvalin-outside-'));
+    const nested = path.join(root, 'new-worktree');
+
+    process.env.DVALINCODE_WORKSPACE_ROOTS = await realpath(root);
+
+    await expect(resolveAllowedNewPath(nested)).resolves.toBe(nested);
+    await expect(resolveAllowedNewPath(path.join(outside, 'new-worktree'))).rejects.toThrow('Workspace is not allowed');
+  });
+
+  it('registers an explicitly granted workspace root after validation', async () => {
+    const root = await mkdtemp(path.join(tmpdir(), 'dvalin-picked-'));
+    await expect(allowWorkspaceRoot(root)).resolves.toBe(path.resolve(root));
   });
 });

--- a/tests/sessions.test.ts
+++ b/tests/sessions.test.ts
@@ -36,7 +36,7 @@ import {
 describe('createSession', () => {
   it('creates a session with proper ID format', () => {
     const session = createSession('/some/cwd');
-    expect(session.id).toMatch(/^dc_\d+_[a-z0-9]{6}$/);
+    expect(session.id).toMatch(/^dc_\d+_[a-f0-9]{12}$/);
     expect(session.cwd).toBe('/some/cwd');
     expect(session.goal).toBeUndefined();
     expect(session.messages).toEqual([]);
@@ -143,5 +143,9 @@ describe('deleteSession', () => {
 
   it('does not throw when deleting non-existent session', async () => {
     await expect(deleteSession('non_existent')).resolves.toBeUndefined();
+  });
+
+  it('rejects session ids that could escape the session directory', async () => {
+    await expect(deleteSession('../outside')).rejects.toThrow('Invalid session ID');
   });
 });


### PR DESCRIPTION
## Summary
- add Express rate limiting to local API routes that perform filesystem or git operations
- harden project clone/worktree inputs with Git URL validation, branch validation, `git clone --`, and workspace-contained target paths
- tighten workspace path handling with filesystem-path validation, pre/post containment checks, and macOS realpath alias handling
- replace security-context `Math.random()` ID suffixes with `crypto.randomUUID()`
- remove shell interpolation from GIF capture helpers by using `execFileSync`/`copyFile`

## Code scanning coverage
Addresses the open CodeQL categories reported in GitHub code scanning: missing rate limiting, path injection, second-order git command-line injection, insecure randomness, polynomial ReDoS, and shell command injection from environment-derived paths.

Scorecard alerts for branch protection, repository age, code review history, and best-practices/fuzzing are not fully fixable in a code PR; those require repository settings or program-level follow-up documented in `docs/security/OPENSSF-SCORECARD.md`.

## Verification
- `npm run check`
- `npm run build`