### PR TITLE
feat(mcp): governed remote MCP client (Streamable HTTP · glama-compatible)

### DIFF
--- a/docs/GOVERNED-MCP.md
+++ b/docs/GOVERNED-MCP.md
@@ -1,0 +1,117 @@
+# Governed MCP v1 Design
+
+## Scope
+
+Add a **remote Model Context Protocol (MCP) client** so DvalinCode can use tools
+exposed by remote MCP servers and gateways — in particular
+[Glama](https://glama.ai/), which fronts thousands of MCP servers behind a single
+Streamable-HTTP endpoint with `Authorization: Bearer` auth.
+
+The point of this slice is not "MCP support" — it is **governed** MCP support.
+Glama (and any gateway) governs the *server* side. DvalinCode's job is
+**client-side governance**: the org policy bounds what the agent may do with those
+tools, the tamper-evident audit records every call, and the egress guard controls
+the third-party network connection. **We never outsource trust to the gateway.**
+
+v1 is a thin, demonstrable vertical slice. It does **not** add stdio/local
+servers, OAuth/dynamic client registration, resources/prompts/sampling, or a
+second policy engine.
+
+## Transport
+
+Remote **Streamable HTTP** (the transport the MCP spec standardized in 2025):
+JSON-RPC 2.0 over HTTP POST, with responses returned either as a single
+`application/json` body or as a `text/event-stream` (SSE) carrying the response
+message. Session continuity via the `Mcp-Session-Id` header. Auth via
+caller-supplied headers (`Authorization: Bearer ${ENV}`).
+
+Hand-rolled (no SDK dependency) to preserve DvalinCode's zero-runtime-deps
+posture. Only three JSON-RPC methods are needed for v1: `initialize`,
+`tools/list`, `tools/call`.
+
+## Mapping MCP tools onto the governance chokepoint
+
+Each MCP tool becomes an ordinary DvalinCode `Tool`, so it inherits the single
+`registry.run` policy + permission + audit chokepoint automatically:
+
+- **Name**: `mcp__<serverId>__<toolName>` — namespaced to prevent collisions and
+  to make provenance visible in the audit trail and `tools.deny` rules.
+- **Access**: derived from the MCP tool's annotations — `readOnlyHint: true`
+  maps to `read`; everything else defaults to `execute` (the most gated tier).
+  Governance-first: an un-annotated third-party tool is treated as the most
+  dangerous, not the least.
+- **`run`**: proxies a `tools/call` to the server through the governed fetch.
+- Registered into the default registry, so `checkTool` (denylist), permission by
+  access, the auto-edit approval gate, and `emitToolAudit` all apply unchanged.
+
+## Governance surfaces MCP adds (that the chokepoint does not already cover)
+
+1. **Egress.** Connecting to the gateway and every `tools/call` is outbound
+   network to a third party. It is routed through a governed fetch that runs
+   `checkEgress(policy, /*isModelEndpoint*/ false)` **before** the request and
+   audits an `mcp_request` event. Consequence: under `network: off` or
+   `endpoint-only`, MCP is **blocked** — a third-party gateway is not the model
+   endpoint, so "only talk to the model" correctly denies it. MCP requires
+   `network: on` in v1 (a host allowlist is future work).
+2. **Server admission.** Policy gains an `mcp` dimension: a server-id allowlist
+   resolved by narrowing (repo can only tighten machine). A configured server not
+   in the allowlist is not connected.
+3. **Credential minimization.** Auth headers come from `${ENV}` at call time and
+   are **never** persisted — not in audit, not in the run report. `mcp_request`
+   records only server, tool, host, outcome, and duration; never headers, args,
+   or response bodies.
+4. **Trust surface.** `dvalincode trust` lists configured MCP servers, whether
+   each is permitted by policy, its egress status under the current network
+   level, and how many tools it exposes — so an approver sees the third-party
+   attack surface at a glance.
+5. **Off by default.** MCP servers are opt-in (`enabled: true` in config) and
+   gated by policy + network. A run with no MCP config behaves exactly as today —
+   no new egress, no latency.
+
+> **Forward guardrail.** Every MCP network call must go through the governed
+> fetch (`checkEgress` + audit). A direct `fetch` to a server is a new ungoverned
+> egress path and a release blocker — the same rule as provider adapters
+> (see EGRESS-THREAT-MODEL.md).
+
+## Configuration
+
+```jsonc
+// mcp config (resolved from the existing config store)
+{
+  "mcp": {
+    "servers": [
+      {
+        "id": "glama",
+        "url": "https://glama.ai/mcp/<endpoint>",
+        "headers": { "Authorization": "Bearer ${GLAMA_API_KEY}" },
+        "enabled": true
+      }
+    ]
+  }
+}
+```
+
+`${ENV}` placeholders in header values are resolved from the process
+environment at connect time; the raw secret never touches disk via DvalinCode.
+
+## Acceptance matrix
+
+| Case | Expected result |
+|------|-----------------|
+| No MCP config | Behaves exactly as today; no connection, no egress |
+| Configured + enabled server, `network: on`, allowed by policy | `tools/list` maps to `mcp__<server>__*` tools registered in the registry |
+| A mapped tool is invoked | `tools/call` is proxied and an `mcp_request` audit event is written |
+| `network: off` or `endpoint-only` | Connection/call blocked by `checkEgress`; a policy violation is recorded |
+| Server not in the policy `mcp` allowlist | Server is not connected; its tools are not registered |
+| `tools.deny` lists `mcp__<server>__<tool>` | That tool is blocked at the chokepoint like any other |
+| Read-only annotated tool | Registered with `access: read`; un-annotated tool defaults to `execute` |
+| Audit for an MCP call | Contains server/tool/host/outcome/duration; no `Authorization`, args, or response body |
+| Trust report | Lists configured servers, policy permission, egress status, tool count |
+
+## Non-goals (deferred)
+
+- stdio / local MCP servers.
+- OAuth, dynamic client registration, managed credentials.
+- MCP resources, prompts, sampling, roots, notifications.
+- Per-tool host allowlists beyond the `network` level (a future narrowing rule).
+- Relying on the gateway's own access control in place of local policy.

--- a/src/agent/runner.ts
+++ b/src/agent/runner.ts
@@ -181,7 +181,7 @@ export class AgentRunner {
     return this.registry.list().map(tool => ({
       name: tool.name,
       description: tool.description,
-      parameters: tool.inputSchema.toJSONSchema?.() ?? {},
+      parameters: tool.parametersSchema ?? tool.inputSchema.toJSONSchema?.() ?? {},
     }));
   }
 

--- a/src/agent/session.ts
+++ b/src/agent/session.ts
@@ -31,6 +31,7 @@ import { ProviderManager } from '../providers/manager.js';
 import { ProviderPool } from '../providers/pool.js';
 import type { ProviderAdapter } from '../providers/types.js';
 import { readConfig } from '../server/configStore.js';
+import { registerMcpServers, type McpConnectionSummary } from '../mcp/register.js';
 import { createSession, loadSession, saveSession, summarizeSession } from '../sessions/store.js';
 import { appendJournal, completedTurn, readJournal, recoverSession } from '../sessions/journal.js';
 import { renderReport } from '../audit/report.js';
@@ -105,6 +106,8 @@ export type RunTurnResult = {
   replayed?: boolean;
   /** Turns that had crashed mid-execution and were closed out on this resume. */
   recovered?: RecoveredTurn[];
+  /** Governed MCP servers connected (or denied/blocked/errored) for this turn. */
+  mcp?: McpConnectionSummary[];
 };
 
 /**
@@ -177,8 +180,20 @@ export async function runAgentTurn(input: RunTurnInput, hooks: RunTurnHooks = {}
   const userContent = await expandAtMentions(content, cwd);
 
   const registry = createDefaultToolRegistry();
-  const allowedTools = mode === 'code' && codePermissionMode === 'plan' ? MODE_TOOLS.chat : MODE_TOOLS[mode];
-  registry.setAllowedTools(allowedTools);
+  const isPlan = mode === 'code' && codePermissionMode === 'plan';
+  const baseAllowed = isPlan ? MODE_TOOLS.chat : MODE_TOOLS[mode];
+
+  // Governed MCP: connect enabled + policy-permitted servers and register their
+  // tools, only in acting modes (not chat / plan). Off by default; each server's
+  // egress is enforced by the governed fetch and each tool call is audited.
+  let mcpSummaries: McpConnectionSummary[] = [];
+  if (!isPlan && mode !== 'chat') {
+    const cfg = await readConfig();
+    mcpSummaries = await registerMcpServers(registry, cfg.mcp?.servers, { policy: loadedPolicy.policy });
+  }
+  const mcpToolNames = registry.list().filter(t => t.name.startsWith('mcp__')).map(t => t.name);
+  // A null base means "all tools allowed" — MCP tools are already included, so keep it null.
+  registry.setAllowedTools(baseAllowed === null ? null : [...baseAllowed, ...mcpToolNames]);
 
   const systemPrompt = await buildSystemPrompt({
     cwd,
@@ -246,7 +261,7 @@ export async function runAgentTurn(input: RunTurnInput, hooks: RunTurnHooks = {}
     }
   }
 
-  return { sessionId: session.id, result, reportMarkdown, providerId, model, recovered };
+  return { sessionId: session.id, result, reportMarkdown, providerId, model, recovered, mcp: mcpSummaries };
 }
 
 /** Generate a stable-per-call message id used to key turn idempotency. */

--- a/src/audit/log.ts
+++ b/src/audit/log.ts
@@ -35,6 +35,17 @@ export type AuditEvent =
       durationMs: number;
       statusCode?: number;
     }
