### PR TITLE
test: cover restricted subprocess fail-closed paths

### DIFF
--- a/tests/shellSandbox.test.ts
+++ b/tests/shellSandbox.test.ts
@@ -1,5 +1,38 @@
-import { describe, expect, it } from 'vitest';
-import { selectSubprocessSandbox } from '../src/core/subprocessSandbox.js';
+import { spawn } from 'node:child_process';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { AuditEvent } from '../src/audit/log.js';
+import { PolicyViolationError, resolvePolicy } from '../src/core/policy.js';
+import { runGovernedProcess, selectSubprocessSandbox } from '../src/core/subprocessSandbox.js';
+
+vi.mock('node:child_process', () => ({ spawn: vi.fn() }));
+
+const originalPlatformDescriptor = Object.getOwnPropertyDescriptor(process, 'platform')!;
+const originalPath = process.env.PATH;
+
+afterEach(() => {
+  Object.defineProperty(process, 'platform', originalPlatformDescriptor);
+  if (originalPath === undefined) {
+    delete process.env.PATH;
+  } else {
+    process.env.PATH = originalPath;
+  }
+  vi.clearAllMocks();
+});
+
+function setPlatform(platform: NodeJS.Platform) {
+  Object.defineProperty(process, 'platform', {
+    ...originalPlatformDescriptor,
+    value: platform,
+  });
+}
+
+function captureAudit() {
+  const events: AuditEvent[] = [];
+  return {
+    audit: { append: (event: AuditEvent) => events.push(event), getWarnings: () => [] },
+    events,
+  };
+}
 
 describe('shell network sandbox selection', () => {
   it('uses Seatbelt for restricted macOS policies', () => {
@@ -34,5 +67,58 @@ describe('shell network sandbox selection', () => {
   it('preserves unrestricted behavior for network: on', () => {
     expect(selectSubprocessSandbox('linux', false, {})).toEqual({ allowed: true, sandbox: 'none' });
     expect(selectSubprocessSandbox('win32', false, {})).toEqual({ allowed: true, sandbox: 'none' });
+  });
+});
+
+describe('governed subprocess restricted-network fail-closed integration', () => {
+  it.each([
+    {
+      name: 'Windows with network: off',
+      platform: 'win32' as NodeJS.Platform,
+      policy: resolvePolicy([{ network: 'off' }]),
+      egressRule: 'network egress is disabled by policy (network: off)',
+      sandboxReason: 'win32 has no supported subprocess network sandbox in Governed Network v1',
+    },
+    {
+      name: 'Linux without Bubblewrap and endpoint-only network',
+      platform: 'linux' as NodeJS.Platform,
+      policy: resolvePolicy([{ network: 'endpoint-only' }]),
+      egressRule: 'only the configured model endpoint is reachable (network: endpoint-only)',
+      sandboxReason: 'Bubblewrap is unavailable; restricted subprocess launch fails closed',
+    },
+  ])('refuses to spawn and records a policy violation on $name', async ({ platform, policy, egressRule, sandboxReason }) => {
+    setPlatform(platform);
+    process.env.PATH = '';
+    const spawnMock = vi.mocked(spawn);
+    const { audit, events } = captureAudit();
+
+    let thrown: unknown;
+    try {
+      await runGovernedProcess({
+        command: process.execPath,
+        args: ['-e', 'console.log("should not run")'],
+        cwd: process.cwd(),
+        timeoutMs: 1_000,
+        policy,
+        audit: audit as never,
+        toolName: 'shell',
+      });
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(PolicyViolationError);
+    expect((thrown as PolicyViolationError).rule).toContain(egressRule);
+    expect((thrown as PolicyViolationError).rule).toContain(sandboxReason);
+    expect((thrown as PolicyViolationError).target).toBe('subprocess network isolation');
+    expect(spawnMock).not.toHaveBeenCalled();
+    expect(events).toEqual([
+      expect.objectContaining({
+        type: 'policy_violation',
+        rule: expect.stringContaining(sandboxReason),
+        tool: 'shell',
+        target: 'subprocess network isolation',
+      }),
+    ]);
   });
 });


### PR DESCRIPTION
## What

- Adds integration-level coverage for `runGovernedProcess` under restricted network policies on Windows and Linux-without-bwrap paths.
- Asserts fail-closed behavior raises `PolicyViolationError`, records a `policy_violation` audit event, and never calls `spawn`.

## Why

This covers the end-to-end behavior requested in #57 without requiring a Windows runner or Bubblewrap on CI.

Fixes #57.

## Security impact

Test-only change. It verifies existing restricted subprocess behavior remains fail-closed when network isolation is unavailable.

## Validation

- `npm install`
- `npx vitest run tests/shellSandbox.test.ts` (1 file, 6 tests)
- `npm run check` (typecheck + 36 test files, 203 tests)
- `npm run build`

AI assistance was used to prepare this contribution.