### PR TITLE
feat(evidence): Evidence Pack v1 — offline-verifiable governance bundle

### DIFF
--- a/docs/EVIDENCE-PACK.md
+++ b/docs/EVIDENCE-PACK.md
@@ -1,0 +1,86 @@
+# Evidence Pack v1 Design
+
+## Why
+
+DvalinCode's North Star is being **trivially approvable by a security review**.
+The controls already exist — resolved org policy, per-boundary egress
+enforcement, a tamper-evident hash-chained audit trail — but today a reviewer has
+to gather that evidence by hand and take the mapping to their compliance
+framework on faith.
+
+The Evidence Pack turns claims into a **single, portable, offline-verifiable
+artifact**: "here is my policy, here is what my runs actually did, here is the
+proof none of it was altered, and here is how each control maps to OpenSSF /
+ISO-42001." Evidence over assertions. This is the highest-leverage step toward
+the North Star, and it is pure aggregation of primitives that already exist —
+no new trust surface.
+
+## Command surface
+
+```
+dvalincode evidence export [--out <file>] [--run <id>...] [--last <n>] [--cwd <dir>]
+dvalincode evidence verify <file>
+```
+
+- `export` writes one JSON file (default `dvalincode-evidence-<timestamp>.json`).
+  With no run selector it includes the most recent `--last 10` runs.
+- `verify` re-derives every hash in the file and re-runs the audit-chain check on
+  each embedded run — **fully offline**, reading nothing but the file itself.
+
+## Bundle contents
+
+A single JSON document:
+
+| Section | Source | Purpose |
+|---|---|---|
+| `schema` / `generatedAt` / `tool` | constant / `Date` / version | provenance of the pack |
+| `policy` | `loadPolicy(cwd)` → resolved policy, sources (+ file hashes), canonical hash | **controllable** — the exact rules in force |
+| `trust` | `buildTrustReport(cwd)` | **transparent** — the live enforcement posture (network, sandbox, MCP surface) |
+| `runs[]` | per run: `meta` (run_start fields), `records` (the audit chain), `verify` (`verifyRecords`), `journalAnchor?` | **auditable** — what each run did + proof the chain is intact |
+| `compliance` | static control→clause map, each marked backed/unbacked by this pack | reviewer's bridge to OpenSSF Baseline / ISO-42001 |
+| `manifest` | per-section SHA-256 + top-level `bundleHash` | the pack is itself tamper-evident |
+
+## Integrity model
+
+- Each section is hashed with `sha256(canonicalJSON(section))` — canonical JSON
+  makes the hash independent of key order.
+- `manifest.bundleHash = sha256(canonicalJSON(pack-without-bundleHash))`. Changing
+  any byte of meaning changes the bundle hash.
+- Each embedded run additionally carries its own `verify` result, and `verify`
+  re-computes it from the embedded `records` via `verifyRecords(runId, records)` —
+  so a reviewer can confirm the chain independently of our say-so, and detect if
+  records were edited/inserted/removed/reordered after export.
+- Two layers on purpose: the bundle hash proves *the pack* wasn't altered; the
+  per-run chain proves *each run log* wasn't altered before it went in.
+
+## Data minimization
+
+The pack inherits the audit trail's minimization — it copies already-minimized
+records, never re-derives from raw material. Concretely it contains **no**
+prompts, file contents, shell arguments, API keys, or MCP auth headers, because
+those never entered the audit records in the first place (see
+EGRESS-THREAT-MODEL.md → Audit Data Policy). Policy files and the trust report
+carry no secrets. `verify` asserts this invariant structurally.
+
+## Acceptance matrix
+
+| Case | Expected |
+|---|---|
+| `export` with no runs present | Valid pack with `runs: []`, policy + trust + manifest still present |
+| `export --last 3` | Newest 3 runs embedded, each with a passing `verify` |
+| `verify` on an unmodified pack | `ok: true`; every section hash matches; every run chain intact |
+| Any byte of a section changed | `verify` reports the section whose hash no longer matches |
+| A record edited/removed inside an embedded run | that run's chain `verify` fails at the broken seq; bundle hash also changes |
+| Pack contents | No prompt, file content, shell argument, API key, or auth header anywhere |
+| `verify` | Reads only the file — no network, no `~/.dvalincode` access |
+
+## Non-goals (v1)
+
+- Cryptographic **signing** (device/GPG attestation) — v1 is tamper-*evident*
+  via hashes, matching the audit trail's own posture; signing is a later add-on.
+- Bundling source, SBOM, or CI attestations — those live in the repo/release
+  supply chain, not a per-install runtime pack.
+- A rendered PDF/HTML report — v1 emits machine-verifiable JSON; a renderer can
+  consume it later.
+- Proving controls the running install does **not** exercise (the compliance map
+  marks a clause "unbacked" rather than fabricating evidence).