+  | {
+      type: 'mcp_request';
+      /** Configured MCP server id. */
+      server: string;
+      /** Tool invoked (or the JSON-RPC method for connection-level calls). */
+      tool: string;
+      /** Origin of the gateway/server — never the full URL or query. */
+      host: string;
+      outcome: 'ok' | 'blocked' | 'error';
+      durationMs: number;
+    }
   | { type: 'file_read'; path: string; sha256: string }
   | { type: 'file_write'; path: string; added: number; removed: number; beforeHash: string | null; afterHash: string }
   | { type: 'file_delete'; path: string; beforeHash: string | null }

--- a/src/core/policy.ts
+++ b/src/core/policy.ts
@@ -50,6 +50,7 @@ const policyFileSchema = z
       .strict()
       .optional(),
     tools: z.object({ deny: z.array(z.string()).optional() }).strict().optional(),
+    mcp: z.object({ allow: z.array(z.string()).optional() }).strict().optional(),
     network: z.enum(networkLevels).optional(),
     maxToolCalls: z.number().int().positive().optional(),
   })
@@ -71,6 +72,8 @@ export type ResolvedPolicy = {
   paths: { allow?: string[]; deny: string[] };
   /** Tool-name denylist. */
   tools: { deny: string[] };
+  /** MCP server-id allowlist; undefined = any configured server is permitted. */
+  mcp: { allow?: string[] };
   /** Outbound network posture. */
   network: NetworkLevel;
   /** Hard cap on tool calls per run; undefined = unlimited. */
@@ -86,6 +89,7 @@ export function permissivePolicy(): ResolvedPolicy {
     commands: { deny: [], defaultDeny: false },
     paths: { deny: [] },
     tools: { deny: [] },
+    mcp: {},
     network: 'on',
   };
 }
@@ -164,6 +168,7 @@ function narrow(base: ResolvedPolicy, next: OrgPolicyInput): ResolvedPolicy {
       deny: union(base.paths.deny, next.paths?.deny),
     },
     tools: { deny: union(base.tools.deny, next.tools?.deny) },
