### PR TITLE
docs: OSS front door — 60-second trust path, real CONTRIBUTING, public ROADMAP

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,27 +1,54 @@
 # Contributing
 
-Thanks for helping improve DvalinCode.
+Thanks for helping improve DvalinCode. Contributions of all sizes are welcome — docs, tests, bug reports, and features.
 
-## Development
+**The North Star** (it decides every design argument): *make DvalinCode trivially approvable by any company's security review* — controllable, transparent, auditable — while staying as convenient as any mainstream coding agent.
+
+## Getting started
 
 ```sh
+git clone https://github.com/arthurpanhku/dvalincode
+cd dvalincode
 npm install
-npm run check
+npm run check        # typecheck + full test suite — must be green before and after your change
+npm run build && node dist/index.js trust   # see the governance surface you're working on
 ```
 
-## Guidelines
+Good entry points are labeled [`good first issue`](https://github.com/arthurpanhku/dvalincode/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22). Larger items live in [ROADMAP.md](ROADMAP.md) and issues labeled `help wanted`. If you want to work on something, comment on the issue so we don't duplicate effort — **maintainers aim to respond to new PRs and issues within 48 hours.**
 
-- Keep tools small and explicit.
-- Add a Zod schema for every tool input.
-- Put permission-sensitive behavior behind the permission model.
-- Add tests for new core behavior.
+## Architecture in five lines
+
+- `src/agent/` — the turn loop (`session.ts` → `loop.ts` → `runner.ts`); all three frontends (TUI, web, desktop) drive the same `runAgentTurn`.
+- `src/tools/` — every capability is a typed `Tool` registered in `registry.ts`. **`registry.run` is the single policy + permission + audit chokepoint.**
+- `src/core/policy.ts` — org policy, resolved by *narrowing* (a repo policy can only tighten a machine policy, never widen it).
+- `src/audit/` — tamper-evident, hash-chained, minimized run logs. `src/mcp/`, `src/providers/` — all outbound network goes through a governed fetch.
+- `docs/` — design docs with acceptance matrices ([EGRESS-THREAT-MODEL](docs/EGRESS-THREAT-MODEL.md), [GOVERNED-MCP](docs/GOVERNED-MCP.md), [DURABLE-SESSION](docs/DURABLE-SESSION.md)). Read the one covering your area before coding.
+
+## The governance rules (non-negotiable)
+
+These are what make the project what it is. A PR that violates one will be asked to restructure, no matter how useful the feature:
+
+1. **No side doors.** Anything that produces a side effect, network egress, or a permission change must pass through the existing chokepoints (`registry.run`, `governedProviderFetch` / `governedMcpFetch`, `runGovernedProcess`) — never a direct `fetch`/`exec`/`spawn`.
+2. **Narrowing only.** Policy changes may add restrictions; they may never let a repo-level source widen a machine-level one, and must keep the canonical policy hash stable for unchanged policies.
+3. **Minimize, don't leak.** Audit records carry hashes, sizes, and structure — never prompts, file contents, shell arguments, or credentials.
+4. **Honest enforcement.** If a control can't be enforced on some platform, it fails closed or reports `unavailable` — it is never silently advisory. Document exemptions in the threat model instead of hiding them.
+5. **Zero runtime deps is a feature.** New runtime dependencies need a very strong case; prefer hand-rolling small clients (see `src/mcp/client.ts` for the pattern).
+
+## Everyday guidelines
+
+- Keep tools small and explicit; add a Zod schema for every tool input.
+- Put permission-sensitive behavior behind the permission model and declare `policyTargets`.
+- Add tests for new core behavior — governance guarantees get *bypass tests* (prove the block actually blocks).
+- Match the surrounding code's style; no drive-by reformatting.
 - Do not copy code, prompts, or product text from proprietary or unclear-license projects.
 
-## Pull Requests
+## Pull requests
 
-Please include:
+- Conventional-commit style titles (`feat:`, `fix:`, `docs:`, `test:` …).
+- Say **what** changed, **why**, and **how you tested it** (paste the `npm run check` tail).
+- Security-sensitive changes (policy, audit, egress, sandbox, credentials): note the impact explicitly and update the relevant threat-model doc in the same PR.
+- One logical change per PR — small PRs get reviewed fast.
 
-- What changed
-- Why it changed
-- How you tested it
+## Reporting security issues
 
+**Not** via public issues — see [SECURITY.md](SECURITY.md) for private reporting and scope.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 <p align="center">
   <a href="https://github.com/arthurpanhku/dvalincode/releases/latest"><img src="https://img.shields.io/github/v/release/arthurpanhku/dvalincode?style=for-the-badge&color=818cf8&label=Release" alt="Release"></a>
   <a href="https://github.com/arthurpanhku/dvalincode/releases"><img src="https://img.shields.io/github/downloads/arthurpanhku/dvalincode/total?style=for-the-badge&color=blue&label=Downloads" alt="Downloads"></a>
-  <a href="#-tests"><img src="https://img.shields.io/badge/Tests-162%20%2F%20162%20%E2%9C%93-success?style=for-the-badge" alt="Tests"></a>
+  <a href="#-tests"><img src="https://img.shields.io/badge/Tests-173%20%2F%20173%20%E2%9C%93-success?style=for-the-badge" alt="Tests"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-green?style=for-the-badge" alt="License"></a>
   <a href="https://scorecard.dev/viewer/?uri=github.com/arthurpanhku/dvalincode"><img src="https://api.scorecard.dev/projects/github.com/arthurpanhku/dvalincode/badge" alt="OpenSSF Scorecard"></a>
   <a href="#-quick-install"><img src="https://img.shields.io/badge/Platforms-macOS%20·%20Windows%20·%20Linux-blue?style=for-the-badge" alt="Platforms"></a>
@@ -29,6 +29,29 @@
 <p align="center">
   Bring your own model — DeepSeek, OpenAI, Claude (via OpenRouter), Groq, Ollama, or any OpenAI-compatible endpoint. Switch with one click, no code changes, no lock-in.
 </p>
+
+---
+
+## ⏱️ 60 seconds to proof
+
+Don't take the claims on trust — verify them on your own machine:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/arthurpanhku/dvalincode/main/scripts/install.sh | bash
+dvalincode trust
+```
+
+`trust` prints this install's **live security posture**: the resolved org policy and its hash, per-boundary network enforcement (provider · shell · MCP), and the tamper-evident audit status — the exact evidence a security reviewer needs, straight from the tool itself.
+
+<p align="center">
+  <img src="assets/cli-trust.gif" alt="dvalincode trust — live security posture under an org policy" width="100%">
+</p>
+
+Then let the agent work, and prove what it did after the fact:
+
+```sh
+dvalincode report verify    # re-derive the hash chain of the last run's audit log
+```
 
 ---
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -9,7 +9,7 @@
 <p align="center">
   <a href="https://github.com/arthurpanhku/dvalincode/releases/latest"><img src="https://img.shields.io/github/v/release/arthurpanhku/dvalincode?style=for-the-badge&color=818cf8&label=Release" alt="Release"></a>
   <a href="https://github.com/arthurpanhku/dvalincode/releases"><img src="https://img.shields.io/github/downloads/arthurpanhku/dvalincode/total?style=for-the-badge&color=blue&label=Downloads" alt="Downloads"></a>
-  <a href="#-测试"><img src="https://img.shields.io/badge/Tests-162%20%2F%20162%20%E2%9C%93-success?style=for-the-badge" alt="Tests"></a>
+  <a href="#-测试"><img src="https://img.shields.io/badge/Tests-173%20%2F%20173%20%E2%9C%93-success?style=for-the-badge" alt="Tests"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-green?style=for-the-badge" alt="License"></a>
   <a href="https://scorecard.dev/viewer/?uri=github.com/arthurpanhku/dvalincode"><img src="https://api.scorecard.dev/projects/github.com/arthurpanhku/dvalincode/badge" alt="OpenSSF Scorecard"></a>
   <a href="#-一行安装"><img src="https://img.shields.io/badge/Platforms-macOS%20·%20Windows%20·%20Linux-blue?style=for-the-badge" alt="Platforms"></a>
@@ -29,6 +29,29 @@
 <p align="center">
   自带模型 —— DeepSeek、OpenAI、Claude (via OpenRouter)、Groq、Ollama，或任何 OpenAI 兼容端点。一键切换，无需改代码，无供应商绑定。
 </p>
+
+---
+
+## ⏱️ 60 秒自证
+
+别听宣传——在你自己的机器上验证：
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/arthurpanhku/dvalincode/main/scripts/install.sh | bash
+dvalincode trust
+```
+
+`trust` 打印本机的**实时安全态势**：解析后的组织策略及其哈希、各边界的网络强制状态（provider · shell · MCP）、防篡改审计状态——安全评审需要的证据，由工具自己给出。
+
+<p align="center">
+  <img src="assets/cli-trust.gif" alt="dvalincode trust —— 组织策略下的实时安全态势" width="100%">
+</p>
+
+然后让 agent 干活，事后证明它做过什么：
+
+```sh
+dvalincode report verify    # 重新推导上次运行审计日志的哈希链
+```
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,42 @@
+# Roadmap
+
+**North Star:** make DvalinCode trivially approvable by any company's security review — controllable, transparent, auditable — while staying as convenient as any mainstream coding agent.
+
+Every item below is governed by one architectural rule: *no capability may bypass the policy + audit chokepoints* (see [CONTRIBUTING.md](CONTRIBUTING.md) → "governance rules"). Design docs with acceptance matrices land in `docs/` before implementation.
+
+Issues are the source of truth for status; this file is the map. Want one of these? Comment on its issue — most have a `help wanted` or `good first issue` label.
+
+## Now (in progress / next up)
+
+| Item | Why it matters | Ref |
+|---|---|---|
+| **Evidence Pack v1** | Turn governance claims into an offline-verifiable bundle (resolved policy + hash, audit chains, enforcement posture, run summaries) mapped to OpenSSF / ISO-42001 clauses. Evidence > claims — the highest-leverage step toward the North Star. | [#51](https://github.com/arthurpanhku/dvalincode/issues/51) |
+| **Fix `run-tool` policy bypass** | The `run-tool` CLI entrypoint builds its context without `loadPolicy`, sidestepping org policy — a real governance gap. | [#45](https://github.com/arthurpanhku/dvalincode/issues/45) |
+| **Durable-session transport wiring** | Engine-level crash recovery + idempotent replay exist; transports don't pass a stable `messageId` or surface recovered turns yet. | [#46](https://github.com/arthurpanhku/dvalincode/issues/46) · [#47](https://github.com/arthurpanhku/dvalincode/issues/47) |
+
+## Next
+
+| Item | Why it matters | Ref |
+|---|---|---|
+| **stdio / local MCP servers** | Local MCP without network egress — completes the MCP story beyond remote gateways. Same governed mapping as [GOVERNED-MCP.md](docs/GOVERNED-MCP.md). | [#52](https://github.com/arthurpanhku/dvalincode/issues/52) |
+| **Structured approval engine** | Upgrade boolean approvals to scoped grants ("allow `npm test` for this run") — subject, scope, expiry, recorded in audit. | [#53](https://github.com/arthurpanhku/dvalincode/issues/53) |
+| **Read-only Explore subagent** | Parallel read-only exploration that inherits the parent policy and gets its own audit chain linked to the parent run. | [#54](https://github.com/arthurpanhku/dvalincode/issues/54) |
+| **Remediation worktree under the sandbox profile** | Close the documented exemption for the two local git calls (needs sandbox write access to the remediation dir first). | [#55](https://github.com/arthurpanhku/dvalincode/issues/55) |
+| **MCP discovery audit anchoring** | Tool *calls* are audited per run; anchor the pre-run discovery connection into the chain as well. | [#56](https://github.com/arthurpanhku/dvalincode/issues/56) |
+| **`run_check` / `shell` sandbox parity under `network: on`** | Remove the documented asymmetry, or make it a policy choice. | [#50](https://github.com/arthurpanhku/dvalincode/issues/50) |
+
+## Later
+
+- **Native provider adapters** (Anthropic, Responses API) behind `governedProviderFetch` — reasoning, caching, structured output; model capability manifest + policy-driven model allowlists.
+- **Windows subprocess network isolation** (currently honest fail-closed / `unavailable`).
+- **ACP editor interop** — one adapter on `runAgentTurn` instead of N editor plugins.
+- **Server-mediated enforcement** — hard policy custody beyond local tamper-evidence (the "A5" track in [APPROVABILITY-PLAN.md](docs/APPROVABILITY-PLAN.md)).
+
+## Non-goals
+
+Deliberate, not omissions:
+
+- **In-process plugin loading** (from npm or local dirs) — arbitrary code inside the trust boundary is the opposite of approvable. Extensibility goes through governed MCP and skills.
+- **Cloud sync / sharing services, marketplaces** — the value proposition is local-first custody.
+- **Feature parity with large agent runtimes** — we compete on *approvability*, not surface area.
+- **Persistent unattended PTY** — the one-shot, sandboxed shell is a security feature; long-lived interactive terminals need a governance design first.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -66,6 +66,10 @@ Out of scope:
 - Issues requiring physical access to an already-compromised machine.
 - Denial-of-service findings without a practical security impact.
 - Reports that depend on intentionally disabling documented safety controls.
+- The explicitly documented enforcement exemptions and non-goals in
+  [docs/EGRESS-THREAT-MODEL.md](docs/EGRESS-THREAT-MODEL.md) (e.g. the local git
+  calls in `remediation/worktree.ts`), unless you can demonstrate a practical
+  escalation through them.
 
 ## Security Expectations
 


### PR DESCRIPTION
## Summary

Two layers of the open-source community plan, docs-only (no code change):

**Front door (first screen):**
- New **"⏱️ 60 seconds to proof"** section on both READMEs (EN + 中文): `install → dvalincode trust → report verify`, reusing `cli-trust.gif`. The first action a visitor sees is *verifying the governance claims on their own machine* — "don't take the claims on trust."
- Tests badge 162 → 173 (stale since the MCP merge).
- SECURITY.md: added a documented-exemptions clause to out-of-scope, pointing at the egress threat model (prevents low-quality reports against known, documented exemptions).

**Community surface:**
- **CONTRIBUTING.md** grows from a 478-byte stub into a real contributor guide: architecture-in-five-lines, the **five non-negotiable governance rules** (no side doors · narrowing only · minimize don't leak · honest enforcement · zero runtime deps), bypass-test expectations for governance guarantees, PR conventions, and a **48-hour response commitment**.
- **ROADMAP.md** (new): public Now / Next / Later map, every item cross-linked to a seeded issue, plus deliberate **Non-goals** (in-process plugins, marketplaces, feature-parity chase).

Done alongside this PR, directly in GitHub settings (not part of the diff, noting for the record):
- Repo description now leads with the governance one-liner ("The AI coding agent your security team can approve — …").
- **Private vulnerability reporting enabled** — SECURITY.md pointed at it, but the setting was off.
- **13 issues seeded** from the real backlog: 7 `good first issue` (#45–#50, #57) + 6 `help wanted` (#51–#56), each with context, file pointers, and acceptance criteria. ROADMAP links to all of them.

## Testing

Docs-only; no code paths changed. Verified: install command matches the existing Quick Install section verbatim; all GIF/doc links resolve on this branch; badge count matches `main`'s current suite (173).

## Security and AI Governance

- [x] This change does not expand file, shell, network, model, or approval permissions.
- [x] If it changes agent behavior, prompts, policy, providers, audit logging, or release/build security, I updated the relevant governance evidence in `docs/`. *(N/A — docs only; SECURITY.md scope note added.)*
- [x] If it introduces a new model/provider/tool or new data flow, I completed `docs/governance/AI-CHANGE-IMPACT-ASSESSMENT.md`. *(N/A — no new data flow.)*

## Notes

- CONTRIBUTING's governance rules are written to be citable in reviews ("see rule 1: no side doors") — they mirror the forward guardrails already embedded in the threat-model docs.
- The 48-hour response commitment starts mattering the moment this merges; issues are now the public entry point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)