### PR TITLE
Add dvalincode policy check for policy authoring and CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ not claim third-party ISO certification.
 
 - **🔒 Org policy** — a `dvalin.policy.json` lets a *company*, not the developer, bound the agent: which modes, shell commands, file paths, tools, and models are allowed. Two layers (machine `~/.dvalincode/policy.json` + repo) resolve by **narrowing** — a repo policy can only ever make the machine policy stricter, never widen it. With no policy file, behavior is identical to before. Enforced at a single chokepoint; every denial is an inline `⛔ Blocked by policy` plus a `policy_violation` audit event. [Policy reference →](docs/POLICY-REFERENCE.md)
 - **🔎 `dvalincode trust`** — prints this install's live security posture in one command — active policy + source hashes, audit status, runtime, dependencies — so a reviewer can verify what the agent may and may not do directly, instead of taking claims on trust. `--json` for tooling.
+- **`dvalincode policy check`** — validates `dvalin.policy.json` against the schema, prints the resolved policy + canonical hash (after narrowing with the machine layer), and exits non-zero on failure — for CI and policy authoring. [Policy reference →](docs/POLICY-REFERENCE.md)
 - **🧾 Policy-aware audit** — every run records the hash of the governing policy (and which files contributed) in `run_start`, so the tamper-evident log proves *which* rules were in force.
 - **📐 Approvability plan** — the through-line is documented in [docs/APPROVABILITY-PLAN.md](docs/APPROVABILITY-PLAN.md): make DvalinCode trivially approvable by any company — controllable, transparent, auditable.
 

--- a/docs/POLICY-REFERENCE.md
+++ b/docs/POLICY-REFERENCE.md
@@ -33,7 +33,13 @@ default). A missing policy file is identical to no policy at all.
 
 Malformed policy files are **not** treated as allow-all: they are skipped and surfaced
 as `IGNORED (…)` in `dvalincode trust` so gatekeepers know a policy was intended but
-did not apply.
+did not apply. While authoring, validate before commit:
+
+```sh
+dvalincode policy check                  # validate ./dvalin.policy.json
+dvalincode policy check path/to/file.json
+dvalincode policy check --json           # machine-readable, CI-friendly (exit 1 on failure)
+```
 
 ---
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8,6 +8,7 @@ import { registerScanCommand } from './commands/scan.js';
 import { registerToolsCommand } from './commands/tools.js';
 import { registerReportCommand } from './commands/report.js';
 import { registerTrustCommand } from './commands/trust.js';
+import { registerPolicyCommand } from './commands/policy.js';
 import { registerEvidenceCommand } from './commands/evidence.js';
 import { registerServeCommand } from './commands/serve.js';
 import { registerTuiCommand } from './commands/tui.js';