+    mcp: { allow: intersectAllow(base.mcp.allow, next.mcp?.allow) },
     network: next.network ? moreRestrictiveNetwork(base.network, next.network) : base.network,
     maxToolCalls: minDefined(base.maxToolCalls, next.maxToolCalls),
   };
@@ -192,6 +197,11 @@ export function checkModel(p: ResolvedPolicy, model: string): Decision {
 
 export function checkTool(p: ResolvedPolicy, toolName: string): Decision {
   return p.tools.deny.includes(toolName) ? deny(`tool "${toolName}" is denied by policy`) : ALLOW;
+}
+
+export function checkMcpServer(p: ResolvedPolicy, serverId: string): Decision {
+  if (!p.mcp.allow) return ALLOW;
+  return p.mcp.allow.includes(serverId) ? ALLOW : deny(`MCP server "${serverId}" is not in the allowlist`);
 }
 
 /** Is an outbound connection permitted? `isModelEndpoint` flags the configured LLM host. */

--- a/src/core/trust.ts
+++ b/src/core/trust.ts
@@ -2,9 +2,11 @@ import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import path from 'node:path';
 import { defaultAuditDir, listRuns } from '../audit/log.js';
+import os from 'node:os';
 import {
   loadPolicy,
   checkEgress,
+  checkMcpServer,
   permissivePolicy,
   policyHash,
   type PolicySource,
@@ -43,8 +45,20 @@ export type TrustReport = {
     shell: { status: 'enforced' | 'unavailable' | 'unrestricted'; mechanism: string };
     runCheck: { status: 'enforced' | 'unavailable' | 'unrestricted'; mechanism: string };
   };
+  /** Configured MCP servers and how policy governs them (empty when none configured). */
+  mcp: McpServerPosture[];
   /** dvalincode's own runtime dependencies; omitted when not resolvable (e.g. in a compiled binary). */
   dependencies?: Record<string, string>;
+};
+
+export type McpServerPosture = {
+  id: string;
+  host: string;
+  enabled: boolean;
+  /** Whether the org policy's MCP allowlist permits this server. */
+  permitted: boolean;
+  /** Whether this server is reachable under the current network posture. */
+  egress: 'reachable' | 'denied-by-policy' | 'blocked-by-network';
 };
 
 export function buildTrustReport(cwd: string = process.cwd()): TrustReport {
@@ -83,8 +97,41 @@ export function buildTrustReport(cwd: string = process.cwd()): TrustReport {
       shell: shellEnforcement(shellPlan),
       runCheck: shellEnforcement(runCheckPlan),
     },
+    mcp: mcpPosture(loaded.policy),
     dependencies: readOwnDependencies(),
   };
+}
+
+/** Read configured MCP servers (best-effort, sync) and score each against policy. */
+function mcpPosture(policy: ResolvedPolicy): McpServerPosture[] {
+  const configPath = path.join(os.homedir(), '.dvalincode', 'config.json');
+  let servers: Array<{ id?: string; url?: string; enabled?: boolean }> = [];
+  try {
+    const cfg = JSON.parse(readFileSync(configPath, 'utf8')) as { mcp?: { servers?: typeof servers } };
+    servers = cfg.mcp?.servers ?? [];
+  } catch {
+    return [];
+  }
+  const networkOk = checkEgress(policy, false).allowed;
+  return servers
+    .filter(s => typeof s.id === 'string' && typeof s.url === 'string')
+    .map(s => {
+      const permitted = checkMcpServer(policy, s.id!).allowed;
+      const egress: McpServerPosture['egress'] = !permitted
+        ? 'denied-by-policy'
+        : networkOk
+          ? 'reachable'
+          : 'blocked-by-network';
+      return { id: s.id!, host: originOf(s.url!), enabled: Boolean(s.enabled), permitted, egress };
+    });
+}
+
+function originOf(url: string): string {
+  try {
+    return new URL(url).origin;
+  } catch {
+    return 'invalid-url';
+  }
 }
 
 /** Best-effort read of dvalincode's own package.json dependencies. */
