### PR TITLE
docs: link dvalincode.dev from both READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 </p>
 
 <p align="center">
-  <b>English</b> · <a href="README.zh-CN.md">中文</a>
+  <b>English</b> · <a href="README.zh-CN.md">中文</a> · <a href="https://dvalincode.dev">🌐 dvalincode.dev</a>
 </p>
 
 <p align="center">

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -3,7 +3,7 @@
 </p>
 
 <p align="center">
-  <a href="README.md">English</a> · <b>中文</b>
+  <a href="README.md">English</a> · <b>中文</b> · <a href="https://dvalincode.dev/zh/">🌐 dvalincode.dev</a>
 </p>
 
 <p align="center">


### PR DESCRIPTION
Adds the new official site to the language-switcher line at the top of both READMEs — EN links to https://dvalincode.dev, ZH links to https://dvalincode.dev/zh/.

Follow-up to #74 (site launch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)