@@ -32,6 +33,7 @@ export function buildProgram(): Command {
   registerMemoryCommand(program);
   registerReportCommand(program);
   registerTrustCommand(program);
+  registerPolicyCommand(program);
   registerEvidenceCommand(program);
   registerServeCommand(program);
   registerTuiCommand(program);

--- a/src/commands/policy.ts
+++ b/src/commands/policy.ts
@@ -1,0 +1,106 @@
+import type { Command } from 'commander';
+import path from 'node:path';
+import { resolveCheckedPolicy, repoPolicyPath, type PolicySource, type ResolvedPolicy } from '../core/policy.js';
+
+const NETWORK_NOTE: Record<ResolvedPolicy['network'], string> = {
+  off: 'no outbound network',
+  'endpoint-only': 'model endpoint only',
+  on: 'unrestricted',
+};
+
+export function registerPolicyCommand(program: Command): void {
+  const policy = program
+    .command('policy')
+    .description('Validate and inspect org policy files (dvalin.policy.json)');
+
+  policy
+    .command('check')
+    .description('Validate a policy file against the schema and print the resolved policy + hash')
+    .argument('[path]', 'policy file to check (default: ./dvalin.policy.json)')
+    .option('--json', 'output the result as JSON')
+    .action((file: string | undefined, options: { json?: boolean }) => {
+      const target = file ?? repoPolicyPath(process.cwd());
+      const result = resolveCheckedPolicy(target);
+
+      if (!result.ok) {
+        if (options.json) {
+          console.log(JSON.stringify({ ok: false, path: result.path, kind: result.kind, errors: result.errors }, null, 2));
+        } else {
+          console.error(`✗ validation failed: ${result.path}`);
+          for (const err of result.errors) console.error(`  ${err}`);
+        }
+        process.exit(1);
+      }
+
+      if (result.machineWarning) {
+        console.warn(`⚠ Ignored malformed machine policy: ${result.machineWarning}`);
+      }
+
+      if (options.json) {
+        console.log(
+          JSON.stringify(
+            {
+              ok: true,
+              path: result.path,
+              hash: result.hash,
+              sources: result.sources,
+              resolved: result.policy,
+            },
+            null,
+            2,
+          ),
+        );
+        return;
+      }
+
+      console.log(`✓ ${path.basename(result.path)} is valid`);
+      console.log('');
+      console.log('Resolved policy (after narrowing with machine layer):');
+      console.log(`  hash      ${result.hash}`);
+      console.log('  sources');
+      for (const s of result.sources) {
+        console.log(`    ${sourceLine(s)}`);
+      }
+      console.log('  effective');
+      console.log(renderEffective(result.policy));
+    });
+}
+
+function sourceLine(s: PolicySource): string {
+  const status = s.error ? `IGNORED (${s.error})` : s.present ? `sha256:${short(s.hash)}` : 'absent';
+  return `${s.layer.padEnd(8)} ${s.path}  ${status}`;
+}
+
+function renderEffective(p: ResolvedPolicy): string {
+  const lines = [
+    `    modes        ${p.modes.join(', ') || '(none)'}`,
+    `    network      ${p.network} — ${NETWORK_NOTE[p.network]}`,
+    `    providers    ${p.providers.allow ? `allow: ${p.providers.allow.join(', ')}` : 'any'}`,
+    `    models       ${p.models.allow ? `allow: ${p.models.allow.join(', ')}` : 'any'}`,
+    `    commands     ${describeCommands(p)}`,
+    `    paths        ${describePaths(p)}`,
+    `    tools        ${p.tools.deny.length ? `deny: ${p.tools.deny.join(', ')}` : 'all allowed'}`,
+    `    mcp          ${p.mcp.allow ? `allow: ${p.mcp.allow.join(', ')}` : 'any configured server'}`,
+    `    maxToolCalls ${p.maxToolCalls ?? 'unlimited'}`,
+  ];
+  return lines.join('\n');
+}
+
+function describeCommands(p: ResolvedPolicy): string {
+  if (p.commands.allow) return `allowlist: ${p.commands.allow.join(', ')}`;
+  const parts: string[] = [];
+  if (p.commands.defaultDeny) parts.push('default-deny');
+  if (p.commands.deny.length) parts.push(`deny: ${p.commands.deny.join(', ')}`);
+  return parts.length ? parts.join('; ') : 'all allowed';
+}
+
+function describePaths(p: ResolvedPolicy): string {
+  const parts: string[] = [];
+  if (p.paths.allow) parts.push(`allowlist: ${p.paths.allow.join(', ')}`);
+  if (p.paths.deny.length) parts.push(`deny: ${p.paths.deny.join(', ')}`);
+  return parts.length ? parts.join('; ') : 'workspace (per .dvalincodeignore)';
+}
+
+function short(hash: string | null): string {
+  return hash ? hash.slice(0, 12) : '—';
+}

--- a/src/core/policy.ts
+++ b/src/core/policy.ts
@@ -343,7 +343,109 @@ export function loadPolicy(cwd: string = process.cwd()): LoadedPolicy {
   };
 }
 