@@ -130,6 +177,7 @@ export function renderTrustReport(r: TrustReport): string {
   lines.push(`    commands     ${describeCommands(p)}`);
   lines.push(`    paths        ${describePaths(p)}`);
   lines.push(`    tools        ${p.tools.deny.length ? `deny: ${p.tools.deny.join(', ')}` : 'all allowed'}`);
+  lines.push(`    mcp          ${p.mcp.allow ? `allow: ${p.mcp.allow.join(', ')}` : 'any configured server'}`);
   lines.push(`    maxToolCalls ${p.maxToolCalls ?? 'unlimited'}`);
   lines.push('  enforcement');
   lines.push(
@@ -143,6 +191,15 @@ export function renderTrustReport(r: TrustReport): string {
   lines.push(`  dir       ${r.audit.dir}`);
   lines.push(`  runs      ${r.audit.runCount} recorded`);
   lines.push('  verify    dvalincode report verify <run-id>');
+
+  if (r.mcp.length > 0) {
+    lines.push('');
+    lines.push('MCP servers (third-party tool surface)');
+    for (const s of r.mcp) {
+      const state = `${s.enabled ? 'enabled' : 'disabled'} · ${s.egress}`;
+      lines.push(`  ${s.id.padEnd(12)} ${s.host}  ${state}`);
+    }
+  }
 
   if (r.dependencies) {
     lines.push('');

--- a/src/mcp/client.ts
+++ b/src/mcp/client.ts
@@ -1,0 +1,141 @@
+import { governedMcpFetch, type McpEgressContext } from './governedFetch.js';
+
+/**
+ * A minimal, hand-rolled MCP client over the Streamable HTTP transport — no SDK,
+ * to preserve DvalinCode's zero-runtime-deps posture. It speaks only the three
+ * JSON-RPC methods v1 needs (`initialize`, `tools/list`, `tools/call`) and reads
+ * responses whether the server replies with `application/json` or a
+ * `text/event-stream` (SSE) body. All network I/O goes through `governedMcpFetch`.
+ */
+
+const PROTOCOL_VERSION = '2025-06-18';
+const CLIENT_INFO = { name: 'dvalincode', version: '0.9.0' };
+
+export type McpToolAnnotations = { readOnlyHint?: boolean; destructiveHint?: boolean; title?: string };
+
+export type McpToolDef = {
+  name: string;
+  description?: string;
+  inputSchema?: Record<string, unknown>;
+  annotations?: McpToolAnnotations;
+};
+
+export type McpContent = { type: string; text?: string; [key: string]: unknown };
+export type McpCallResult = { content?: McpContent[]; isError?: boolean };
+
+type JsonRpcMessage = {
+  jsonrpc?: string;
+  id?: number | string;
+  result?: Record<string, unknown>;
+  error?: { code?: number; message?: string };
+};
+
+export type McpServerRef = { id: string; url: string };
+
+export class McpClient {
+  private sessionId: string | undefined;
+  private nextId = 1;
+
+  constructor(
+    private readonly server: McpServerRef,
+    private readonly authHeaders: Record<string, string>,
+  ) {}
+
+  /**
+   * Handshake: `initialize` then the `notifications/initialized` acknowledgement.
+   * The egress context is passed per call so tool invocations can be audited
+   * against the live per-run sink (which the discovery step does not yet have).
+   */
+  async initialize(egress: McpEgressContext): Promise<void> {
+    await this.request('initialize', { protocolVersion: PROTOCOL_VERSION, capabilities: {}, clientInfo: CLIENT_INFO }, 'initialize', egress);
+    await this.notify('notifications/initialized', egress);
+  }
+
+  async listTools(egress: McpEgressContext): Promise<McpToolDef[]> {
+    const msg = await this.request('tools/list', {}, 'tools/list', egress);
+    return (msg.result?.tools as McpToolDef[] | undefined) ?? [];
+  }
+
+  async callTool(name: string, args: unknown, egress: McpEgressContext): Promise<McpCallResult> {
+    const msg = await this.request('tools/call', { name, arguments: args ?? {} }, name, egress);
+    return (msg.result as McpCallResult | undefined) ?? {};
+  }
+
+  // ── transport ────────────────────────────────────────────────────────────
+
+  private baseHeaders(): Record<string, string> {
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+      Accept: 'application/json, text/event-stream',
+      'MCP-Protocol-Version': PROTOCOL_VERSION,
+      ...this.authHeaders,
+    };
+    if (this.sessionId) headers['Mcp-Session-Id'] = this.sessionId;
+    return headers;
+  }
+
+  /** Send a JSON-RPC request and return the response message; throws on JSON-RPC error. */
+  private async request(method: string, params: Record<string, unknown>, auditTool: string, egress: McpEgressContext): Promise<JsonRpcMessage> {
+    const id = this.nextId++;
+    const res = await governedMcpFetch(
+      this.server.url,
+      { method: 'POST', headers: this.baseHeaders(), body: JSON.stringify({ jsonrpc: '2.0', id, method, params }) },
+      egress,
+      auditTool,
+    );
+    // The server assigns a session on initialize; carry it on every later call.
+    const session = res.headers.get('mcp-session-id');
+    if (session) this.sessionId = session;
+
+    if (!res.ok) throw new Error(`MCP ${method} failed: HTTP ${res.status}`);
+    const msg = await readJsonRpc(res, id);
+    if (msg.error) throw new Error(`MCP ${method} error: ${msg.error.message ?? `code ${msg.error.code}`}`);
+    return msg;
+  }
+
+  /** Fire-and-forget notification (no id, no response expected). */
+  private async notify(method: string, egress: McpEgressContext): Promise<void> {
+    try {
+      const res = await governedMcpFetch(
+        this.server.url,
+        { method: 'POST', headers: this.baseHeaders(), body: JSON.stringify({ jsonrpc: '2.0', method }) },
+        egress,
+        method,
+      );
+      await res.body?.cancel().catch(() => undefined);
+    } catch {
+      // Notifications are best-effort; a failure here must not abort discovery.
+    }
+  }
+}
+
+/**
+ * Read a JSON-RPC response whether the body is `application/json` (single object)
+ * or a `text/event-stream` (SSE) carrying the response as a `data:` event. For a
+ * short request/response this reads the full body — v1 does not stream partials.
+ */
+async function readJsonRpc(res: Response, id: number | string): Promise<JsonRpcMessage> {
+  const contentType = res.headers.get('content-type') ?? '';
+  if (!contentType.includes('text/event-stream')) {
+    return (await res.json()) as JsonRpcMessage;
+  }
+  const text = await res.text();
+  let fallback: JsonRpcMessage | undefined;
+  for (const line of text.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed.startsWith('data:')) continue;
+    const payload = trimmed.slice(5).trim();
+    if (!payload || payload === '[DONE]') continue;
+    let msg: JsonRpcMessage;
+    try {
+      msg = JSON.parse(payload) as JsonRpcMessage;
+    } catch {
+      continue;
+    }
+    if (msg.result === undefined && msg.error === undefined) continue;
+    if (msg.id === id) return msg;
+    fallback ??= msg;
+  }
+  if (fallback) return fallback;
+  throw new Error('no JSON-RPC response found in SSE stream');
+}

--- a/src/mcp/config.ts
+++ b/src/mcp/config.ts
@@ -1,0 +1,20 @@
+import type { McpServerConfig } from '../server/configStore.js';
+
+/**
+ * Resolve `${ENV}` placeholders in header values from the process environment.
+ * Secrets therefore live in the environment, never in DvalinCode's config file
+ * or audit trail. A missing variable resolves to an empty string (the request
+ * will fail auth loudly rather than silently sending a literal `${VAR}`).
+ */
+export function resolveHeaders(headers: Record<string, string> | undefined): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [key, value] of Object.entries(headers ?? {})) {
+    out[key] = value.replace(/\$\{([A-Za-z0-9_]+)\}/g, (_, name: string) => process.env[name] ?? '');
+  }
+  return out;
+}
+
+/** Servers that are explicitly enabled. Disabled/omitted servers are never connected. */
+export function enabledServers(servers: McpServerConfig[] | undefined): McpServerConfig[] {
+  return (servers ?? []).filter(s => s.enabled);
+}

