### PR TITLE
fix: run-tool CLI entrypoint enforces org policy

### DIFF
--- a/src/commands/runTool.ts
+++ b/src/commands/runTool.ts
@@ -1,5 +1,6 @@
 import type { Command } from 'commander';
 import { createDvalinContext } from '../core/context.js';
+import { loadPolicy } from '../core/policy.js';
 import type { ToolRegistry } from '../tools/registry.js';
 import { renderToolResult } from '../ui/output.js';
 
@@ -12,10 +13,20 @@ export function registerRunToolCommand(program: Command, registry: ToolRegistry)
     .option('-y, --yes', 'allow tools that execute processes or modify files', false)
     .action(async (name: string, options: { input: string; yes: boolean }) => {
       const input = parseJson(options.input);
+      // Org policy applies to every entrypoint, including this one (#45).
+      // Mirrors runAgentTurn: malformed sources are skipped loudly, never
+      // silently treated as "allow everything".
+      const loadedPolicy = loadPolicy(process.cwd());
+      for (const source of loadedPolicy.sources) {
+        if (source.error) {
+          console.warn(`⚠ Ignored malformed policy at ${source.path}: ${source.error}`);
+        }
+      }
       const context = createDvalinContext({
         cwd: process.cwd(),
         allowExecute: options.yes,
         allowWrite: options.yes,
+        policy: loadedPolicy.policy,
       });
       const result = await registry.run(name, input, context);
       console.log(renderToolResult(result));

--- a/tests/commands/runTool.test.ts
+++ b/tests/commands/runTool.test.ts
@@ -1,0 +1,110 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { z } from 'zod';
+import { Command } from 'commander';
+import { registerRunToolCommand } from '../../src/commands/runTool.js';
+import { ToolRegistry } from '../../src/tools/registry.js';
+import { PolicyViolationError } from '../../src/core/policy.js';
+import type { Tool } from '../../src/tools/types.js';
+
+// Regression tests for #45: the run-tool CLI entrypoint must enforce org
+// policy exactly like the agent path, not bypass it.
+
+function testTool(ran: { value: boolean }): Tool<{ text: string }> {
+  return {
+    name: 'echo_test',
+    description: 'echo for tests',
+    access: 'execute',
+    inputSchema: z.object({ text: z.string() }),
+    policyTargets: input => [{ kind: 'command', value: `echo_test ${input.text}` }],
+    async run(input) {
+      ran.value = true;
+      return { title: 'Echo', output: input.text };
+    },
+  };
+}
+
+function makeProgram(registry: ToolRegistry): Command {
+  const program = new Command();
+  program.exitOverride(); // surface errors instead of process.exit
+  registerRunToolCommand(program, registry);
+  return program;
+}
+
+async function invoke(program: Command, args: string[]): Promise<void> {
+  await program.parseAsync(['node', 'dvalincode', 'run-tool', ...args]);
+}
+
+describe('run-tool org policy enforcement (#45)', () => {
+  let dir: string;
+  afterEach(() => {
+    delete process.env.DVALINCODE_POLICY_FILE;
+    if (dir) rmSync(dir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it('blocks a tool denied by policy and never runs it', async () => {
+    dir = mkdtempSync(join(tmpdir(), 'dc-runtool-'));
+    const policyFile = join(dir, 'policy.json');
+    writeFileSync(policyFile, JSON.stringify({ tools: { deny: ['echo_test'] } }));
+    process.env.DVALINCODE_POLICY_FILE = policyFile;
+
+    const ran = { value: false };
+    const registry = new ToolRegistry();
+    registry.register(testTool(ran));
+
+    await expect(invoke(makeProgram(registry), ['echo_test', '-i', '{"text":"hi"}', '-y'])).rejects.toBeInstanceOf(
+      PolicyViolationError,
+    );
+    expect(ran.value).toBe(false);
+  });
+
+  it('blocks a command matching the policy denylist', async () => {
+    dir = mkdtempSync(join(tmpdir(), 'dc-runtool-'));
+    const policyFile = join(dir, 'policy.json');
+    writeFileSync(policyFile, JSON.stringify({ commands: { deny: ['echo_test'] } }));
+    process.env.DVALINCODE_POLICY_FILE = policyFile;
+
+    const ran = { value: false };
+    const registry = new ToolRegistry();
+    registry.register(testTool(ran));
+
+    await expect(invoke(makeProgram(registry), ['echo_test', '-i', '{"text":"hi"}', '-y'])).rejects.toBeInstanceOf(
+      PolicyViolationError,
+    );
+    expect(ran.value).toBe(false);
+  });
+
+  it('runs normally with no policy file (behavior unchanged)', async () => {
+    dir = mkdtempSync(join(tmpdir(), 'dc-runtool-'));
+    process.env.DVALINCODE_POLICY_FILE = join(dir, 'absent.json');
+
+    const ran = { value: false };
+    const registry = new ToolRegistry();
+    registry.register(testTool(ran));
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await invoke(makeProgram(registry), ['echo_test', '-i', '{"text":"hi"}', '-y']);
+    expect(ran.value).toBe(true);
+    expect(log).toHaveBeenCalled();
+  });
+
+  it('warns loudly on a malformed policy instead of silently allowing', async () => {
+    dir = mkdtempSync(join(tmpdir(), 'dc-runtool-'));
+    const policyFile = join(dir, 'policy.json');
+    writeFileSync(policyFile, '{ not json');
+    process.env.DVALINCODE_POLICY_FILE = policyFile;
+
+    const ran = { value: false };
+    const registry = new ToolRegistry();
+    registry.register(testTool(ran));
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await invoke(makeProgram(registry), ['echo_test', '-i', '{"text":"hi"}', '-y']);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('Ignored malformed policy'));
+    expect(ran.value).toBe(true); // fail-safe matches runAgentTurn semantics
+  });
+});


### PR DESCRIPTION
## Summary

Closes #45. The `run-tool` CLI entrypoint built its context without `loadPolicy`, so org policy (`commands.deny`, `paths`, `tools.deny`, network) did not apply there while the agent path enforced it — a governance side-door contradicting the "every entrypoint passes the chokepoint" rule (CONTRIBUTING → governance rule 1).

Fix mirrors `runAgentTurn`: load the policy, warn loudly on malformed sources (fail-safe, never silently permissive), pass it into `createDvalinContext`. Enforcement itself needs no change — `registry.run` already does it once the policy is present.

## Testing

- 4 new regression tests (`tests/commands/runTool.test.ts`) driving the real commander command: tool-deny blocked before the tool runs; command-deny blocked; no-policy behavior byte-identical; malformed policy warns loudly.
- Original PoC re-run against the built CLI: with `{"commands":{"deny":["curl"]}}`, `run-tool shell curl …` now prints `Blocked by policy: command matches denylist: /curl/` and exits 1 (previously executed the command).
- `npm run check`: 177 passed (was 173), typecheck clean.

## Security and AI Governance

- [x] This change does not expand file, shell, network, model, or approval permissions. *(It strictly narrows: an entrypoint that ignored policy now enforces it.)*
- [x] If it changes agent behavior, prompts, policy, providers, audit logging, or release/build security, I updated the relevant governance evidence in `docs/`. *(No doc change needed — this makes behavior match what the docs already claim.)*
- [x] If it introduces a new model/provider/tool or new data flow, I completed the AI change impact assessment. *(N/A — no new data flow.)*

## Notes

Found while producing the README governance GIFs; tracked as #45 and listed on the ROADMAP "Now" table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)