### PR TITLE
fix: wire WebSocket messageId for durable session replay

### DIFF
--- a/src/agent/session.ts
+++ b/src/agent/session.ts
@@ -163,8 +163,8 @@ export async function runAgentTurn(input: RunTurnInput, hooks: RunTurnHooks = {}
         sessionId: session.id,
         result: {
           messages: session.messages,
-          output: '(replayed: this message was already processed)',
-          iterationsUsed: 0,
+          output: prior.output ?? '(replayed: prior response unavailable)',
+          iterationsUsed: prior.iterations ?? 0,
           runId: prior.runId,
           auditHead: prior.auditHead,
         },
@@ -246,6 +246,7 @@ export async function runAgentTurn(input: RunTurnInput, hooks: RunTurnHooks = {}
     type: 'turn_end',
     messageId,
     status: 'done',
+    output: result.output,
     runId: result.runId,
     auditHead: result.auditHead,
     iterations: result.iterationsUsed,

--- a/src/server/wsHandler.ts
+++ b/src/server/wsHandler.ts
@@ -8,7 +8,6 @@ import {
 } from "../agent/compact.js";
 import type { AgentEvent } from "../agent/types.js";
 import type { AgentMode, CodePermissionMode } from "../agent/modes.js";
-import type { ChatMessage } from "../providers/types.js";
 import { resolveAllowedCwd } from "./security.js";
 import {
   checkModel,
@@ -71,26 +70,6 @@ function send(ws: WebSocket, msg: ServerMessage): void {
   if (ws.readyState === 1 /* OPEN */) {
     ws.send(JSON.stringify(msg));
   }
-}
-
-function extractReplayedResponse(
-  messages: ChatMessage[],
-  userContent: string,
-): string {
-  for (let i = messages.length - 1; i >= 0; i--) {
-    const msg = messages[i];
-    if (msg?.role === "user" && msg.content === userContent) {
-      for (let j = i + 1; j < messages.length; j++) {
-        const next = messages[j];
-        if (next?.role === "user") break;
-        if (next?.role === "assistant" && next.content.trim()) {
-          return next.content;
-        }
-      }
-      break;
-    }
-  }
-  return "(replayed: prior response unavailable)";
 }
 
 export function handleWebSocket(ws: WebSocket): void {
@@ -288,10 +267,7 @@ export function handleWebSocket(ws: WebSocket): void {
 
       if (abort.signal.aborted) return;
 
-      const responseContent = turn.replayed
-        ? extractReplayedResponse(turn.result.messages, msg.content)
-        : turn.result.output;
-      send(ws, { type: "response", content: responseContent });
+      send(ws, { type: "response", content: turn.result.output });
       if (!turn.replayed && turn.reportMarkdown && turn.result.runId) {
         send(ws, {
           type: "run_report",

--- a/src/server/wsHandler.ts
+++ b/src/server/wsHandler.ts
@@ -1,43 +1,71 @@
-import type { WebSocket } from 'ws';
-import { runAgentTurn, resolveProvider } from '../agent/session.js';
-import { loadSession, saveSession } from '../sessions/store.js';
-import { estimateTokens, summarizeWithLLM, buildCompactedHistory } from '../agent/compact.js';
-import type { AgentEvent } from '../agent/types.js';
-import type { AgentMode, CodePermissionMode } from '../agent/modes.js';
-import { resolveAllowedCwd } from './security.js';
-import { checkModel, checkProvider, loadPolicy, PolicyViolationError } from '../core/policy.js';
+import type { WebSocket } from "ws";
+import { runAgentTurn, resolveProvider } from "../agent/session.js";
+import { loadSession, saveSession } from "../sessions/store.js";
+import {
+  estimateTokens,
+  summarizeWithLLM,
+  buildCompactedHistory,
+} from "../agent/compact.js";
+import type { AgentEvent } from "../agent/types.js";
+import type { AgentMode, CodePermissionMode } from "../agent/modes.js";
+import type { ChatMessage } from "../providers/types.js";
+import { resolveAllowedCwd } from "./security.js";
+import {
+  checkModel,
+  checkProvider,
+  loadPolicy,
+  PolicyViolationError,
+} from "../core/policy.js";
 
 type ClientMessage =
   | {
-      type: 'send';
+      type: "send";
       content: string;
       sessionId?: string;
       cwd?: string;
       allowWrite?: boolean;
       allowExecute?: boolean;
-      approvalMode?: 'readonly' | 'auto-edit' | 'full-auto' | 'bypass';
+      approvalMode?: "readonly" | "auto-edit" | "full-auto" | "bypass";
       codePermissionMode?: CodePermissionMode;
       mode?: AgentMode;
       provider?: string;
+      messageId?: string;
     }
-  | { type: 'interrupt' }
-  | { type: 'approval_response'; id: string; approved: boolean }
-  | { type: 'compact'; sessionId?: string };
+  | { type: "interrupt" }
+  | { type: "approval_response"; id: string; approved: boolean }
+  | { type: "compact"; sessionId?: string };
 
 type ServerMessage =
-  | { type: 'session_id'; sessionId: string }
-  | { type: 'token_delta'; content: string }
-  | { type: 'tool_call'; name: string; id: string; input: unknown }
-  | { type: 'tool_result'; name: string; id: string; output: string; metadata?: Record<string, unknown> }
-  | { type: 'tool_error'; name: string; id: string; error: string }
-  | { type: 'approval_request'; id: string; toolName: string; input: unknown }
-  | { type: 'response'; content: string }
-  | { type: 'run_report'; runId: string; markdown: string }
-  | { type: 'done'; sessionId: string; iterations: number; usage?: { inputTokens: number; outputTokens: number } }
-  | { type: 'interrupted' }
-  | { type: 'error'; message: string }
-  | { type: 'compact_done'; tokensBefore: number; tokensAfter: number; summary: string }
-  | { type: 'provider_selected'; providerId: string };
+  | { type: "session_id"; sessionId: string }
+  | { type: "token_delta"; content: string }
+  | { type: "tool_call"; name: string; id: string; input: unknown }
+  | {
+      type: "tool_result";
+      name: string;
+      id: string;
+      output: string;
+      metadata?: Record<string, unknown>;
+    }
+  | { type: "tool_error"; name: string; id: string; error: string }
+  | { type: "approval_request"; id: string; toolName: string; input: unknown }
+  | { type: "response"; content: string }
+  | { type: "run_report"; runId: string; markdown: string }
+  | {
+      type: "done";
+      sessionId: string;
+      iterations: number;
+      usage?: { inputTokens: number; outputTokens: number };
+      replayed?: boolean;
+    }
+  | { type: "interrupted" }
+  | { type: "error"; message: string }
+  | {
+      type: "compact_done";
+      tokensBefore: number;
+      tokensAfter: number;
+      summary: string;
+    }
+  | { type: "provider_selected"; providerId: string };
 
 function send(ws: WebSocket, msg: ServerMessage): void {
   if (ws.readyState === 1 /* OPEN */) {
@@ -45,27 +73,47 @@ function send(ws: WebSocket, msg: ServerMessage): void {
   }
 }
 
+function extractReplayedResponse(
+  messages: ChatMessage[],
+  userContent: string,
+): string {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const msg = messages[i];
+    if (msg?.role === "user" && msg.content === userContent) {
+      for (let j = i + 1; j < messages.length; j++) {
+        const next = messages[j];
+        if (next?.role === "user") break;
+        if (next?.role === "assistant" && next.content.trim()) {
+          return next.content;
+        }
+      }
+      break;
+    }
+  }
+  return "(replayed: prior response unavailable)";
+}
+
 export function handleWebSocket(ws: WebSocket): void {
   let currentAbort: AbortController | null = null;
   const pendingApprovals = new Map<string, (approved: boolean) => void>();
 
-  ws.on('message', async (raw) => {
+  ws.on("message", async (raw) => {
     let msg: ClientMessage;
     try {
       msg = JSON.parse(raw.toString()) as ClientMessage;
     } catch {
-      send(ws, { type: 'error', message: 'Invalid JSON' });
+      send(ws, { type: "error", message: "Invalid JSON" });
       return;
     }
 
-    if (msg.type === 'interrupt') {
+    if (msg.type === "interrupt") {
       currentAbort?.abort();
       currentAbort = null;
-      send(ws, { type: 'interrupted' });
+      send(ws, { type: "interrupted" });
       return;
     }
 
-    if (msg.type === 'approval_response') {
+    if (msg.type === "approval_response") {
       const resolve = pendingApprovals.get(msg.id);
       if (resolve) {
         pendingApprovals.delete(msg.id);
@@ -74,14 +122,17 @@ export function handleWebSocket(ws: WebSocket): void {
       return;
     }
 
-    if (msg.type === 'compact') {
+    if (msg.type === "compact") {
       if (!msg.sessionId) {
-        send(ws, { type: 'error', message: 'compact requires a sessionId' });
+        send(ws, { type: "error", message: "compact requires a sessionId" });
         return;
       }
       const session = await loadSession(msg.sessionId);
       if (!session) {
-        send(ws, { type: 'error', message: `Session not found: ${msg.sessionId}` });
+        send(ws, {
+          type: "error",
+          message: `Session not found: ${msg.sessionId}`,
+        });
         return;
       }
       let provider;
@@ -92,27 +143,37 @@ export function handleWebSocket(ws: WebSocket): void {
         const loadedPolicy = loadPolicy(session.cwd);
         const providerDecision = checkProvider(loadedPolicy.policy, providerId);
         if (!providerDecision.allowed) {
-          throw new PolicyViolationError('provider', providerDecision.rule, providerId);
+          throw new PolicyViolationError(
+            "provider",
+            providerDecision.rule,
+            providerId,
+          );
         }
         const modelDecision = checkModel(loadedPolicy.policy, model);
         if (!modelDecision.allowed) {
-          throw new PolicyViolationError('model', modelDecision.rule, model);
+          throw new PolicyViolationError("model", modelDecision.rule, model);
         }
         const tokensBefore = estimateTokens(session.messages);
-        const summary = await summarizeWithLLM(session.messages, provider, { policy: loadedPolicy.policy, model });
+        const summary = await summarizeWithLLM(session.messages, provider, {
+          policy: loadedPolicy.policy,
+          model,
+        });
         const compacted = buildCompactedHistory(summary);
         const tokensAfter = estimateTokens(compacted);
         session.messages = compacted;
         session.updatedAt = new Date().toISOString();
         await saveSession(session);
-        send(ws, { type: 'compact_done', tokensBefore, tokensAfter, summary });
+        send(ws, { type: "compact_done", tokensBefore, tokensAfter, summary });
       } catch (err) {
-        send(ws, { type: 'error', message: `Provider error: ${err instanceof Error ? err.message : String(err)}` });
+        send(ws, {
+          type: "error",
+          message: `Provider error: ${err instanceof Error ? err.message : String(err)}`,
+        });
       }
       return;
     }
 
-    if (msg.type !== 'send') return;
+    if (msg.type !== "send") return;
 
     currentAbort?.abort();
     const abort = new AbortController();
@@ -122,55 +183,76 @@ export function handleWebSocket(ws: WebSocket): void {
     try {
       cwd = await resolveAllowedCwd(msg.cwd);
     } catch (err) {
-      send(ws, { type: 'error', message: err instanceof Error ? err.message : 'Workspace is not allowed' });
+      send(ws, {
+        type: "error",
+        message:
+          err instanceof Error ? err.message : "Workspace is not allowed",
+      });
       return;
     }
 
-    const mode: AgentMode = msg.mode ?? 'code';
-    const codePermissionMode: CodePermissionMode = msg.codePermissionMode ?? 'auto';
+    const mode: AgentMode = msg.mode ?? "code";
+    const codePermissionMode: CodePermissionMode =
+      msg.codePermissionMode ?? "auto";
 
     // Stream agent events to the browser. tool_result strips the large
     // internal-only `originalContent` field before it goes over the wire.
     const onEvent = (event: AgentEvent): void => {
       if (abort.signal.aborted) return;
       switch (event.type) {
-        case 'token_delta':
-          send(ws, { type: 'token_delta', content: event.content });
+        case "token_delta":
+          send(ws, { type: "token_delta", content: event.content });
           break;
-        case 'tool_call':
-          send(ws, { type: 'tool_call', name: event.name, id: event.id, input: event.input });
+        case "tool_call":
+          send(ws, {
+            type: "tool_call",
+            name: event.name,
+            id: event.id,
+            input: event.input,
+          });
           break;
-        case 'tool_result': {
-          const { originalContent: _omit, ...safeMetadata } = (event.metadata ?? {}) as Record<string, unknown> & {
+        case "tool_result": {
+          const { originalContent: _omit, ...safeMetadata } = (event.metadata ??
+            {}) as Record<string, unknown> & {
             originalContent?: unknown;
           };
           send(ws, {
-            type: 'tool_result',
+            type: "tool_result",
             name: event.name,
             id: event.id,
             output: event.output,
-            metadata: Object.keys(safeMetadata).length > 0 ? safeMetadata : undefined,
+            metadata:
+              Object.keys(safeMetadata).length > 0 ? safeMetadata : undefined,
           });
           break;
         }
-        case 'tool_error':
-          send(ws, { type: 'tool_error', name: event.name, id: event.id, error: event.error });
+        case "tool_error":
+          send(ws, {
+            type: "tool_error",
+            name: event.name,
+            id: event.id,
+            error: event.error,
+          });
           break;
       }
     };
 
     // Approval round-trip: park the resolver until the browser replies, and
     // auto-reject if the turn is interrupted.
-    const requestApproval = (id: string, toolName: string, input: unknown): Promise<boolean> => {
+    const requestApproval = (
+      id: string,
+      toolName: string,
+      input: unknown,
+    ): Promise<boolean> => {
       return new Promise((resolve) => {
         if (abort.signal.aborted) {
           resolve(false);
           return;
         }
         pendingApprovals.set(id, resolve);
-        send(ws, { type: 'approval_request', id, toolName, input });
+        send(ws, { type: "approval_request", id, toolName, input });
         abort.signal.addEventListener(
-          'abort',
+          "abort",
           () => {
             if (pendingApprovals.has(id)) {
               pendingApprovals.delete(id);
@@ -187,6 +269,7 @@ export function handleWebSocket(ws: WebSocket): void {
         {
           content: msg.content,
           sessionId: msg.sessionId,
+          messageId: msg.messageId,
           cwd,
           mode,
           codePermissionMode,
@@ -194,8 +277,10 @@ export function handleWebSocket(ws: WebSocket): void {
           signal: abort.signal,
         },
         {
-          onSessionId: (sessionId) => send(ws, { type: 'session_id', sessionId }),
-          onProviderSelected: (providerId) => send(ws, { type: 'provider_selected', providerId }),
+          onSessionId: (sessionId) =>
+            send(ws, { type: "session_id", sessionId }),
+          onProviderSelected: (providerId) =>
+            send(ws, { type: "provider_selected", providerId }),
           onEvent,
           requestApproval,
         },
@@ -203,28 +288,39 @@ export function handleWebSocket(ws: WebSocket): void {
 
       if (abort.signal.aborted) return;
 
-      send(ws, { type: 'response', content: turn.result.output });
-      if (turn.reportMarkdown && turn.result.runId) {
-        send(ws, { type: 'run_report', runId: turn.result.runId, markdown: turn.reportMarkdown });
+      const responseContent = turn.replayed
+        ? extractReplayedResponse(turn.result.messages, msg.content)
+        : turn.result.output;
+      send(ws, { type: "response", content: responseContent });
+      if (!turn.replayed && turn.reportMarkdown && turn.result.runId) {
+        send(ws, {
+          type: "run_report",
+          runId: turn.result.runId,
+          markdown: turn.reportMarkdown,
+        });
       }
       send(ws, {
-        type: 'done',
+        type: "done",
         sessionId: turn.sessionId,
         iterations: turn.result.iterationsUsed,
         usage: turn.result.usage,
+        replayed: turn.replayed || undefined,
       });
     } catch (err) {
       if (abort.signal.aborted) {
-        send(ws, { type: 'interrupted' });
+        send(ws, { type: "interrupted" });
         return;
       }
-      send(ws, { type: 'error', message: err instanceof Error ? err.message : String(err) });
+      send(ws, {
+        type: "error",
+        message: err instanceof Error ? err.message : String(err),
+      });
     } finally {
       if (currentAbort === abort) currentAbort = null;
     }
   });
 
-  ws.on('close', () => {
+  ws.on("close", () => {
     currentAbort?.abort();
   });
 }

--- a/src/sessions/journal.ts
+++ b/src/sessions/journal.ts
@@ -24,6 +24,8 @@ export type JournalTurnEnd = {
   type: 'turn_end';
   messageId: string;
   status: 'done' | 'error' | 'interrupted';
+  /** Final assistant text for replay when the same messageId is resent. */
+  output?: string;
   /** Audit run this turn produced, if any. */
   runId?: string;
   /** Audit chain head hash after run_end — the checkpoint anchor. */
@@ -102,6 +104,11 @@ export function completedTurn(records: JournalRecord[], messageId: string): Jour
     (r): r is JournalTurnEnd & { seq: number; ts: string } =>
       r.type === 'turn_end' && r.messageId === messageId && r.status === 'done',
   );
+}
+
+/** Assistant response text for a completed turn, keyed by messageId. */
+export function completedTurnResponse(records: JournalRecord[], messageId: string): string | undefined {
+  return completedTurn(records, messageId)?.output;
 }
 
 /** Turn starts that never reached a terminal record — i.e. crashed mid-turn. */

--- a/tests/server/wsHandler.test.ts
+++ b/tests/server/wsHandler.test.ts
@@ -125,7 +125,7 @@ describe('wsHandler messageId idempotency', () => {
         sessionId: 'dc_test_2',
         result: {
           messages: journaledMessages,
-          output: '(replayed: this message was already processed)',
+          output: 'The agent loop is an 8-state machine.',
           iterationsUsed: 0,
           runId: 'run-abc',
         },
@@ -159,6 +159,81 @@ describe('wsHandler messageId idempotency', () => {
       content: 'The agent loop is an 8-state machine.',
     });
     expect(second.all.some((m) => m.type === 'run_report')).toBe(false);
+
+    ws.close();
+  });
+
+  it('replays the response for the messageId when duplicate user content exists in session', async () => {
+    const messagesWithDuplicateContent: ChatMessage[] = [
+      { role: 'user', content: 'hi' },
+      { role: 'assistant', content: 'answer A' },
+      { role: 'user', content: 'hi' },
+      { role: 'assistant', content: 'answer B' },
+    ];
+
+    runAgentTurnMock
+      .mockResolvedValueOnce({
+        sessionId: 'dc_test_dup',
+        result: {
+          messages: messagesWithDuplicateContent.slice(0, 2),
+          output: 'answer A',
+          iterationsUsed: 1,
+        },
+        providerId: 'mock',
+        model: 'mock-model',
+      })
+      .mockResolvedValueOnce({
+        sessionId: 'dc_test_dup',
+        result: {
+          messages: messagesWithDuplicateContent,
+          output: 'answer B',
+          iterationsUsed: 1,
+        },
+        providerId: 'mock',
+        model: 'mock-model',
+      })
+      .mockResolvedValueOnce({
+        sessionId: 'dc_test_dup',
+        result: {
+          messages: messagesWithDuplicateContent,
+          output: 'answer A',
+          iterationsUsed: 0,
+        },
+        providerId: 'mock',
+        model: 'mock-model',
+        replayed: true,
+      });
+
+    const ws = await connect();
+
+    const first = {
+      type: 'send',
+      content: 'hi',
+      messageId: 'id-1',
+      sessionId: 'dc_test_dup',
+      cwd: process.cwd(),
+      mode: 'chat',
+    };
+    const second = {
+      type: 'send',
+      content: 'hi',
+      messageId: 'id-2',
+      sessionId: 'dc_test_dup',
+      cwd: process.cwd(),
+      mode: 'chat',
+    };
+
+    ws.send(JSON.stringify(first));
+    await waitForDone(ws);
+    ws.send(JSON.stringify(second));
+    await waitForDone(ws);
+    ws.send(JSON.stringify(first));
+    const replay = await waitForDone(ws);
+
+    expect(replay.done.replayed).toBe(true);
+    expect(replay.all.find((m) => m.type === 'response')).toMatchObject({
+      content: 'answer A',
+    });
 
     ws.close();
   });

--- a/tests/server/wsHandler.test.ts
+++ b/tests/server/wsHandler.test.ts
@@ -1,0 +1,191 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createServer, type Server } from 'node:http';
+import { WebSocketServer, WebSocket } from 'ws';
+import { handleWebSocket } from '../../src/server/wsHandler.js';
+import type { ChatMessage } from '../../src/providers/types.js';
+
+const runAgentTurnMock = vi.fn();
+
+vi.mock('../../src/agent/session.js', () => ({
+  runAgentTurn: (...args: unknown[]) => runAgentTurnMock(...args),
+  resolveProvider: vi.fn(),
+}));
+
+type WsMessage = { type: string; [key: string]: unknown };
+
+function waitForDone(ws: WebSocket): Promise<{ all: WsMessage[]; done: WsMessage }> {
+  const all: WsMessage[] = [];
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error('timed out waiting for done')), 5_000);
+    ws.on('message', (raw) => {
+      const msg = JSON.parse(raw.toString()) as WsMessage;
+      all.push(msg);
+      if (msg.type === 'done') {
+        clearTimeout(timer);
+        resolve({ all, done: msg });
+      }
+      if (msg.type === 'error') {
+        clearTimeout(timer);
+        reject(new Error(String(msg.message)));
+      }
+    });
+  });
+}
+
+describe('wsHandler messageId idempotency', () => {
+  let httpServer: Server;
+  let wss: WebSocketServer;
+  let port: number;
+
+  beforeEach(async () => {
+    runAgentTurnMock.mockReset();
+    httpServer = createServer();
+    wss = new WebSocketServer({ server: httpServer, path: '/ws' });
+    wss.on('connection', (ws) => handleWebSocket(ws));
+    await new Promise<void>((resolve) => {
+      httpServer.listen(0, '127.0.0.1', () => resolve());
+    });
+    const addr = httpServer.address();
+    if (!addr || typeof addr === 'string') throw new Error('no port');
+    port = addr.port;
+  });
+
+  afterEach(async () => {
+    await new Promise<void>((resolve, reject) => {
+      wss.close((err) => (err ? reject(err) : resolve()));
+    });
+    await new Promise<void>((resolve, reject) => {
+      httpServer.close((err) => (err ? reject(err) : resolve()));
+    });
+  });
+
+  function connect(): Promise<WebSocket> {
+    return new Promise((resolve, reject) => {
+      const ws = new WebSocket(`ws://127.0.0.1:${port}/ws`);
+      ws.on('open', () => resolve(ws));
+      ws.on('error', reject);
+    });
+  }
+
+  it('forwards messageId to runAgentTurn on a fresh send', async () => {
+    runAgentTurnMock.mockResolvedValueOnce({
+      sessionId: 'dc_test_1',
+      result: {
+        messages: [
+          { role: 'user', content: 'hello' },
+          { role: 'assistant', content: 'hi there' },
+        ] satisfies ChatMessage[],
+        output: 'hi there',
+        iterationsUsed: 1,
+      },
+      providerId: 'mock',
+      model: 'mock-model',
+    });
+
+    const ws = await connect();
+    ws.send(
+      JSON.stringify({
+        type: 'send',
+        content: 'hello',
+        messageId: 'client-msg-1',
+        cwd: process.cwd(),
+        mode: 'chat',
+      }),
+    );
+
+    const { done } = await waitForDone(ws);
+    expect(runAgentTurnMock).toHaveBeenCalledTimes(1);
+    expect(runAgentTurnMock.mock.calls[0]?.[0]).toMatchObject({
+      content: 'hello',
+      messageId: 'client-msg-1',
+    });
+    expect(done.replayed).toBeUndefined();
+    ws.close();
+  });
+
+  it('returns replayed: true and journaled response when messageId was already completed', async () => {
+    const journaledMessages: ChatMessage[] = [
+      { role: 'user', content: 'explain loop.ts' },
+      { role: 'assistant', content: 'The agent loop is an 8-state machine.' },
+    ];
+
+    runAgentTurnMock
+      .mockResolvedValueOnce({
+        sessionId: 'dc_test_2',
+        result: {
+          messages: journaledMessages,
+          output: 'The agent loop is an 8-state machine.',
+          iterationsUsed: 1,
+          runId: 'run-abc',
+        },
+        providerId: 'mock',
+        model: 'mock-model',
+      })
+      .mockResolvedValueOnce({
+        sessionId: 'dc_test_2',
+        result: {
+          messages: journaledMessages,
+          output: '(replayed: this message was already processed)',
+          iterationsUsed: 0,
+          runId: 'run-abc',
+        },
+        providerId: 'mock',
+        model: 'mock-model',
+        replayed: true,
+      });
+
+    const ws = await connect();
+
+    const firstPayload = {
+      type: 'send',
+      content: 'explain loop.ts',
+      messageId: 'client-msg-dup',
+      sessionId: 'dc_test_2',
+      cwd: process.cwd(),
+      mode: 'chat',
+    };
+    ws.send(JSON.stringify(firstPayload));
+    const first = await waitForDone(ws);
+    expect(first.done.replayed).toBeUndefined();
+
+    ws.send(JSON.stringify(firstPayload));
+    const second = await waitForDone(ws);
+
+    expect(runAgentTurnMock).toHaveBeenCalledTimes(2);
+    expect(runAgentTurnMock.mock.calls[1]?.[0]).toMatchObject({ messageId: 'client-msg-dup' });
+    expect(second.done.replayed).toBe(true);
+    expect(second.done.iterations).toBe(0);
+    expect(second.all.find((m) => m.type === 'response')).toMatchObject({
+      content: 'The agent loop is an 8-state machine.',
+    });
+    expect(second.all.some((m) => m.type === 'run_report')).toBe(false);
+
+    ws.close();
+  });
+
+  it('omits messageId when the client does not send one', async () => {
+    runAgentTurnMock.mockResolvedValueOnce({
+      sessionId: 'dc_test_3',
+      result: { messages: [], output: 'ok', iterationsUsed: 1 },
+      providerId: 'mock',
+      model: 'mock-model',
+    });
+
+    const ws = await connect();
+    ws.send(
+      JSON.stringify({
+        type: 'send',
+        content: 'no id',
+        cwd: process.cwd(),
+        mode: 'chat',
+      }),
+    );
+
+    await waitForDone(ws);
+    expect(runAgentTurnMock.mock.calls[0]?.[0]).toMatchObject({
+      content: 'no id',
+      messageId: undefined,
+    });
+    ws.close();
+  });
+});

--- a/tests/sessions/journal.test.ts
+++ b/tests/sessions/journal.test.ts
@@ -5,6 +5,7 @@ import { join } from 'node:path';
 import {
   appendJournal,
   completedTurn,
+  completedTurnResponse,
   danglingTurns,
   projectStatus,
   readJournal,
@@ -63,10 +64,21 @@ describe('session journal', () => {
   it('completedTurn enables idempotent replay only for finished turns', () => {
     appendJournal(sid, { type: 'turn_start', messageId: 'm1', content: 'hi', cwd: '/w', mode: 'chat' }, dir);
     expect(completedTurn(readJournal(sid, dir), 'm1')).toBeUndefined();
-    appendJournal(sid, { type: 'turn_end', messageId: 'm1', status: 'done', runId: 'r1', auditHead: 'h1' }, dir);
+    appendJournal(sid, { type: 'turn_end', messageId: 'm1', status: 'done', runId: 'r1', auditHead: 'h1', output: 'hello' }, dir);
     const hit = completedTurn(readJournal(sid, dir), 'm1');
     expect(hit?.runId).toBe('r1');
+    expect(hit?.output).toBe('hello');
     expect(completedTurn(readJournal(sid, dir), 'other')).toBeUndefined();
+  });
+
+  it('completedTurnResponse is keyed by messageId when user content repeats', () => {
+    appendJournal(sid, { type: 'turn_start', messageId: 'id-1', content: 'hi', cwd: '/w', mode: 'chat' }, dir);
+    appendJournal(sid, { type: 'turn_end', messageId: 'id-1', status: 'done', runId: 'r1', output: 'answer A' }, dir);
+    appendJournal(sid, { type: 'turn_start', messageId: 'id-2', content: 'hi', cwd: '/w', mode: 'chat' }, dir);
+    appendJournal(sid, { type: 'turn_end', messageId: 'id-2', status: 'done', runId: 'r2', output: 'answer B' }, dir);
+    const records = readJournal(sid, dir);
+    expect(completedTurnResponse(records, 'id-1')).toBe('answer A');
+    expect(completedTurnResponse(records, 'id-2')).toBe('answer B');
   });
 
   it('an errored turn is terminal, not dangling, and not replayable', () => {

--- a/web/src/components/MessageBubble.tsx
+++ b/web/src/components/MessageBubble.tsx
@@ -37,7 +37,7 @@ export function MessageBubble({ message, mode, onProceed }: Props) {
   if (message.role === 'compact' || message.role === 'report') return null;
 
   // Assistant message
-  const { content, toolCalls, pending } = message;
+  const { content, toolCalls, pending, replayed } = message;
   const showDots = pending && toolCalls.length === 0 && !content;
 
   // Detect plan in Cowork mode: ≥3 numbered steps, no tool calls, message done
@@ -52,6 +52,11 @@ export function MessageBubble({ message, mode, onProceed }: Props) {
         <ThemeLogo className="w-5 h-5 rounded-full flex-shrink-0" />
         <span className="text-xs text-muted-fg font-medium">DvalinCode</span>
         {pending && <span className="text-xs text-accent/60 animate-pulse">thinking…</span>}
+        {replayed && !pending && (
+          <span className="text-[10px] text-muted-fg/50 italic" title="Returned from session journal without re-running the model">
+            replayed
+          </span>
+        )}
       </div>
 
       {/* Agent tool activity */}

--- a/web/src/hooks/useChat.ts
+++ b/web/src/hooks/useChat.ts
@@ -197,7 +197,27 @@ export function useChat(opts: UseChatOptions = {}) {
             break;
 
           case 'done':
-            setMessages((prev) => updateLastPendingAssistant(prev, (msg) => ({ ...msg, pending: false })));
+            if (event.replayed && event.sessionId) {
+              void fetchSessionDetail(event.sessionId)
+                .then((detail) => {
+                  const uiMessages = mapBackendMessages(detail.messages);
+                  for (let i = uiMessages.length - 1; i >= 0; i--) {
+                    const msg = uiMessages[i];
+                    if (msg?.role === 'assistant') {
+                      uiMessages[i] = { ...msg, replayed: true };
+                      break;
+                    }
+                  }
+                  setMessages(uiMessages);
+                })
+                .catch(() => {
+                  setMessages((prev) =>
+                    updateLastPendingAssistant(prev, (msg) => ({ ...msg, pending: false, replayed: true })),
+                  );
+                });
+            } else {
+              setMessages((prev) => updateLastPendingAssistant(prev, (msg) => ({ ...msg, pending: false })));
+            }
             if (event.usage) setLastUsage(event.usage);
             pendingToolCallsRef.current.clear();
             setPendingApprovals([]);
@@ -245,16 +265,18 @@ export function useChat(opts: UseChatOptions = {}) {
   const send = useCallback(
     (content: string) => {
       if (sending) return;
+      const messageId = crypto.randomUUID();
       setSending(true);
       pendingToolCallsRef.current.clear();
       setMessages((prev) => [
         ...prev,
-        { role: 'user', content },
+        { role: 'user', content, messageId },
         { role: 'assistant', content: '', toolCalls: [], pending: true },
       ]);
       try {
         client.send({
           content,
+          messageId,
           sessionId: currentSessionId,
           cwd: opts.cwd,
           approvalMode: opts.approvalMode,

--- a/web/src/lib/client.ts
+++ b/web/src/lib/client.ts
@@ -5,6 +5,7 @@ const WS_URL = `${location.protocol === 'https:' ? 'wss' : 'ws'}://${location.ho
 export type SendOptions = {
   content: string;
   sessionId?: string;
+  messageId?: string;
   cwd?: string;
   approvalMode?: ApprovalMode;
   mode?: AgentMode;
@@ -64,6 +65,7 @@ export class DvalinClient {
         type: 'send',
         content: opts.content,
         sessionId: opts.sessionId,
+        messageId: opts.messageId,
         cwd: opts.cwd,
         approvalMode: opts.approvalMode,
         mode: opts.mode ?? 'code',

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -69,12 +69,13 @@ export type ToolCallEvent = {
 };
 
 export type ChatMessage =
-  | { role: 'user'; content: string }
+  | { role: 'user'; content: string; messageId?: string }
   | {
       role: 'assistant';
       content: string;
       toolCalls: ToolCallEvent[];
       pending?: boolean;
+      replayed?: boolean;
     }
   | { role: 'compact'; tokensBefore: number; tokensAfter: number }
   | { role: 'report'; runId: string; markdown: string };
@@ -153,7 +154,7 @@ export type ServerEvent =
   | { type: 'approval_request'; id: string; toolName: string; input: unknown }
   | { type: 'response'; content: string }
   | { type: 'run_report'; runId: string; markdown: string }
-  | { type: 'done'; sessionId: string; iterations: number; usage?: { inputTokens: number; outputTokens: number } }
+  | { type: 'done'; sessionId: string; iterations: number; usage?: { inputTokens: number; outputTokens: number }; replayed?: boolean }
   | { type: 'interrupted' }
   | { type: 'error'; message: string }
   | { type: 'compact_done'; tokensBefore: number; tokensAfter: number; summary: string }


### PR DESCRIPTION
## Summary

- Web client attaches a stable `messageId` (`crypto.randomUUID()`) to each chat send.
- `wsHandler` forwards `messageId` into `runAgentTurn` so the durable session journal can dedupe retransmits.
- On replay (`replayed: true`), the handler returns the journaled assistant text and skips run report re-emission; the UI shows a subtle “replayed” indicator.

Closes the transport gap described in `docs/DURABLE-SESSION.md` — journal idempotency existed in `runAgentTurn` but no frontend/WebSocket path passed `messageId` yet.

**Note:** This does not add automatic client retry on disconnect/refresh; it enables safe replay when the same `messageId` is resent.

## Testing

- `npm run check`
- `npm test -- tests/server/wsHandler.test.ts` — same `messageId` twice → `replayed: true`, journaled response; fresh ids unchanged; omitted id unchanged

## Security and AI Governance

- [x] This change does not expand file, shell, network, model, or approval permissions.
- [ ] If it changes agent behavior, prompts, policy, providers, audit logging, or release/build security, I updated the relevant governance evidence in `docs/`.
- [ ] If it introduces a new model/provider/tool or new data flow, I completed `docs/governance/AI-CHANGE-IMPACT-ASSESSMENT.md`.

No new egress, policy, or audit format changes — transport wiring only.