--- a/src/mcp/governedFetch.ts
+++ b/src/mcp/governedFetch.ts
@@ -1,0 +1,57 @@
+import { checkEgress, PolicyViolationError, type ResolvedPolicy } from '../core/policy.js';
+import type { AuditSink } from '../audit/log.js';
+
+export type McpEgressContext = {
+  policy: ResolvedPolicy;
+  audit?: AuditSink;
+  serverId: string;
+};
+
+/**
+ * The one network path for MCP. Every request to a server passes through here so
+ * egress is enforced and audited before any third-party connection is made. An
+ * MCP gateway is **not** the model endpoint, so `checkEgress(policy, false)`
+ * blocks it under `network: off` / `endpoint-only`. Auth headers and bodies are
+ * never logged — the audit record carries only server, tool, host, outcome, and
+ * duration.
+ */
+export async function governedMcpFetch(
+  url: string,
+  init: RequestInit,
+  ctx: McpEgressContext,
+  tool: string,
+): Promise<Response> {
+  const host = safeOrigin(url);
+  const started = Date.now();
+
+  const decision = checkEgress(ctx.policy, false);
+  if (!decision.allowed) {
+    ctx.audit?.append({ type: 'mcp_request', server: ctx.serverId, tool, host, outcome: 'blocked', durationMs: Date.now() - started });
+    ctx.audit?.append({ type: 'policy_violation', rule: decision.rule, tool: `mcp:${ctx.serverId}`, target: host });
+    throw new PolicyViolationError(`mcp:${ctx.serverId}`, decision.rule, host);
+  }
+
+  try {
+    const res = await fetch(url, init);
+    ctx.audit?.append({
+      type: 'mcp_request',
+      server: ctx.serverId,
+      tool,
+      host,
+      outcome: res.ok ? 'ok' : 'error',
+      durationMs: Date.now() - started,
+    });
+    return res;
+  } catch (err) {
+    ctx.audit?.append({ type: 'mcp_request', server: ctx.serverId, tool, host, outcome: 'error', durationMs: Date.now() - started });
+    throw err;
+  }
+}
+
+function safeOrigin(url: string): string {
+  try {
+    return new URL(url).origin;
+  } catch {
+    return 'invalid-url';
+  }
+}

--- a/src/mcp/register.ts
+++ b/src/mcp/register.ts
@@ -1,0 +1,97 @@
+import { z } from 'zod';
+import { checkMcpServer, PolicyViolationError, type ResolvedPolicy } from '../core/policy.js';
+import type { AuditSink } from '../audit/log.js';
+import type { Tool, ToolAccess } from '../tools/types.js';
+import type { ToolRegistry } from '../tools/registry.js';
+import type { McpServerConfig } from '../server/configStore.js';
+import { McpClient, type McpToolDef, type McpCallResult } from './client.js';
+import { resolveHeaders, enabledServers } from './config.js';
+
+/** Namespaced tool name — collision-proof and provenance-visible in the audit trail. */
+export function mcpNamespacedName(serverId: string, toolName: string): string {
+  return `mcp__${serverId}__${toolName}`;
+}
+
+/** Governance-first: only an explicitly read-only tool is `read`; everything else is the most-gated tier. */
+function accessFor(def: McpToolDef): ToolAccess {
+  return def.annotations?.readOnlyHint ? 'read' : 'execute';
+}
+
+function renderContent(result: McpCallResult): string {
+  const parts = (result.content ?? []).map(c => (typeof c.text === 'string' ? c.text : `[${c.type}]`));
+  const text = parts.join('\n').trim();
+  if (text) return text;
+  return result.isError ? '(MCP tool returned an error with no content)' : '(no content)';
+}
+
+/** Adapt one discovered MCP tool into a DvalinCode `Tool` that proxies `tools/call`. */
+export function mcpToolToTool(serverId: string, def: McpToolDef, client: McpClient): Tool<unknown> {
+  return {
+    name: mcpNamespacedName(serverId, def.name),
+    description: def.description ?? `MCP tool "${def.name}" from server "${serverId}"`,
+    access: accessFor(def),
+    inputSchema: z.unknown(),
+    parametersSchema: def.inputSchema ?? { type: 'object' },
+    isConcurrencySafe: () => Boolean(def.annotations?.readOnlyHint),
+    async run(input, context) {
+      // Egress + audit are bound to the live per-run context here, so every
+      // tools/call is checked against policy and recorded in this run's chain.
+      const result = await client.callTool(def.name, input ?? {}, {
+        policy: context.policy,
+        audit: context.audit,
+        serverId,
+      });
+      return {
+        title: `MCP ${serverId}: ${def.name}`,
+        output: renderContent(result),
+        metadata: { server: serverId, tool: def.name, isError: Boolean(result.isError) },
+      };
+    },
+  };
+}
+
+export type McpServerStatus = 'connected' | 'denied' | 'blocked' | 'error';
+
+export type McpConnectionSummary = {
+  id: string;
+  status: McpServerStatus;
+  tools: number;
+  reason?: string;
+};
+
+/**
+ * Connect to each enabled + policy-permitted MCP server, discover its tools, and
+ * register them into the registry. Discovery egress is enforced by the governed
+ * fetch; per-tool calls are enforced and audited against the live run later.
+ */
+export async function registerMcpServers(
+  registry: ToolRegistry,
+  servers: McpServerConfig[] | undefined,
+  ctx: { policy: ResolvedPolicy; audit?: AuditSink },
+): Promise<McpConnectionSummary[]> {
+  const summaries: McpConnectionSummary[] = [];
+  for (const server of enabledServers(servers)) {
+    const decision = checkMcpServer(ctx.policy, server.id);
+    if (!decision.allowed) {
+      summaries.push({ id: server.id, status: 'denied', tools: 0, reason: decision.rule });
+      continue;
+    }
+
+    const client = new McpClient({ id: server.id, url: server.url }, resolveHeaders(server.headers));
+    const egress = { policy: ctx.policy, audit: ctx.audit, serverId: server.id };
+    try {
+      await client.initialize(egress);
+      const tools = await client.listTools(egress);
+      for (const def of tools) registry.register(mcpToolToTool(server.id, def, client));
+      summaries.push({ id: server.id, status: 'connected', tools: tools.length });
+    } catch (err) {
+      const blocked = err instanceof PolicyViolationError;
+      summaries.push({ id: server.id, status: blocked ? 'blocked' : 'error', tools: 0, reason: errMsg(err) });
+    }
+  }
+  return summaries;
+}
+
+function errMsg(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}