+/** One Zod issue per line — used by `dvalincode policy check` for readable authoring feedback. */
+export function formatZodIssues(err: z.ZodError): string[] {
+  return err.issues.map(i => {
+    const field = i.path.length ? i.path.join('.') : '(root)';
+    return `${field}: ${i.message}`;
+  });
+}
+
+export type PolicyValidationFailure = {
+  ok: false;
+  kind: 'missing' | 'read' | 'json' | 'schema';
+  path: string;
+  errors: string[];
+};
+
+export type PolicyValidationSuccess = {
+  ok: true;
+  path: string;
+  fileHash: string;
+  parsed: OrgPolicyInput;
+};
+
+/** Validate a policy file against `orgPolicySchema` without loading other layers. */
+export function validatePolicyFile(file: string): PolicyValidationSuccess | PolicyValidationFailure {
+  const resolved = path.resolve(file);
+  if (!existsSync(resolved)) {
+    return { ok: false, kind: 'missing', path: resolved, errors: ['file does not exist'] };
+  }
+  let raw: string;
+  try {
+    raw = readFileSync(resolved, 'utf8');
+  } catch (err) {
+    return { ok: false, kind: 'read', path: resolved, errors: [errMsg(err)] };
+  }
+  let json: unknown;
+  try {
+    json = JSON.parse(raw);
+  } catch (err) {
+    return {
+      ok: false,
+      kind: 'json',
+      path: resolved,
+      errors: [err instanceof Error ? err.message : String(err)],
+    };
+  }
+  const parsed = orgPolicySchema.safeParse(json);
+  if (!parsed.success) {
+    return { ok: false, kind: 'schema', path: resolved, errors: formatZodIssues(parsed.error) };
+  }
+  return { ok: true, path: resolved, fileHash: sha256(raw), parsed: parsed.data };
+}
+
+export type PolicyCheckSuccess = {
+  ok: true;
+  path: string;
+  policy: ResolvedPolicy;
+  hash: string;
+  sources: PolicySource[];
+  /** Set when the machine layer exists but could not be applied (mirrors runtime). */
+  machineWarning?: string;
+};
+
+export type PolicyCheckFailure = PolicyValidationFailure;
+
+/**
+ * Validate `file` and resolve the effective policy after narrowing with the machine layer.
+ * The checked file must be valid; a malformed machine policy is skipped with `machineWarning`.
+ */
+export function resolveCheckedPolicy(
+  file: string,
+  cwd: string = process.cwd(),
+): PolicyCheckSuccess | PolicyCheckFailure {
+  const resolved = path.resolve(cwd, file);
+  const validation = validatePolicyFile(resolved);
+  if (!validation.ok) return validation;
+
+  const machinePath = path.resolve(machinePolicyPath());
+  const machine = readSource('machine', machinePath);
+  const inputs: OrgPolicyInput[] = [];
+  if (machine.parsed && resolved !== machinePath) inputs.push(machine.parsed);
+  inputs.push(validation.parsed);
+  const policy = resolvePolicy(inputs);
+
+  const sources: PolicySource[] = [];
+  if (resolved !== machinePath) sources.push(machine.source);
+  sources.push({
+    layer: resolved === machinePath ? 'machine' : 'repo',
+    path: resolved,
+    present: true,
+    hash: validation.fileHash,
+  });
+
+  return {
+    ok: true,
+    path: resolved,
+    policy,
+    hash: policyHash(policy),
+    sources,
+    machineWarning: machine.source.error,
+  };
+}
+
 function errMsg(err: unknown): string {
-  if (err instanceof z.ZodError) return err.issues.map(i => `${i.path.join('.')}: ${i.message}`).join('; ');
+  if (err instanceof z.ZodError) return formatZodIssues(err).join('; ');
   return err instanceof Error ? err.message : String(err);
 }

