### PR TITLE
release: v0.10.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 <p align="center">
   <a href="https://github.com/arthurpanhku/dvalincode/releases/latest"><img src="https://img.shields.io/github/v/release/arthurpanhku/dvalincode?style=for-the-badge&color=818cf8&label=Release" alt="Release"></a>
   <a href="https://github.com/arthurpanhku/dvalincode/releases"><img src="https://img.shields.io/github/downloads/arthurpanhku/dvalincode/total?style=for-the-badge&color=blue&label=Downloads" alt="Downloads"></a>
-  <a href="#-tests"><img src="https://img.shields.io/badge/Tests-173%20%2F%20173%20%E2%9C%93-success?style=for-the-badge" alt="Tests"></a>
+  <a href="#-tests"><img src="https://img.shields.io/badge/Tests-183%20%2F%20183%20%E2%9C%93-success?style=for-the-badge" alt="Tests"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-green?style=for-the-badge" alt="License"></a>
   <a href="https://scorecard.dev/viewer/?uri=github.com/arthurpanhku/dvalincode"><img src="https://api.scorecard.dev/projects/github.com/arthurpanhku/dvalincode/badge" alt="OpenSSF Scorecard"></a>
   <a href="#-quick-install"><img src="https://img.shields.io/badge/Platforms-macOS%20·%20Windows%20·%20Linux-blue?style=for-the-badge" alt="Platforms"></a>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -9,7 +9,7 @@
 <p align="center">
   <a href="https://github.com/arthurpanhku/dvalincode/releases/latest"><img src="https://img.shields.io/github/v/release/arthurpanhku/dvalincode?style=for-the-badge&color=818cf8&label=Release" alt="Release"></a>
   <a href="https://github.com/arthurpanhku/dvalincode/releases"><img src="https://img.shields.io/github/downloads/arthurpanhku/dvalincode/total?style=for-the-badge&color=blue&label=Downloads" alt="Downloads"></a>
-  <a href="#-测试"><img src="https://img.shields.io/badge/Tests-173%20%2F%20173%20%E2%9C%93-success?style=for-the-badge" alt="Tests"></a>
+  <a href="#-测试"><img src="https://img.shields.io/badge/Tests-183%20%2F%20183%20%E2%9C%93-success?style=for-the-badge" alt="Tests"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-green?style=for-the-badge" alt="License"></a>
   <a href="https://scorecard.dev/viewer/?uri=github.com/arthurpanhku/dvalincode"><img src="https://api.scorecard.dev/projects/github.com/arthurpanhku/dvalincode/badge" alt="OpenSSF Scorecard"></a>
   <a href="#-一行安装"><img src="https://img.shields.io/badge/Platforms-macOS%20·%20Windows%20·%20Linux-blue?style=for-the-badge" alt="Platforms"></a>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dvalincode",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "A local-first, provider-neutral CLI foundation for agentic coding workflows.",
   "type": "module",
   "license": "MIT",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -21,7 +21,7 @@ export function buildProgram(): Command {
   program
     .name('dvalincode')
     .description('Local-first coding agent — terminal UI by default, `serve` for the web GUI')
-    .version('0.9.0');
+    .version('0.10.0');
 
   registerScanCommand(program);
   registerToolsCommand(program, registry);

--- a/src/core/trust.ts
+++ b/src/core/trust.ts
@@ -27,7 +27,7 @@ import {
  */
 
 /** Keep in lockstep with the version in src/cli.ts. */
-const VERSION = '0.9.0';
+const VERSION = '0.10.0';
 
 export type TrustReport = {
   version: string;


### PR DESCRIPTION
## Summary

Release-prep for **v0.10.0** (minor). Bumps the version in `package.json`, `src/cli.ts`, `src/core/trust.ts` (kept in lockstep) and the tests badge 173 → 183 on both READMEs. No behavior change.

Verified: `--version` and `dvalincode trust` both report `0.10.0`; `npm run check` green at 183 tests.

## Highlights since v0.9.0

- **feat(mcp)**: governed remote MCP client — Streamable HTTP, glama-compatible, egress-gated + audited, zero new deps (#44)
- **feat(evidence)**: Evidence Pack v1 — offline-verifiable governance bundle (`evidence export` / `verify`), OpenSSF/ISO-42001 mapping (#60)
- **docs**: consolidated attack-surface threat model `docs/THREAT-MODEL.md` (#61)
- **fix**: `run-tool` CLI entrypoint now enforces org policy — closed a governance side-door (#59)
- **docs/oss**: 60-second trust path, real CONTRIBUTING, public ROADMAP, CLI governance GIFs (#58, #43)

## After merge

Tag `v0.10.0` + `gui-v0.10.0` on `main` → the `release.yml` / `release-gui.yml` workflows build the platform binaries and publish the GitHub Release automatically.

## Security and AI Governance

- [x] No file/shell/network/model/approval permission change (version + badge only).
- [x] No governance-doc change needed.
- [x] No new model/provider/tool or data flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)