--- a/src/server/configStore.ts
+++ b/src/server/configStore.ts
@@ -34,10 +34,22 @@ export type ProviderPoolConfig = {
   entries: PoolEntry[];
 };
 
+/** A remote MCP server DvalinCode may connect to. Header values may contain
+ * `${ENV}` placeholders resolved from the environment at connect time. */
+export type McpServerConfig = {
+  id: string;
+  url: string;
+  headers?: Record<string, string>;
+  enabled?: boolean;
+};
+
+export type McpConfig = { servers: McpServerConfig[] };
+
 export type AppConfig = {
   llm: LLMConfig;
   profiles?: Record<string, Profile>;
   pool?: ProviderPoolConfig;
+  mcp?: McpConfig;
 };
 
 const CONFIG_DIR = join(homedir(), '.dvalincode');
@@ -60,6 +72,8 @@ export async function readConfig(): Promise<AppConfig> {
     return {
       llm: { ...DEFAULTS.llm, ...parsed.llm },
       profiles: parsed.profiles,
+      pool: parsed.pool,
+      mcp: parsed.mcp,
     };
   } catch {
     return DEFAULTS;
@@ -92,6 +106,17 @@ export function maskConfig(config: AppConfig): AppConfig & { llm: { apiKeySet: b
       }
     : undefined;
 
+  const maskedMcp: McpConfig | undefined = config.mcp
+    ? {
+        servers: config.mcp.servers.map(s => ({
+          ...s,
+          headers: s.headers
+            ? Object.fromEntries(Object.keys(s.headers).map(k => [k, '••••••••']))
+            : undefined,
+        })),
+      }
+    : undefined;
+
   return {
     ...config,
     llm: {
@@ -101,5 +126,6 @@ export function maskConfig(config: AppConfig): AppConfig & { llm: { apiKeySet: b
     },
     profiles: maskedProfiles,
     pool: maskedPool,
+    mcp: maskedMcp,
   };
 }

--- a/src/tools/types.ts
+++ b/src/tools/types.ts
@@ -24,6 +24,12 @@ export type Tool<Input> = {
   description: string;
   access: ToolAccess;
   inputSchema: z.ZodType<Input>;
+  /**
+   * Pre-computed JSON Schema for the LLM's tool parameters. When set, it is used
+   * instead of deriving one from `inputSchema` — e.g. MCP tools carry their
+   * server's native input schema rather than a DvalinCode-authored zod type.
+   */
+  parametersSchema?: Record<string, unknown>;
   isConcurrencySafe?: (input: Input) => boolean;
   run(input: Input, context: DvalinContext): Promise<ToolResult>;
 

--- a/tests/mcp/mcp.test.ts
+++ b/tests/mcp/mcp.test.ts
@@ -1,0 +1,217 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { McpClient } from '../../src/mcp/client.js';
+import { mcpToolToTool, registerMcpServers } from '../../src/mcp/register.js';
+import { resolveHeaders } from '../../src/mcp/config.js';
+import { governedMcpFetch } from '../../src/mcp/governedFetch.js';
+import { permissivePolicy, resolvePolicy, PolicyViolationError } from '../../src/core/policy.js';
+import { ToolRegistry } from '../../src/tools/registry.js';
+import { createDvalinContext } from '../../src/core/context.js';
+import type { AuditEvent, AuditSink } from '../../src/audit/log.js';
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+function collector() {
+  const events: AuditEvent[] = [];
+  const sink = { append: (e: AuditEvent) => events.push(e) } as unknown as AuditSink;
+  return { sink, events };
+}
+
+function jsonResponse(body: unknown, headers: Record<string, string> = {}): Response {
+  return new Response(JSON.stringify(body), { status: 200, headers: { 'content-type': 'application/json', ...headers } });
+}
+
+const SEARCH_DEF = {
+  name: 'search',
+  description: 'Search docs',
+  inputSchema: { type: 'object', properties: { q: { type: 'string' } } },
+  annotations: { readOnlyHint: true },
+};
+const WRITE_DEF = { name: 'write_note', description: 'Write a note', inputSchema: { type: 'object' } };
+
+function mockServer(): ReturnType<typeof vi.fn> {
+  return vi.fn(async (_url: string | URL, init: RequestInit) => {
+    const req = JSON.parse(init.body as string) as { id?: number; method: string; params?: any };
+    switch (req.method) {
+      case 'initialize':
+        return jsonResponse(
+          { jsonrpc: '2.0', id: req.id, result: { protocolVersion: '2025-06-18', capabilities: {}, serverInfo: { name: 'mock' } } },
+          { 'mcp-session-id': 'sess-1' },
+        );
+      case 'notifications/initialized':
+        return new Response(null, { status: 202 });
+      case 'tools/list':
+        return jsonResponse({ jsonrpc: '2.0', id: req.id, result: { tools: [SEARCH_DEF, WRITE_DEF] } });
+      case 'tools/call':
+        return jsonResponse({
+          jsonrpc: '2.0',
+          id: req.id,
+          result: { content: [{ type: 'text', text: `called ${req.params.name} args=${JSON.stringify(req.params.arguments)}` }] },
+        });
+      default:
+        return jsonResponse({ jsonrpc: '2.0', id: req.id, error: { code: -32601, message: 'method not found' } });
+    }
+  });
+}
+
+const egress = (policy = permissivePolicy(), audit?: AuditSink) => ({ policy, audit, serverId: 'glama' });
+
+afterEach(() => vi.unstubAllGlobals());
+
+// ── config ─────────────────────────────────────────────────────────────────
+
+describe('mcp config', () => {
+  it('resolves ${ENV} placeholders in headers from the environment', () => {
+    process.env.TEST_MCP_KEY = 'secret-123';
+    expect(resolveHeaders({ Authorization: 'Bearer ${TEST_MCP_KEY}' })).toEqual({ Authorization: 'Bearer secret-123' });
+    delete process.env.TEST_MCP_KEY;
+  });
+});
+
+// ── client protocol ──────────────────────────────────────────────────────────
+
+describe('McpClient (Streamable HTTP)', () => {
+  it('initializes, lists tools, and proxies a call (JSON transport)', async () => {
+    const fetchMock = mockServer();
+    vi.stubGlobal('fetch', fetchMock);
+    const client = new McpClient({ id: 'glama', url: 'https://glama.ai/mcp/x' }, {});
+
+    await client.initialize(egress());
+    const tools = await client.listTools(egress());
+    expect(tools.map(t => t.name)).toEqual(['search', 'write_note']);
+
+    const result = await client.callTool('search', { q: 'hello' }, egress());
+    expect(result.content?.[0]?.text).toContain('called search args={"q":"hello"}');
+
+    // Session id from initialize is echoed on later requests.
+    const listCall = fetchMock.mock.calls.find(c => JSON.parse(c[1].body).method === 'tools/list');
+    expect((listCall![1].headers as Record<string, string>)['Mcp-Session-Id']).toBe('sess-1');
+  });
+
+  it('reads a JSON-RPC response delivered as an SSE stream', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (_u: string, init: RequestInit) => {
+      const req = JSON.parse(init.body as string);
+      if (req.method === 'initialize') return jsonResponse({ jsonrpc: '2.0', id: req.id, result: {} });
+      if (req.method === 'notifications/initialized') return new Response(null, { status: 202 });
+      const sse = `event: message\ndata: ${JSON.stringify({ jsonrpc: '2.0', id: req.id, result: { tools: [SEARCH_DEF] } })}\n\n`;
+      return new Response(sse, { status: 200, headers: { 'content-type': 'text/event-stream' } });
+    }));
+    const client = new McpClient({ id: 'glama', url: 'https://glama.ai/mcp/x' }, {});
+    await client.initialize(egress());
+    const tools = await client.listTools(egress());
+    expect(tools[0].name).toBe('search');
+  });
+});
+
+// ── egress governance ────────────────────────────────────────────────────────
+
+describe('governed MCP egress', () => {
+  it('blocks the connection under network: off and never calls fetch', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+    const { sink, events } = collector();
+    const off = resolvePolicy([{ network: 'off' }]);
+
+    await expect(
+      governedMcpFetch('https://glama.ai/mcp/x', { method: 'POST' }, egress(off, sink), 'initialize'),
+    ).rejects.toBeInstanceOf(PolicyViolationError);
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    const req = events.find(e => e.type === 'mcp_request');
+    expect(req).toMatchObject({ type: 'mcp_request', server: 'glama', host: 'https://glama.ai', outcome: 'blocked' });
+    expect(events.some(e => e.type === 'policy_violation')).toBe(true);
+  });
+
+  it('blocks under endpoint-only (an MCP gateway is not the model endpoint)', async () => {
+    vi.stubGlobal('fetch', vi.fn());
+    const ep = resolvePolicy([{ network: 'endpoint-only' }]);
+    await expect(
+      governedMcpFetch('https://glama.ai/mcp/x', { method: 'POST' }, egress(ep), 'tools/call'),
+    ).rejects.toBeInstanceOf(PolicyViolationError);
+  });
+
+  it('audits a successful call without leaking auth headers, args, or body', async () => {
+    vi.stubGlobal('fetch', mockServer());
+    const { sink, events } = collector();
+    const client = new McpClient({ id: 'glama', url: 'https://glama.ai/mcp/x' }, { Authorization: 'Bearer secret-xyz' });
+    await client.initialize(egress(permissivePolicy(), sink));
+    await client.callTool('search', { q: 'sensitive query' }, egress(permissivePolicy(), sink));
+
+    const serialized = JSON.stringify(events);
+    expect(serialized).not.toContain('secret-xyz');
+    expect(serialized).not.toContain('sensitive query');
+    const call = events.filter(e => e.type === 'mcp_request');
+    expect(call.every(e => (e as any).outcome === 'ok')).toBe(true);
+    expect(call.some(e => (e as any).tool === 'search')).toBe(true);
+  });
+});
+
+// ── tool adapter + registry ──────────────────────────────────────────────────
+
+describe('mcp tool adapter', () => {
+  it('maps annotations to access and namespaces the tool name', () => {
+    const client = new McpClient({ id: 'glama', url: 'https://x' }, {});
+    const read = mcpToolToTool('glama', SEARCH_DEF, client);
+    const write = mcpToolToTool('glama', WRITE_DEF, client);
+    expect(read.name).toBe('mcp__glama__search');
+    expect(read.access).toBe('read');
+    expect(read.parametersSchema).toEqual(SEARCH_DEF.inputSchema);
+    // Un-annotated tools default to the most-gated tier.
+    expect(write.access).toBe('execute');
+  });
+
+  it('is blocked by tools.deny at the registry chokepoint like any other tool', async () => {
+    vi.stubGlobal('fetch', mockServer());
+    const registry = new ToolRegistry();
+    const client = new McpClient({ id: 'glama', url: 'https://glama.ai/mcp/x' }, {});
+    registry.register(mcpToolToTool('glama', SEARCH_DEF, client));
+
+    const denied = createDvalinContext({
+      approvalMode: 'full-auto',
+      policy: resolvePolicy([{ tools: { deny: ['mcp__glama__search'] } }]),
+    });
+    await expect(registry.run('mcp__glama__search', { q: 'x' }, denied)).rejects.toBeInstanceOf(PolicyViolationError);
+  });
+});
+
+// ── server admission ──────────────────────────────────────────────────────────
+
+describe('registerMcpServers admission', () => {
+  it('does not connect a server absent from the policy mcp allowlist', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+    const registry = new ToolRegistry();
+    const summaries = await registerMcpServers(
+      registry,
+      [{ id: 'evil', url: 'https://evil.example/mcp', enabled: true }],
+      { policy: resolvePolicy([{ mcp: { allow: ['glama'] } }]) },
+    );
+    expect(summaries[0]).toMatchObject({ id: 'evil', status: 'denied', tools: 0 });
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(registry.list()).toHaveLength(0);
+  });
+
+  it('skips disabled servers entirely', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+    const registry = new ToolRegistry();
+    const summaries = await registerMcpServers(
+      registry,
+      [{ id: 'glama', url: 'https://glama.ai/mcp/x', enabled: false }],
+      { policy: permissivePolicy() },
+    );
+    expect(summaries).toHaveLength(0);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('connects an allowed server and registers its tools', async () => {
+    vi.stubGlobal('fetch', mockServer());
+    const registry = new ToolRegistry();
+    const summaries = await registerMcpServers(
+      registry,
+      [{ id: 'glama', url: 'https://glama.ai/mcp/x', enabled: true }],
+      { policy: permissivePolicy() },
+    );
+    expect(summaries[0]).toMatchObject({ id: 'glama', status: 'connected', tools: 2 });
+    expect(registry.list().map(t => t.name)).toEqual(['mcp__glama__search', 'mcp__glama__write_note']);
+  });
+});