--- a/src/audit/log.ts
+++ b/src/audit/log.ts
@@ -188,7 +188,15 @@ export function verifyChain(runId: string, dir: string = defaultAuditDir()): Ver
   } catch (err) {
     return { ok: false, reason: `cannot read run log: ${errMsg(err)}` };
   }
+  return verifyRecords(runId, records);
+}
 
+/**
+ * Verify an in-memory record array against the genesis link derived from `runId`.
+ * Same check as `verifyChain` but without disk I/O — this is what lets an
+ * exported Evidence Pack re-verify its embedded chains fully offline.
+ */
+export function verifyRecords(runId: string, records: AuditRecord[]): VerifyResult {
   let expectedPrev = sha256(runId);
   for (let i = 0; i < records.length; i++) {
     const record = records[i];

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8,6 +8,7 @@ import { registerScanCommand } from './commands/scan.js';
 import { registerToolsCommand } from './commands/tools.js';
 import { registerReportCommand } from './commands/report.js';
 import { registerTrustCommand } from './commands/trust.js';
+import { registerEvidenceCommand } from './commands/evidence.js';
 import { registerServeCommand } from './commands/serve.js';
 import { registerTuiCommand } from './commands/tui.js';
 import { registerDataCommands } from './commands/data.js';
@@ -31,6 +32,7 @@ export function buildProgram(): Command {
   registerMemoryCommand(program);
   registerReportCommand(program);
   registerTrustCommand(program);
+  registerEvidenceCommand(program);
   registerServeCommand(program);
   registerTuiCommand(program);
   registerDataCommands(program);

--- a/src/commands/evidence.ts
+++ b/src/commands/evidence.ts
@@ -1,0 +1,54 @@
+import { readFileSync, writeFileSync } from 'node:fs';
+import type { Command } from 'commander';
+import { buildEvidencePack, verifyEvidencePack, type EvidencePack } from '../evidence/pack.js';
+
+export function registerEvidenceCommand(program: Command): void {
+  const evidence = program
+    .command('evidence')
+    .description('Produce and verify an offline governance Evidence Pack (policy + posture + audit proofs)');
+
+  evidence
+    .command('export')
+    .description('Write an offline-verifiable Evidence Pack for this install')
+    .option('--out <file>', 'output path (default: dvalincode-evidence-<timestamp>.json)')
+    .option('--run <id...>', 'specific run id(s) to include')
+    .option('--last <n>', 'include the newest N audit runs (default 10)', v => parseInt(v, 10))
+    .action((options: { out?: string; run?: string[]; last?: number }) => {
+      const pack = buildEvidencePack({ runIds: options.run, last: options.last });
+      const out = options.out ?? `dvalincode-evidence-${pack.generatedAt.replace(/[:.]/g, '-')}.json`;
+      writeFileSync(out, JSON.stringify(pack, null, 2), 'utf8');
+
+      const backed = pack.compliance.filter(c => c.backed).length;
+      console.log(`✓ Evidence Pack written: ${out}`);
+      console.log(`  policy hash   ${pack.policy.hash.slice(0, 16)}…`);
+      console.log(`  runs          ${pack.runs.length} (${pack.runs.filter(r => r.verify.ok).length} chains verified)`);
+      console.log(`  compliance    ${backed}/${pack.compliance.length} controls backed by this pack`);
+      console.log(`  bundle hash   ${pack.manifest.bundleHash.slice(0, 16)}…`);
+      console.log('  verify with   dvalincode evidence verify ' + out);
+    });
+
+  evidence
+    .command('verify')
+    .description('Re-derive every hash and re-check each embedded audit chain, fully offline')
+    .argument('<file>', 'path to an Evidence Pack')
+    .action((file: string) => {
+      let pack: EvidencePack;
+      try {
+        pack = JSON.parse(readFileSync(file, 'utf8')) as EvidencePack;
+      } catch (err) {
+        console.error(`Cannot read Evidence Pack: ${err instanceof Error ? err.message : String(err)}`);
+        process.exit(1);
+      }
+
+      const report = verifyEvidencePack(pack);
+      if (report.ok) {
+        console.log(`✓ Evidence Pack intact — ${pack.runs.length} run chain(s) verified, all section hashes match`);
+        return;
+      }
+      console.error('✗ Evidence Pack verification FAILED');
+      for (const issue of [...report.sectionIssues, ...report.runIssues, ...report.minimizationIssues]) {
+        console.error(`  - ${issue}`);
+      }
+      process.exit(1);
+    });
+}

--- a/src/evidence/compliance.ts
+++ b/src/evidence/compliance.ts
@@ -1,0 +1,78 @@
+import type { EvidencePack } from './pack.js';
+
+/**
+ * A reviewer's bridge from DvalinCode's runtime controls to the compliance
+ * frameworks the project already tracks (docs/security/OPENSSF-SCORECARD.md,
+ * docs/governance/ISO-42001-AIMS.md). Each entry names a control, the pack
+ * section that *backs* it with real data, and the clause it maps to. The pack
+ * marks a control `backed: true` only when that section actually contains
+ * evidence in this export — we never fabricate coverage.
+ */
+export type ComplianceControl = {
+  id: string;
+  control: string;
+  section: 'policy' | 'trust' | 'runs';
+  openssf?: string;
+  iso42001?: string;
+};
+
+export const COMPLIANCE_CONTROLS: ComplianceControl[] = [
+  {
+    id: 'org-policy-narrowing',
+    control: 'Agent authority is bounded by an org policy resolved by narrowing (a repo source can only tighten the machine source).',
+    section: 'policy',
+    openssf: 'Least-privilege / access control',
+    iso42001: 'A.5 policies for AI; A.9 use limitation',
+  },
+  {
+    id: 'policy-integrity',
+    control: 'The governing policy is content-hashed; each run records the hash it ran under.',
+    section: 'policy',
+    iso42001: 'A.6 change management; A.8 records of processing',
+  },
+  {
+    id: 'network-egress-enforcement',
+    control: 'Outbound network is enforced per boundary (provider, shell/subprocess, MCP) and fails closed where isolation is unavailable.',
+    section: 'trust',
+    openssf: 'Network egress control',
+    iso42001: 'A.9 operational controls',
+  },
+  {
+    id: 'self-verifiable-posture',
+    control: 'The install can emit its own live security posture for independent verification (dvalincode trust).',
+    section: 'trust',
+    iso42001: 'A.7 transparency; Clause 9 monitoring',
+  },
+  {
+    id: 'tamper-evident-audit',
+    control: 'Every agent run produces a hash-chained audit log whose integrity is verifiable after the fact.',
+    section: 'runs',
+    openssf: 'Tamper-evident logging',
+    iso42001: 'A.8 records; Clause 9.2 audit',
+  },
+  {
+    id: 'audit-minimization',
+    control: 'Audit records are minimized — no prompts, file contents, shell arguments, or credentials are persisted.',
+    section: 'runs',
+    iso42001: 'A.9 data minimization; privacy by design',
+  },
+];
+
+export type ComplianceEntry = ComplianceControl & { backed: boolean };
+
+/** Mark each control backed/unbacked by what this specific pack actually contains. */
+export function evaluateCompliance(pack: Omit<EvidencePack, 'compliance' | 'manifest'>): ComplianceEntry[] {
+  return COMPLIANCE_CONTROLS.map(c => ({ ...c, backed: isBacked(c, pack) }));
+}
+
+function isBacked(c: ComplianceControl, pack: Omit<EvidencePack, 'compliance' | 'manifest'>): boolean {
+  switch (c.section) {
+    case 'policy':
+      return Boolean(pack.policy?.hash);
+    case 'trust':
+      return Boolean(pack.trust);
+    case 'runs':
+      // Backed only when at least one run's chain is present and verified.
+      return pack.runs.length > 0 && pack.runs.every(r => r.verify.ok);
+  }
+}

--- a/src/evidence/pack.ts
+++ b/src/evidence/pack.ts
@@ -1,0 +1,186 @@
+import { sha256, canonicalJSON } from '../audit/hash.js';
+import {
+  defaultAuditDir,
+  listRuns,
+  readRecords,
+  verifyRecords,
+  type AuditRecord,
+  type RunMeta,
+  type VerifyResult,
+} from '../audit/log.js';
+import { loadPolicy, type PolicySource, type ResolvedPolicy } from '../core/policy.js';
+import { buildTrustReport, type TrustReport } from '../core/trust.js';
+import { readJournal } from '../sessions/journal.js';
+import { evaluateCompliance, type ComplianceEntry } from './compliance.js';
+
+export const EVIDENCE_SCHEMA = 'dvalincode-evidence/v1';
+
+export type EvidenceRun = {
+  runId: string;
+  meta: RunMeta | null;
+  records: AuditRecord[];
+  verify: VerifyResult;
+  /** Link to the originating session turn, when the run recorded a sessionId. */
+  journalAnchor?: { sessionId: string; messageId: string; auditHead?: string };
+};
+
+export type EvidencePack = {
+  schema: typeof EVIDENCE_SCHEMA;
+  generatedAt: string;
+  tool: { name: 'dvalincode'; version: string };
+  policy: { resolved: ResolvedPolicy; sources: PolicySource[]; hash: string };
+  trust: TrustReport;
+  runs: EvidenceRun[];
+  compliance: ComplianceEntry[];
+  manifest: { sections: Record<string, string>; bundleHash: string };
+};
+
+export type BuildOptions = {
+  cwd?: string;
+  auditDir?: string;
+  sessionsDir?: string;
+  /** Explicit run ids; otherwise the newest `last` runs are included. */
+  runIds?: string[];
+  last?: number;
+};
+
+/** Assemble an Evidence Pack from the install's current policy, posture, and audit runs. */
+export function buildEvidencePack(opts: BuildOptions = {}): EvidencePack {
+  const cwd = opts.cwd ?? process.cwd();
+  const auditDir = opts.auditDir ?? defaultAuditDir();
+  const loaded = loadPolicy(cwd);
+  const trust = buildTrustReport(cwd);
+
+  const ids = opts.runIds ?? listRuns(auditDir).slice(0, opts.last ?? 10);
+  const runs: EvidenceRun[] = ids.map(runId => {
+    let records: AuditRecord[] = [];
+    let verify: VerifyResult;
+    try {
+      records = readRecords(runId, auditDir);
+      verify = verifyRecords(runId, records);
+    } catch (err) {
+      verify = { ok: false, reason: err instanceof Error ? err.message : String(err) };
+    }
+    const start = records.find(r => r.type === 'run_start');
+    const meta = start && start.type === 'run_start' ? stripType(start) : null;
+    return { runId, meta, records, verify, journalAnchor: findAnchor(meta, runId, opts.sessionsDir) };
+  });
+
+  const core = {
+    schema: EVIDENCE_SCHEMA as typeof EVIDENCE_SCHEMA,
+    generatedAt: new Date().toISOString(),
+    tool: { name: 'dvalincode' as const, version: trust.version },
+    policy: { resolved: loaded.policy, sources: loaded.sources, hash: loaded.hash },
+    trust,
+    runs,
+  };
+  const compliance = evaluateCompliance(core);
+  const withCompliance = { ...core, compliance };
+  return { ...withCompliance, manifest: buildManifest(withCompliance) };
+}
+
+export type VerifyReport = {
+  ok: boolean;
+  bundleHashOk: boolean;
+  sectionIssues: string[];
+  runIssues: string[];
+  minimizationIssues: string[];
+};
+
+/** Re-derive every hash and re-run each embedded chain — fully offline. */
+export function verifyEvidencePack(pack: EvidencePack): VerifyReport {
+  const sectionIssues: string[] = [];
+  const runIssues: string[] = [];
+
+  const expected = manifestSections(stripManifest(pack));
+  for (const [name, hash] of Object.entries(expected)) {
+    if (pack.manifest.sections[name] !== hash) sectionIssues.push(`section "${name}" hash mismatch`);
+  }
+  for (const name of Object.keys(pack.manifest.sections)) {
+    if (!(name in expected)) sectionIssues.push(`manifest lists unknown section "${name}"`);
+  }
+
+  const bundleHashOk = pack.manifest.bundleHash === sha256(canonicalJSON(stripBundleHash(pack)));
+  if (!bundleHashOk) sectionIssues.push('bundle hash mismatch');
+
+  for (const run of pack.runs) {
+    const result = verifyRecords(run.runId, run.records);
+    if (!result.ok) runIssues.push(`run ${run.runId}: ${result.reason ?? `broken at seq ${result.brokenAtSeq}`}`);
+  }
+
+  const minimizationIssues = scanForSecrets(pack);
+
+  return {
+    ok: sectionIssues.length === 0 && bundleHashOk && runIssues.length === 0 && minimizationIssues.length === 0,
+    bundleHashOk,
+    sectionIssues,
+    runIssues,
+    minimizationIssues,
+  };
+}
+
+// ── internals ────────────────────────────────────────────────────────────────
+
+function stripType<T extends { type: unknown }>(record: T): Omit<T, 'type'> {
+  const { type: _drop, seq: _seq, ts: _ts, prevHash: _prev, ...rest } = record as T & {
+    seq?: unknown;
+    ts?: unknown;
+    prevHash?: unknown;
+  };
+  return rest as Omit<T, 'type'>;
+}
+
+function findAnchor(meta: RunMeta | null, runId: string, sessionsDir?: string): EvidenceRun['journalAnchor'] {
+  const sessionId = meta?.sessionId;
+  if (!sessionId) return undefined;
+  const end = readJournal(sessionId, sessionsDir).find(
+    r => r.type === 'turn_end' && r.runId === runId,
+  );
+  if (!end || end.type !== 'turn_end') return { sessionId, messageId: '(unknown)' };
+  return { sessionId, messageId: end.messageId, auditHead: end.auditHead };
+}
+
+type CoreSections = Omit<EvidencePack, 'manifest'>;
+
+/** Per-section SHA-256 of the meaningful sections (excludes the manifest itself). */
+function manifestSections(core: CoreSections): Record<string, string> {
+  return {
+    header: sha256(canonicalJSON({ schema: core.schema, generatedAt: core.generatedAt, tool: core.tool })),
+    policy: sha256(canonicalJSON(core.policy)),
+    trust: sha256(canonicalJSON(core.trust)),
+    runs: sha256(canonicalJSON(core.runs)),
+    compliance: sha256(canonicalJSON(core.compliance)),
+  };
+}
+
+function buildManifest(core: CoreSections): EvidencePack['manifest'] {
+  const sections = manifestSections(core);
+  return { sections, bundleHash: sha256(canonicalJSON(core)) };
+}
+
+function stripManifest(pack: EvidencePack): CoreSections {
+  const { manifest: _m, ...core } = pack;
+  return core;
+}
+
+function stripBundleHash(pack: EvidencePack): CoreSections {
+  return stripManifest(pack);
+}
+
+const SECRET_KEY = /^(authorization|api[-_]?key|apikey|password|secret|token|bearer)$/i;
+
+/** Structural minimization guard: flag any key that looks like a credential with a non-empty value. */
+function scanForSecrets(value: unknown, path = ''): string[] {
+  const issues: string[] = [];
+  if (Array.isArray(value)) {
+    value.forEach((v, i) => issues.push(...scanForSecrets(v, `${path}[${i}]`)));
+  } else if (value && typeof value === 'object') {
+    for (const [key, v] of Object.entries(value)) {
+      if (SECRET_KEY.test(key) && typeof v === 'string' && v.length > 0) {
+        issues.push(`possible secret at ${path}.${key}`);
+      }
+      issues.push(...scanForSecrets(v, path ? `${path}.${key}` : key));
+    }
+  }
+  return issues;
+}

--- a/tests/evidence/evidence.test.ts
+++ b/tests/evidence/evidence.test.ts
@@ -1,0 +1,106 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { AuditSink } from '../../src/audit/log.js';
+import { buildEvidencePack, verifyEvidencePack, type EvidencePack } from '../../src/evidence/pack.js';
+
+function seedRun(dir: string, runId: string): void {
+  const sink = new AuditSink(runId, dir);
+  sink.append({
+    type: 'run_start',
+    task: 'minimized sha256:abc bytes:12',
+    mode: 'code',
+    provider: 'deepseek',
+    model: 'deepseek-v4-pro',
+    cwd: '/repo',
+    gitHead: 'a1b2c3',
+    sessionId: 'dc_sess_1',
+  });
+  sink.append({ type: 'tool_call', tool: 'read_file', argsSummary: '{"sha256":"x"}', status: 'ok', durationMs: 2 });
+  sink.append({ type: 'run_end', status: 'done', iterations: 1 });
+}
+
+function build(auditDir: string): EvidencePack {
+  return buildEvidencePack({ auditDir, sessionsDir: join(auditDir, 'sessions'), last: 10 });
+}
+
+describe('Evidence Pack', () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'dc-evidence-'));
+  });
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  it('builds a valid pack with no runs (policy + trust + manifest still present)', () => {
+    const pack = build(dir);
+    expect(pack.schema).toBe('dvalincode-evidence/v1');
+    expect(pack.runs).toEqual([]);
+    expect(pack.policy.hash).toMatch(/^[a-f0-9]{64}$/);
+    expect(pack.trust.version).toBeTruthy();
+    expect(pack.manifest.bundleHash).toMatch(/^[a-f0-9]{64}$/);
+    expect(verifyEvidencePack(pack).ok).toBe(true);
+  });
+
+  it('embeds and verifies audit run chains', () => {
+    seedRun(dir, 'run-A');
+    seedRun(dir, 'run-B');
+    const pack = build(dir);
+    expect(pack.runs.map(r => r.runId).sort()).toEqual(['run-A', 'run-B']);
+    expect(pack.runs.every(r => r.verify.ok)).toBe(true);
+    expect(pack.runs[0].meta?.provider).toBe('deepseek');
+
+    const report = verifyEvidencePack(pack);
+    expect(report.ok).toBe(true);
+    expect(report.runIssues).toEqual([]);
+  });
+
+  it('detects a tampered section via hash mismatch', () => {
+    seedRun(dir, 'run-A');
+    const pack = build(dir);
+    // Forge the recorded policy hash without recomputing the manifest.
+    const tampered = structuredClone(pack);
+    tampered.policy.hash = 'f'.repeat(64);
+
+    const report = verifyEvidencePack(tampered);
+    expect(report.ok).toBe(false);
+    expect(report.sectionIssues.some(i => i.includes('policy'))).toBe(true);
+    expect(report.bundleHashOk).toBe(false);
+  });
+
+  it('detects a record edited inside an embedded run', () => {
+    seedRun(dir, 'run-A');
+    const pack = build(dir);
+    const tampered = structuredClone(pack);
+    // Change a field inside the chain without fixing prevHash links.
+    (tampered.runs[0].records[1] as { tool: string }).tool = 'shell';
+
+    const report = verifyEvidencePack(tampered);
+    expect(report.ok).toBe(false);
+    expect(report.runIssues.some(i => i.includes('run-A'))).toBe(true);
+  });
+
+  it('contains no credential-shaped fields and flags injected secrets', () => {
+    seedRun(dir, 'run-A');
+    const pack = build(dir);
+    // A clean pack passes the minimization scan.
+    expect(verifyEvidencePack(pack).minimizationIssues).toEqual([]);
+
+    // Inject a secret to prove the scanner catches leakage.
+    const leaked = structuredClone(pack) as EvidencePack & { policy: { apiKey?: string } };
+    leaked.policy.apiKey = 'sk-live-should-never-be-here';
+    expect(verifyEvidencePack(leaked).minimizationIssues.length).toBeGreaterThan(0);
+  });
+
+  it('marks run-backed compliance controls unbacked when there are no runs', () => {
+    const empty = build(dir);
+    const runsControl = empty.compliance.find(c => c.section === 'runs');
+    expect(runsControl?.backed).toBe(false);
+    const policyControl = empty.compliance.find(c => c.section === 'policy');
+    expect(policyControl?.backed).toBe(true);
+
+    seedRun(dir, 'run-A');
+    const withRun = build(dir);
+    expect(withRun.compliance.find(c => c.section === 'runs')?.backed).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #51 — the highest-leverage item on the roadmap toward the North Star (*trivially approvable by a security review*). It turns DvalinCode's existing controls into a **single, portable, offline-verifiable artifact**: here is my policy, here is what my runs actually did, here is proof none of it was altered, and here is how each control maps to OpenSSF / ISO-42001.

Pure aggregation of primitives that already exist (`loadPolicy`, `buildTrustReport`, the hash-chained audit log) — **no new trust surface, no new runtime deps.** Design + integrity model + acceptance matrix in [`docs/EVIDENCE-PACK.md`](docs/EVIDENCE-PACK.md).

## Command surface

```
dvalincode evidence export [--out <file>] [--run <id>...] [--last <n>]
dvalincode evidence verify <file>
```

## What's inside a pack

| Section | Backs the principle |
|---|---|
| `policy` — resolved policy + sources (file hashes) + canonical hash | **controllable** |
| `trust` — the live enforcement posture (network, sandbox, MCP surface) | **transparent** |
| `runs[]` — each run's audit chain + a per-run `verify` + journal anchor | **auditable** |
| `compliance` — control → OpenSSF/ISO-42001 clauses, each marked backed/unbacked *by this pack* | reviewer's bridge |
| `manifest` — per-section SHA-256 + top-level `bundleHash` | the pack is itself tamper-evident |

## Integrity model (two layers, on purpose)

- **Bundle hash** — `sha256(canonicalJSON(pack − bundleHash))` proves *the pack* wasn't altered.
- **Per-run chain** — `verify` re-runs `verifyRecords(runId, records)` on the embedded chain, proving *each run log* wasn't altered before export (catches edits/inserts/removes/reorders).
- **Minimization guard** — `verify` walks the pack and flags any credential-shaped key with a value. The pack inherits the audit trail's minimization (it copies already-minimized records), so it contains no prompts, file contents, shell args, API keys, or MCP auth headers.

`verify` reads **only the file** — no network, no `~/.dvalincode` access.

## Testing

- 6 unit tests (`tests/evidence/evidence.test.ts`): empty pack valid; runs embedded + verified; tampered section → hash mismatch; edited record → chain break; injected secret flagged, clean pack clean; compliance backed/unbacked logic.
- Small refactor: `verifyChain` now delegates to a new `verifyRecords(runId, records)` so embedded chains verify without disk I/O (covered by the existing audit tests, still green).
- **Live**: `evidence export --last 3` → 3 chains verified, 6/6 controls backed; offline `verify` intact; a one-byte edit to an embedded record trips the section hash **and** the bundle hash **and** the exact chain break, exit 1.
- `npm run check`: 179 passed (+6), typecheck clean.

## Security and AI Governance

- [x] This change does not expand file, shell, network, model, or approval permissions. *(Read-only aggregation + a new local file write for the export.)*
- [x] Governance evidence updated in `docs/` — new `docs/EVIDENCE-PACK.md`; the compliance map references the existing OpenSSF/ISO docs.
- [x] No new model/provider/tool or data flow. *(`verify` is fully offline.)*

## Notes

- The compliance map is deliberately **honest**: a control is `backed: true` only when this specific pack contains its evidence (e.g. run-backed controls are unbacked when there are no runs) — we never fabricate coverage.
- Non-goals for v1 (documented): cryptographic signing/attestation, SBOM bundling, rendered PDF/HTML. v1 is tamper-*evident* via hashes, matching the audit trail's own posture.
- README/ROADMAP surfacing intentionally deferred to avoid conflicts with the still-open #58.

🤖 Generated with [Claude Code](https://claude.com/claude-code)