### PR TITLE
feat(site): add GoatCounter visit analytics

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -46,6 +46,17 @@ export default defineConfig({
     ['meta', { property: 'og:image', content: `${HOSTNAME}/hero.png` }],
     ['meta', { property: 'og:url', content: HOSTNAME }],
     ['meta', { name: 'twitter:card', content: 'summary_large_image' }],
+    // GoatCounter — cookie-less, GDPR-exempt visit counting. count.js ignores
+    // localhost, so dev servers never pollute the stats. The script counts the
+    // initial page load; SPA route changes are counted in theme/index.ts.
+    [
+      'script',
+      {
+        'data-goatcounter': 'https://dvalincode.goatcounter.com/count',
+        async: '',
+        src: 'https://gc.zgo.at/count.js',
+      },
+    ],
   ],
 
   locales: {

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -1,0 +1,21 @@
+import DefaultTheme from 'vitepress/theme'
+import type { Theme } from 'vitepress'
+
+declare global {
+  interface Window {
+    goatcounter?: { count: (opts?: { path?: string }) => void }
+  }
+}
+
+// GoatCounter's count.js only sees the initial page load (config.ts head
+// script). VitePress navigates client-side after that, so each route change
+// must be counted explicitly.
+export default {
+  extends: DefaultTheme,
+  enhanceApp({ router }) {
+    if (typeof window === 'undefined') return
+    router.onAfterRouteChanged = (to) => {
+      window.goatcounter?.count({ path: to })
+    }
+  },
+} satisfies Theme


### PR DESCRIPTION
Adds privacy-first visit counting to dvalincode.dev — pageviews + unique visitors, no cookies, no consent banner needed, so it stays consistent with the project's privacy/compliance positioning.

- `config.ts` head: GoatCounter `count.js` (counts initial page loads; skips localhost automatically)
- `theme/index.ts` (new): `router.onAfterRouteChanged` → `goatcounter.count()` so SPA navigations are counted too

**Verified in browser preview:** script tag present with endpoint `dvalincode.goatcounter.com/count`, `window.goatcounter` loaded, client-side nav to `/APPROVABILITY-PLAN` fired exactly one `count({path})` call, default theme rendering unaffected, `npm run check` green.

**Post-merge (owner):** register the site code `dvalincode` at goatcounter.com so the endpoint goes live — until then the beacon 404s harmlessly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)