### PR DESCRIPTION
Adds a **governed** remote MCP client so DvalinCode can use tools from remote MCP servers/gateways — notably [Glama](https://glama.ai/) — with **zero new runtime dependencies** (hand-rolled to preserve the zero-dep posture). Design + acceptance matrix: [`docs/GOVERNED-MCP.md`](docs/GOVERNED-MCP.md).

## Why "governed", not just "MCP"

The gateway governs the **server** side. DvalinCode's job is **client-side** governance: org policy bounds what the agent may do with those tools, the tamper-evident audit records every call, and the egress guard controls the third-party connection. **Trust is never outsourced to the gateway.** For a security-review-approvable agent, remote MCP (arbitrary third-party egress) is exactly the surface that must be governed from day one.

## What's new (`src/mcp/`)

- **`client.ts`** — minimal Streamable HTTP JSON-RPC client: `initialize` / `tools/list` / `tools/call`, handles both `application/json` and `text/event-stream` (SSE) responses, carries `Mcp-Session-Id`.
- **`governedFetch.ts`** — the single MCP network path: `checkEgress` before every request + an `mcp_request` audit event. Never logs auth headers, args, or response bodies.
- **`register.ts`** — maps each MCP tool → a DvalinCode `Tool` (`mcp__<server>__<tool>`, access from annotations, `run` proxies `tools/call`) + `registerMcpServers` (policy admission + discovery).
- **`config.ts`** — `${ENV}` secret resolution; only `enabled` servers connect.

## Governance wired into existing chokepoints

- `core/policy.ts` — new `mcp` server allowlist (narrowing-preserving) + `checkMcpServer`.
- `audit/log.ts` — `mcp_request` event type.
- `agent/session.ts` — opt-in registration, **acting modes only**, gated by policy + network; **off by default** (a run with no MCP config behaves exactly as today — no new egress, no latency).
- `core/trust.ts` — new "MCP servers (third-party tool surface)" section + an `mcp` policy line.
- `server/configStore.ts` — `mcp` config with masked secrets; `tools/types.ts` — `parametersSchema` passthrough so the LLM sees the server's native input schema.

## Guarantees (unit-tested **and** verified live over a real socket)

- **Egress-gated**: an MCP gateway isn't the model endpoint, so `network: off` / `endpoint-only` **blocks** it before any socket opens (`PolicyViolationError`).
- **Same chokepoint**: MCP tools are ordinary `Tool`s → `tools.deny`, permission-by-access, the approval gate, and audit all apply (tested: `mcp__glama__search` blocked by `tools.deny`).
- **Server admission**: a server absent from `policy.mcp.allow` is never connected (no fetch).
- **Credential minimization**: the Bearer token comes from `${ENV}` and **never** appears in the audit trail (asserted).

## Using it with Glama

```jsonc
{ "mcp": { "servers": [{
  "id": "glama",
  "url": "https://glama.ai/mcp/<endpoint>",
  "headers": { "Authorization": "Bearer ${GLAMA_API_KEY}" },
  "enabled": true
}]}}
```

## Verification

- `npm run check`: **173 passed** (was 162; +11 MCP tests), typecheck clean.
- Live smoke test against a real local HTTP MCP server: discovered a tool, called it, confirmed `mcp_request` audit events with **no token leak**, and confirmed `network: off` blocks the call.

## Deferred (documented non-goals)

stdio/local servers, OAuth/dynamic client registration, MCP resources/prompts/sampling, per-host allowlists beyond the `network` level, and auditing the pre-run discovery connection (tool *calls* are audited; discovery egress is enforced but not yet chained to the per-run sink).

🤖 Generated with [Claude Code](https://claude.com/claude-code)