--- a/tests/core/policy-check.test.ts
+++ b/tests/core/policy-check.test.ts
@@ -1,0 +1,152 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import {
+  validatePolicyFile,
+  resolveCheckedPolicy,
+  resolvePolicy,
+  policyHash,
+  permissivePolicy,
+} from '../../src/core/policy.js';
+
+describe('validatePolicyFile', () => {
+  const cleanups: Array<() => void> = [];
+  afterEach(() => {
+    while (cleanups.length) cleanups.pop()!();
+  });
+
+  function tempDir(): string {
+    const dir = mkdtempSync(path.join(tmpdir(), 'dvalin-policy-check-'));
+    cleanups.push(() => rmSync(dir, { recursive: true, force: true }));
+    return dir;
+  }
+
+  it('accepts a valid policy file', () => {
+    const dir = tempDir();
+    const file = path.join(dir, 'dvalin.policy.json');
+    writeFileSync(file, JSON.stringify({ modes: ['chat'], network: 'endpoint-only' }));
+
+    const result = validatePolicyFile(file);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.parsed.modes).toEqual(['chat']);
+      expect(result.fileHash).toMatch(/^[a-f0-9]{64}$/);
+    }
+  });
+
+  it('rejects a missing file', () => {
+    const result = validatePolicyFile(path.join(tempDir(), 'missing.json'));
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.kind).toBe('missing');
+      expect(result.errors[0]).toContain('does not exist');
+    }
+  });
+
+  it('rejects invalid JSON', () => {
+    const dir = tempDir();
+    const file = path.join(dir, 'dvalin.policy.json');
+    writeFileSync(file, '{ not json');
+
+    const result = validatePolicyFile(file);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.kind).toBe('json');
+  });
+
+  it('rejects schema violations with per-field errors', () => {
+    const dir = tempDir();
+    const file = path.join(dir, 'dvalin.policy.json');
+    writeFileSync(
+      file,
+      JSON.stringify({ modes: ['agent'], network: 'full', extra: true }),
+    );
+
+    const result = validatePolicyFile(file);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.kind).toBe('schema');
+      expect(result.errors.some(e => e.includes('modes'))).toBe(true);
+      expect(result.errors.some(e => e.includes('network'))).toBe(true);
+      expect(result.errors.some(e => e.includes('extra'))).toBe(true);
+    }
+  });
+});
+
+describe('resolveCheckedPolicy', () => {
+  const cleanups: Array<() => void> = [];
+  afterEach(() => {
+    delete process.env.DVALINCODE_POLICY_FILE;
+    while (cleanups.length) cleanups.pop()!();
+  });
+
+  function tempDir(): string {
+    const dir = mkdtempSync(path.join(tmpdir(), 'dvalin-policy-resolve-'));
+    cleanups.push(() => rmSync(dir, { recursive: true, force: true }));
+    return dir;
+  }
+
+  it('resolves a valid repo file with no machine layer', () => {
+    process.env.DVALINCODE_POLICY_FILE = path.join(tempDir(), 'absent.json');
+    const repoDir = tempDir();
+    const file = path.join(repoDir, 'dvalin.policy.json');
+    writeFileSync(file, JSON.stringify({ modes: ['chat'], network: 'off' }));
+
+    const result = resolveCheckedPolicy(file, repoDir);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.policy.modes).toEqual(['chat']);
+      expect(result.policy.network).toBe('off');
+      expect(result.hash).toBe(policyHash(resolvePolicy([{ modes: ['chat'], network: 'off' }])));
+    }
+  });
+
+  it('narrows with a valid machine layer', () => {
+    const machineDir = tempDir();
+    const machineFile = path.join(machineDir, 'policy.json');
+    writeFileSync(machineFile, JSON.stringify({ modes: ['chat', 'cowork'], network: 'endpoint-only' }));
+    process.env.DVALINCODE_POLICY_FILE = machineFile;
+
+    const repoDir = tempDir();
+    const file = path.join(repoDir, 'dvalin.policy.json');
+    writeFileSync(file, JSON.stringify({ modes: ['chat', 'cowork', 'code'], network: 'on' }));
+
+    const result = resolveCheckedPolicy(file, repoDir);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.policy.modes).toEqual(['chat', 'cowork']);
+      expect(result.policy.network).toBe('endpoint-only');
+      expect(result.sources.some(s => s.layer === 'machine')).toBe(true);
+    }
+  });
+
+  it('fails on a malformed checked file', () => {
+    process.env.DVALINCODE_POLICY_FILE = path.join(tempDir(), 'absent.json');
+    const repoDir = tempDir();
+    const file = path.join(repoDir, 'dvalin.policy.json');
+    writeFileSync(file, '{ broken');
+
+    const result = resolveCheckedPolicy(file, repoDir);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.kind).toBe('json');
+  });
+
+  it('skips a malformed machine layer but still resolves the checked file', () => {
+    const machineDir = tempDir();
+    const machineFile = path.join(machineDir, 'policy.json');
+    writeFileSync(machineFile, '{ broken');
+    process.env.DVALINCODE_POLICY_FILE = machineFile;
+
+    const repoDir = tempDir();
+    const file = path.join(repoDir, 'dvalin.policy.json');
+    writeFileSync(file, JSON.stringify({ network: 'off' }));
+
+    const result = resolveCheckedPolicy(file, repoDir);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.machineWarning).toBeTruthy();
+      expect(result.policy.network).toBe('off');
+      expect(result.policy.modes).toEqual(permissivePolicy().modes);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `dvalincode policy check [path]` to validate org policy files against `orgPolicySchema` with readable per-field Zod errors
- Prints the resolved policy after narrowing with the machine layer (`~/.dvalincode/policy.json`) plus the canonical hash — same semantics as runtime/`trust`
- Exits non-zero on validation failure for CI; supports `--json` for tooling
- Documented in README and `docs/POLICY-REFERENCE.md`
## Motivation
Authoring `dvalin.policy.json` was trial-and-error: malformed files are safely skipped at runtime with only a warning, and the only way to see the resolved result was `dvalincode trust` (a full security report). This command makes policy authoring self-service for platform teams.
## Usage
```sh
dvalincode policy check                  # default: ./dvalin.policy.json
dvalincode policy check path/to/file.json
dvalincode policy check --json           # CI-friendly JSON output
