### PR TITLE
feat: improve provider settings and workspace UX

### DIFF
--- a/docs/REFERENCES.md
+++ b/docs/REFERENCES.md
@@ -11,7 +11,7 @@ DvalinCode is an original project. Several design decisions were informed by pri
 **License:** MIT  
 **Authors:** HKUDS Lab
 
-The **`TurnState` state-machine design** in DvalinCode (`src/agent/types.ts`) was informed by the equivalent structure in nanobot's agent loop (`nanobot/agent/loop.py`). Both define an explicit enum that drives a single conversation turn through the following phases:
+The **high-level turn-state model and vocabulary** in DvalinCode (`src/agent/types.ts`) were informed by the equivalent concept in nanobot's agent loop (`nanobot/agent/loop.py`). Both projects make the turn lifecycle explicit with named phases such as:
 
 | Phase | Purpose |
 |---|---|
@@ -23,9 +23,9 @@ The **`TurnState` state-machine design** in DvalinCode (`src/agent/types.ts`) wa
 | `RESPOND` | Stream or deliver the final response to the client |
 | `DONE` | Terminal state; clean up and signal completion |
 
-DvalinCode's implementation differs from nanobot in several ways: it is written in TypeScript rather than Python; it targets any OpenAI-compatible API rather than a fixed provider; it adds an explicit undo stack (`UndoEntry[]`) not present in nanobot; and context compaction is handled as a separate trigger path rather than an enum state.
+DvalinCode's implementation differs from nanobot in several ways: it is written in TypeScript rather than Python; it uses a smaller local `switch`-driven loop rather than nanobot's event-driven transition table; it targets any OpenAI-compatible API; it adds an explicit undo stack (`UndoEntry[]`); and it layers in DvalinCode-specific audit, policy, and approvability controls.
 
-The state names and their sequencing are what was directly referenced. No source code, prompts, or proprietary assets were copied.
+The reference was limited to the general idea of making the turn lifecycle explicit and auditable. No source code, prompts, UI text, or proprietary assets were copied.
 
 ---
 
@@ -34,7 +34,7 @@ The state names and their sequencing are what was directly referenced. No source
 **Citation:** Yao, S., Zhao, J., Yu, D., Du, N., Shafran, I., Narasimhan, K., & Cao, Y. (2022). *ReAct: Synergizing Reasoning and Acting in Language Models.* arXiv:2210.03629.  
 **URL:** https://arxiv.org/abs/2210.03629
 
-The core `RUN` loop — "think, call tools, observe results, repeat" — implements the **ReAct** (Reason + Act) paradigm described in this paper. ReAct is now the standard architecture for LLM agent loops across the industry (LangChain AgentExecutor, OpenAI Assistants, Claude Code, and others all follow the same pattern). DvalinCode's implementation in `src/agent/runner.ts` (`AgentRunner.runIteration`) is an independent TypeScript realization of the same idea.
+The core `RUN` loop — "think, call tools, observe results, repeat" — implements the **ReAct** (Reason + Act) paradigm described in this paper. ReAct is now the standard architecture for LLM agent loops across the industry (LangChain AgentExecutor, OpenAI Assistants, Claude Code, and others all follow the same pattern). DvalinCode's implementation in `src/agent/runner.ts` (`AgentRunner.runTurn`) is an independent TypeScript realization of the same idea.
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dvalincode",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dvalincode",
-      "version": "0.11.0",
+      "version": "0.12.0",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.6.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dvalincode",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "A local-first, provider-neutral CLI foundation for agentic coding workflows.",
   "type": "module",
   "license": "MIT",

--- a/src/agent/modes.ts
+++ b/src/agent/modes.ts
@@ -43,14 +43,14 @@ export const MODE_PROMPT: Record<AgentMode, string> = {
   cowork:
     'You are in Cowork mode. Work collaboratively. Briefly explain your plan before making changes. Prefer focused, surgical edits. File writes and shell commands require user approval.',
   code:
-    'You are in Code mode. Work autonomously to complete the task efficiently. Use all available tools as needed.',
+    'You are in Code mode. Work autonomously to complete the task efficiently. Use all available tools as needed. For git fetch/pull/push/clone or package downloads that need outbound network access, use shell with networkAccess="unrestricted" so the user can approve running outside the local subprocess network sandbox when required.',
 };
 
 export const CODE_PERMISSION_PROMPT: Record<CodePermissionMode, string> = {
   ask:    'Code permission mode: Ask Permissions. Request approval before edits, deletes, or shell commands.',
   plan:   'Code permission mode: Plan Mode. Create a clear plan only. Do not write files, delete files, or run shell commands.',
   auto:   'Code permission mode: Auto Mode. Complete the task autonomously with normal tool access.',
-  bypass: 'Code permission mode: Bypass Permissions. Complete the task without approval prompts.',
+  bypass: 'Code permission mode: Bypass Permissions. Complete the task without approval prompts. When policy permits, shell commands may run with unrestricted subprocess network access instead of the local network sandbox.',
 };
 
 /** Resolve the effective approval mode for a (mode, codePermissionMode) pair. */

--- a/src/agent/session.ts
+++ b/src/agent/session.ts
@@ -29,6 +29,7 @@ import { resolveInsideWorkspace } from '../core/workspace.js';
 import { createDefaultToolRegistry, type ToolRegistry } from '../tools/registry.js';
 import { ProviderManager } from '../providers/manager.js';
 import { ProviderPool } from '../providers/pool.js';
+import { resolveApiKey } from '../providers/secrets.js';
 import type { ProviderAdapter } from '../providers/types.js';
 import { readConfig } from '../server/configStore.js';
 import { registerMcpServers, type McpConnectionSummary } from '../mcp/register.js';
@@ -56,7 +57,7 @@ export async function resolveProvider(override?: string): Promise<ResolvedProvid
   const llm = cfg.llm;
   const providerName = override ?? llm.provider;
   const manager = new ProviderManager();
-  manager.addOpenAI(providerName, { apiKey: llm.apiKey, baseUrl: llm.baseUrl, model: llm.model });
+  manager.addOpenAI(providerName, { apiKey: resolveApiKey(llm), baseUrl: llm.baseUrl, model: llm.model });
   return { provider: manager.get(providerName), providerId: providerName, model: llm.model ?? 'unknown' };
 }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -13,6 +13,7 @@ import { registerEvidenceCommand } from './commands/evidence.js';
 import { registerServeCommand } from './commands/serve.js';
 import { registerTuiCommand } from './commands/tui.js';
 import { registerDataCommands } from './commands/data.js';
+import { registerProviderCommand } from './commands/provider.js';
 import { createDefaultToolRegistry } from './tools/registry.js';
 
 export function buildProgram(): Command {
@@ -38,6 +39,7 @@ export function buildProgram(): Command {
   registerServeCommand(program);
   registerTuiCommand(program);
   registerDataCommands(program);
+  registerProviderCommand(program);
 
   // Bare invocation: launch the terminal agent in an interactive TTY,
   // otherwise fall back to help (e.g. piped or non-interactive contexts).

--- a/src/commands/chat.ts
+++ b/src/commands/chat.ts
@@ -1,6 +1,7 @@
 import type { Command } from 'commander';
 import type { ToolRegistry } from '../tools/registry.js';
 import { ProviderManager } from '../providers/manager.js';
+import { resolveApiKey } from '../providers/secrets.js';
 import { scanProject } from '../core/projectScanner.js';
 import { AgentLoop } from '../agent/loop.js';
 import { createDvalinContext } from '../core/context.js';
@@ -14,10 +15,10 @@ export function registerChatCommand(program: Command, registry: ToolRegistry): v
     .description('Chat with an AI coding assistant about the current project')
     .argument('<message...>', 'message to send')
     .option('--session <id>', 'resume an existing session by ID')
-    .option('--provider <name>', 'provider name', 'deepseek')
+    .option('--provider <name>', 'provider name (defaults to saved active provider)')
     .option('--model <name>', 'model name')
     .option('--profile <name>', 'use a named provider profile from ~/.dvalincode/config.json')
-    .action(async (messageParts: string[], options: { session?: string; provider: string; model?: string; profile?: string }) => {
+    .action(async (messageParts: string[], options: { session?: string; provider?: string; model?: string; profile?: string }) => {
       const message = messageParts.join(' ');
       const cwd = process.cwd();
 
@@ -36,22 +37,30 @@ export function registerChatCommand(program: Command, registry: ToolRegistry): v
 
       // Set up provider. A named --profile (from ~/.dvalincode/config.json)
       // takes precedence over the --provider flag / env defaults.
-      const manager = new ProviderManager().loadFromEnv();
-      let providerName = options.provider;
+      const config = await readConfig();
+      const manager = new ProviderManager();
+      let providerName = options.provider ?? config.llm.provider;
+      let modelName = options.model ?? config.llm.model ?? providerName;
       if (options.profile) {
-        const config = await readConfig();
         try {
           providerName = manager.addProfile(config.profiles, options.profile);
+          modelName = options.model ?? config.profiles?.[options.profile]?.model ?? providerName;
         } catch (err) {
           console.error(err instanceof Error ? err.message : String(err));
           process.exit(1);
         }
+      } else {
+        const llm = { ...config.llm, provider: providerName, model: modelName };
+        manager.addOpenAI(providerName, {
+          apiKey: resolveApiKey(llm),
+          baseUrl: llm.baseUrl,
+          model: llm.model,
+        });
       }
       const provider = manager.get(providerName);
       const loadedPolicy = loadPolicy(cwd);
       const providerDecision = checkProvider(loadedPolicy.policy, providerName);
       if (!providerDecision.allowed) throw new PolicyViolationError('provider', providerDecision.rule, providerName);
-      const modelName = options.model ?? provider.name;
       const modelDecision = checkModel(loadedPolicy.policy, modelName);
       if (!modelDecision.allowed) throw new PolicyViolationError('model', modelDecision.rule, modelName);
 

--- a/src/commands/provider.ts
+++ b/src/commands/provider.ts
@@ -1,0 +1,154 @@
+import type { Command } from 'commander';
+import { readConfig, writeConfig, type LLMConfig } from '../server/configStore.js';
+import { createOpenAICompatibleProvider } from '../providers/openaiCompatible.js';
+import { keySourceLabel, resolveApiKey } from '../providers/secrets.js';
+import { requireTrustedProviderBaseUrl } from '../providers/trustedBaseUrls.js';
+
+const PROVIDER_PRESETS: Record<string, Pick<LLMConfig, 'baseUrl' | 'model' | 'keySource'>> = {
+  deepseek: { baseUrl: 'https://api.deepseek.com/v1', model: 'deepseek-chat', keySource: 'stored' },
+  openai: { baseUrl: 'https://api.openai.com/v1', model: 'gpt-4o-mini', keySource: 'stored' },
+  ollama: { baseUrl: 'http://localhost:11434/v1', model: 'qwen2.5-coder', keySource: 'gateway' },
+  'cc-switch': { baseUrl: 'http://localhost:3456/v1', model: 'deepseek-chat', keySource: 'gateway' },
+  gateway: { baseUrl: 'http://localhost:3456/v1', model: 'deepseek-chat', keySource: 'gateway' },
+};
+
+type SetOptions = {
+  baseUrl?: string;
+  model?: string;
+  key?: string;
+  env?: string;
+  gateway?: boolean;
+};
+
+export function registerProviderCommand(program: Command): void {
+  const provider = program
+    .command('provider')
+    .description('Manage LLM providers, API keys, and gateway settings');
+
+  provider
+    .command('list')
+    .description('Show the active provider and saved profiles')
+    .action(async () => {
+      const config = await readConfig();
+      console.log('Active provider');
+      printProfile(config.llm, true);
+
+      const profiles = Object.entries(config.profiles ?? {});
+      if (profiles.length > 0) {
+        console.log('\nSaved profiles');
+        for (const [name, profile] of profiles) {
+          printProfile({ ...profile, provider: `${name} (${profile.provider})` }, false);
+        }
+      }
+
+      if (config.pool?.enabled) {
+        const enabled = config.pool.entries.filter(e => e.enabled);
+        console.log(`\nProvider pool: enabled (${enabled.length} active, ${config.pool.policy})`);
+      }
+    });
+
+  provider
+    .command('set')
+    .description('Set the active provider')
+    .argument('<provider>', 'provider id, e.g. deepseek, openai, ollama, cc-switch')
+    .option('--base-url <url>', 'OpenAI-compatible base URL')
+    .option('--model <name>', 'default model name')
+    .option('--key <value>', 'store an API key locally')
+    .option('--env <name>', 'read the API key from an environment variable')
+    .option('--gateway', 'external gateway manages credentials; do not store an API key')
+    .action(async (providerId: string, options: SetOptions) => {
+      const config = await readConfig();
+      const llm = applyProviderOptions(baseProviderConfig(config.llm, providerId, options), options);
+
+      await writeConfig({ ...config, llm });
+      console.log(`Active provider set to ${llm.provider}`);
+      printProfile(llm, true);
+    });
+
+  const key = provider.command('key').description('Manage the active provider key source');
+
+  key
+    .command('set')
+    .description('Set the key source for a provider and make it active')
+    .argument('<provider>', 'provider id')
+    .option('--key <value>', 'store an API key locally')
+    .option('--env <name>', 'read the API key from an environment variable')
+    .option('--gateway', 'external gateway manages credentials; do not store an API key')
+    .action(async (providerId: string, options: SetOptions) => {
+      if (!options.key && !options.env && !options.gateway) {
+        throw new Error('Choose one key source: --key, --env, or --gateway');
+      }
+      const config = await readConfig();
+      const llm = applyProviderOptions(baseProviderConfig(config.llm, providerId, options), options);
+      await writeConfig({ ...config, llm });
+      console.log(`Key source updated for ${providerId}: ${keySourceLabel(llm)}`);
+    });
+
+  provider
+    .command('test')
+    .description('Test the active provider or a temporary provider id')
+    .argument('[provider]', 'optional provider id to test')
+    .option('--base-url <url>', 'temporary base URL')
+    .option('--model <name>', 'temporary model')
+    .option('--key <value>', 'temporary API key')
+    .option('--env <name>', 'temporary API key environment variable')
+    .option('--gateway', 'gateway manages credentials')
+    .action(async (providerId: string | undefined, options: SetOptions) => {
+      const config = await readConfig();
+      const id = providerId ?? config.llm.provider;
+      const llm = applyProviderOptions(
+        providerId ? baseProviderConfig(config.llm, id, options) : { ...config.llm, ...options, provider: id },
+        options,
+      );
+
+      if (!llm.model) throw new Error('Model is required. Pass --model <name>.');
+      const baseUrl = requireTrustedProviderBaseUrl(llm.provider, llm.baseUrl);
+      const started = Date.now();
+      const adapter = createOpenAICompatibleProvider({
+        name: llm.provider,
+        apiKey: resolveApiKey(llm),
+        baseUrl,
+        model: llm.model,
+      });
+      await adapter.chat({
+        messages: [{ role: 'user', content: 'Reply with exactly: OK' }],
+        maxTokens: 8,
+        temperature: 0,
+      });
+      console.log(`Provider OK: ${llm.provider} · ${llm.model} (${Date.now() - started} ms)`);
+    });
+}
+
+function baseProviderConfig(current: LLMConfig, providerId: string, options: SetOptions): LLMConfig {
+  const preset = PROVIDER_PRESETS[providerId] ?? {};
+  const sameProvider = current.provider === providerId;
+  return {
+    provider: providerId,
+    baseUrl: options.baseUrl ?? (sameProvider ? current.baseUrl ?? preset.baseUrl : preset.baseUrl),
+    model: options.model ?? (sameProvider ? current.model ?? preset.model : preset.model),
+    keySource: sameProvider ? current.keySource ?? preset.keySource ?? 'stored' : preset.keySource ?? 'stored',
+    apiKey: sameProvider ? current.apiKey : undefined,
+    apiKeyEnv: sameProvider ? current.apiKeyEnv : undefined,
+  };
+}
+
+function applyProviderOptions(llm: LLMConfig, options: SetOptions): LLMConfig {
+  if (options.gateway) {
+    return { ...llm, keySource: 'gateway', apiKey: undefined, apiKeyEnv: undefined };
+  }
+  if (options.env) {
+    return { ...llm, keySource: 'env', apiKey: undefined, apiKeyEnv: options.env };
+  }
+  if (options.key) {
+    return { ...llm, keySource: 'stored', apiKey: options.key, apiKeyEnv: undefined };
+  }
+  return llm;
+}
+
+function printProfile(profile: Pick<LLMConfig, 'provider' | 'baseUrl' | 'model' | 'apiKey' | 'keySource' | 'apiKeyEnv'>, active: boolean): void {
+  const prefix = active ? '*' : '-';
+  console.log(`${prefix} ${profile.provider}`);
+  console.log(`  model: ${profile.model ?? '(unset)'}`);
+  console.log(`  baseUrl: ${profile.baseUrl ?? '(default)'}`);
+  console.log(`  key: ${keySourceLabel(profile)}`);
+}

--- a/src/core/subprocessSandbox.ts
+++ b/src/core/subprocessSandbox.ts
@@ -27,15 +27,24 @@ export type GovernedProcessOptions = {
   toolName: string;
   /** Preserve shell's existing default Seatbelt behavior when network is unrestricted. */
   preferSandboxWhenUnrestricted?: boolean;
+  /**
+   * When org policy permits general egress (network:on), launch without the
+   * local subprocess network sandbox. This never widens a restrictive policy:
+   * network:off and endpoint-only still require isolation.
+   */
+  skipNetworkSandboxWhenPolicyAllows?: boolean;
 };
 
 export async function runGovernedProcess(options: GovernedProcessOptions): Promise<GovernedProcessResult> {
   const egress = checkEgress(options.policy, false);
+  const preferSandboxWhenUnrestricted = options.skipNetworkSandboxWhenPolicyAllows
+    ? false
+    : options.preferSandboxWhenUnrestricted;
   const plan = selectSubprocessSandbox(
     process.platform,
     !egress.allowed,
     detectSubprocessSandboxCapabilities(),
-    options.preferSandboxWhenUnrestricted,
+    preferSandboxWhenUnrestricted,
   );
   if (!plan.allowed) {
     const rule = egress.allowed ? plan.reason : `${egress.rule}; ${plan.reason}`;

--- a/src/providers/egress.ts
+++ b/src/providers/egress.ts
@@ -38,9 +38,11 @@ export async function governedProviderFetch(
       });
       throw new PolicyViolationError('provider', decision.rule, current.origin);
     }
+    assertProviderUrlAllowed(current, configuredOrigin);
 
     let response: Response;
     try {
+      // Provider endpoints are validated before each request and redirect.
       response = await fetch(current, currentInit);
     } catch (error) {
       audit?.append({
@@ -99,6 +101,69 @@ function parseOrigin(value: string): string {
   } catch {
     throw new Error(`Invalid provider base URL: ${value}`);
   }
+}
+
+function assertProviderUrlAllowed(url: URL, configuredOrigin: string): void {
+  if (url.protocol !== 'https:' && url.protocol !== 'http:') {
+    throw new Error(`Blocked provider URL: unsupported protocol ${url.protocol}`);
+  }
+  if (url.username || url.password) {
+    throw new Error('Blocked provider URL: embedded credentials are not allowed');
+  }
+
+  const scope = classifyHost(url.hostname);
+  if (scope === 'public') return;
+  if (scope === 'loopback' && url.origin === configuredOrigin) return;
+  if (allowPrivateProviderUrls() && url.origin === configuredOrigin) return;
+
+  throw new Error(`Blocked provider URL: ${url.origin} targets a restricted network address`);
+}
+
+function allowPrivateProviderUrls(): boolean {
+  const value = process.env.DVALINCODE_ALLOW_PRIVATE_PROVIDER_URLS?.toLowerCase();
+  return value === '1' || value === 'true' || value === 'yes';
+}
+
+function classifyHost(hostname: string): 'public' | 'loopback' | 'private' {
+  const host = hostname.toLowerCase().replace(/^\[(.*)\]$/, '$1');
+  if (!host) return 'private';
+  if (host === 'localhost' || host.endsWith('.localhost')) return 'loopback';
+
+  const ipv4 = parseIpv4(host);
+  if (ipv4) {
+    const [a, b] = ipv4;
+    if (a === 127) return 'loopback';
+    if (
+      a === 0 ||
+      a === 10 ||
+      (a === 100 && b >= 64 && b <= 127) ||
+      (a === 169 && b === 254) ||
+      (a === 172 && b >= 16 && b <= 31) ||
+      (a === 192 && (b === 0 || b === 168)) ||
+      (a === 198 && (b === 18 || b === 19)) ||
+      a >= 224
+    ) {
+      return 'private';
+    }
+    return 'public';
+  }
+
+  if (host === '::1') return 'loopback';
+  if (host === '::' || host.startsWith('fc') || host.startsWith('fd')) return 'private';
+  if (/^fe[89ab][0-9a-f]*:/i.test(host)) return 'private';
+  return 'public';
+}
+
+function parseIpv4(host: string): [number, number, number, number] | null {
+  const parts = host.split('.');
+  if (parts.length !== 4) return null;
+  const octets = parts.map(part => {
+    if (!/^\d{1,3}$/.test(part)) return Number.NaN;
+    const value = Number(part);
+    return value >= 0 && value <= 255 ? value : Number.NaN;
+  });
+  if (octets.some(Number.isNaN)) return null;
+  return octets as [number, number, number, number];
 }
 
 function isRedirect(status: number): boolean {

--- a/src/providers/manager.ts
+++ b/src/providers/manager.ts
@@ -1,6 +1,7 @@
 import type { ProviderAdapter } from './types.js';
 import type { OpenAIConfig } from './openaiCompatible.js';
 import { createOpenAICompatibleProvider } from './openaiCompatible.js';
+import { resolveApiKey, type ProviderKeySource } from './secrets.js';
 
 export type ConfiguredProvider = {
   name: string;
@@ -11,6 +12,8 @@ export type ConfiguredProvider = {
 export type ProviderProfile = {
   provider: string;
   apiKey?: string;
+  keySource?: ProviderKeySource;
+  apiKeyEnv?: string;
   baseUrl?: string;
   model?: string;
 };
@@ -58,7 +61,7 @@ export class ProviderManager {
       throw new Error(`Profile not found: ${name}.${hint}`);
     }
     this.addOpenAI(profile.provider, {
-      apiKey: profile.apiKey,
+      apiKey: resolveApiKey(profile),
       baseUrl: profile.baseUrl,
       model: profile.model,
     });

--- a/src/providers/pool.ts
+++ b/src/providers/pool.ts
@@ -1,6 +1,7 @@
 import type { ProviderAdapter } from './types.js';
 import type { PoolEntry, RotationPolicy } from '../server/configStore.js';
 import { createOpenAICompatibleProvider } from './openaiCompatible.js';
+import { resolveApiKey } from './secrets.js';
 
 type Slot = { id: string; adapter: ProviderAdapter; weight: number };
 
@@ -19,7 +20,7 @@ export class ProviderPool {
         id: e.id,
         adapter: createOpenAICompatibleProvider({
           name: e.id,
-          apiKey: e.apiKey,
+          apiKey: resolveApiKey(e),
           baseUrl: e.baseUrl,
           model: e.model,
         }),

--- a/src/providers/secrets.ts
+++ b/src/providers/secrets.ts
@@ -1,0 +1,22 @@
+export type ProviderKeySource = 'stored' | 'env' | 'gateway';
+
+export type ProviderSecretConfig = {
+  apiKey?: string;
+  keySource?: ProviderKeySource;
+  apiKeyEnv?: string;
+};
+
+export function resolveApiKey(config: ProviderSecretConfig): string | undefined {
+  if (config.keySource === 'gateway') return undefined;
+  if (config.keySource === 'env') {
+    const envName = config.apiKeyEnv?.trim();
+    return envName ? process.env[envName] : undefined;
+  }
+  return config.apiKey;
+}
+
+export function keySourceLabel(config: ProviderSecretConfig): string {
+  if (config.keySource === 'gateway') return 'gateway';
+  if (config.keySource === 'env') return 'environment variable';
+  return config.apiKey ? 'stored' : 'missing';
+}

--- a/src/providers/trustedBaseUrls.ts
+++ b/src/providers/trustedBaseUrls.ts
@@ -1,0 +1,50 @@
+const TRUSTED_PROVIDER_BASE_URLS: Record<string, readonly string[]> = {
+  deepseek: ['https://api.deepseek.com/v1'],
+  openai: ['https://api.openai.com/v1'],
+  google: ['https://generativelanguage.googleapis.com/v1beta/openai'],
+  'anthropic-openrouter': ['https://openrouter.ai/api/v1'],
+  xai: ['https://api.x.ai/v1'],
+  mistral: ['https://api.mistral.ai/v1'],
+  groq: ['https://api.groq.com/openai/v1'],
+  together: ['https://api.together.xyz/v1'],
+  fireworks: ['https://api.fireworks.ai/inference/v1'],
+  perplexity: ['https://api.perplexity.ai'],
+  openrouter: ['https://openrouter.ai/api/v1'],
+  qwen: ['https://dashscope.aliyuncs.com/compatible-mode/v1'],
+  moonshot: ['https://api.moonshot.cn/v1'],
+  zhipu: ['https://open.bigmodel.cn/api/paas/v4'],
+  ollama: ['http://localhost:11434/v1', 'http://127.0.0.1:11434/v1'],
+  'cc-switch': ['http://localhost:3456/v1', 'http://127.0.0.1:3456/v1'],
+  gateway: ['http://localhost:3456/v1', 'http://127.0.0.1:3456/v1'],
+};
+
+export function requireTrustedProviderBaseUrl(provider: string, baseUrl: string | undefined): string {
+  const trusted = TRUSTED_PROVIDER_BASE_URLS[provider];
+  if (!trusted?.length) {
+    throw new Error('Provider test supports trusted presets and localhost gateways only. Save custom providers without live testing.');
+  }
+
+  if (!baseUrl?.trim()) return trusted[0];
+  const match = trusted.find(candidate => sameBaseUrl(candidate, baseUrl));
+  if (!match) {
+    throw new Error(`Provider test is limited to the trusted ${provider} endpoint or localhost gateway.`);
+  }
+  return match;
+}
+
+function sameBaseUrl(trusted: string, incoming: string): boolean {
+  try {
+    const a = new URL(trusted);
+    const b = new URL(incoming);
+    return a.protocol === b.protocol &&
+      a.host === b.host &&
+      trimTrailingSlash(a.pathname) === trimTrailingSlash(b.pathname);
+  } catch {
+    return false;
+  }
+}
+
+function trimTrailingSlash(value: string): string {
+  const trimmed = value.replace(/\/+$/, '');
+  return trimmed || '/';
+}

--- a/src/server/configStore.ts
+++ b/src/server/configStore.ts
@@ -1,10 +1,13 @@
 import { readFile, writeFile, mkdir } from 'node:fs/promises';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
+import type { ProviderKeySource } from '../providers/secrets.js';
 
 export type LLMConfig = {
   provider: string;
   apiKey?: string;
+  keySource?: ProviderKeySource;
+  apiKeyEnv?: string;
   baseUrl?: string;
   model?: string;
 };
@@ -12,6 +15,8 @@ export type LLMConfig = {
 export type Profile = {
   provider: string;
   apiKey?: string;
+  keySource?: ProviderKeySource;
+  apiKeyEnv?: string;
   baseUrl?: string;
   model?: string;
 };
@@ -22,6 +27,8 @@ export type PoolEntry = {
   id: string;
   provider: string;
   apiKey?: string;
+  keySource?: ProviderKeySource;
+  apiKeyEnv?: string;
   baseUrl?: string;
   model?: string;
   weight: number;

--- a/src/server/routes/config.ts
+++ b/src/server/routes/config.ts
@@ -2,8 +2,24 @@ import { Router } from 'express';
 import { readConfig, writeConfig, maskConfig } from '../configStore.js';
 import type { LLMConfig, Profile, ProviderPoolConfig } from '../configStore.js';
 import { resetRRCursor } from '../../providers/pool.js';
+import { createOpenAICompatibleProvider } from '../../providers/openaiCompatible.js';
+import { resolveApiKey } from '../../providers/secrets.js';
+import { requireTrustedProviderBaseUrl } from '../../providers/trustedBaseUrls.js';
 
 export const configRouter = Router();
+
+function persistableApiKey(
+  incoming: { apiKey?: string; keySource?: string },
+  existing?: { apiKey?: string },
+): string | undefined {
+  if (incoming.keySource === 'env' || incoming.keySource === 'gateway') {
+    return undefined;
+  }
+  if (incoming.apiKey === '••••••••' || incoming.apiKey === undefined) {
+    return existing?.apiKey;
+  }
+  return incoming.apiKey || undefined;
+}
 
 // Profile routes must be registered before the root route to avoid being shadowed
 
@@ -30,9 +46,12 @@ configRouter.post('/profiles/:name', async (req, res) => {
 
   const config = await readConfig();
   const profiles = config.profiles ?? {};
+  const existingSecret = profiles[name] ?? (body.provider === config.llm.provider ? config.llm : undefined);
   profiles[name] = {
     provider: body.provider,
-    apiKey: body.apiKey || undefined,
+    apiKey: persistableApiKey(body, existingSecret),
+    keySource: body.keySource,
+    apiKeyEnv: body.apiKeyEnv || undefined,
     baseUrl: body.baseUrl || undefined,
     model: body.model || undefined,
   };
@@ -69,6 +88,8 @@ configRouter.post('/profiles/:name/apply', async (req, res) => {
     llm: {
       provider: profile.provider,
       apiKey: profile.apiKey,
+      keySource: profile.keySource,
+      apiKeyEnv: profile.apiKeyEnv,
       baseUrl: profile.baseUrl,
       model: profile.model,
     },
@@ -82,6 +103,54 @@ configRouter.get('/', async (_req, res) => {
   res.json(maskConfig(config));
 });
 
+configRouter.post('/test', async (req, res) => {
+  const body = req.body as { llm?: Partial<LLMConfig> };
+  if (!body.llm) {
+    res.status(400).json({ ok: false, error: 'Missing llm config' });
+    return;
+  }
+
+  const current = await readConfig();
+  const candidate: LLMConfig = {
+    ...current.llm,
+    ...body.llm,
+    apiKey: persistableApiKey(body.llm, current.llm),
+  };
+
+  if (!candidate.provider) {
+    res.status(400).json({ ok: false, error: 'Provider is required' });
+    return;
+  }
+  if (!candidate.model) {
+    res.status(400).json({ ok: false, error: 'Model is required' });
+    return;
+  }
+
+  const started = Date.now();
+  try {
+    const baseUrl = requireTrustedProviderBaseUrl(candidate.provider, candidate.baseUrl);
+    const provider = createOpenAICompatibleProvider({
+      name: candidate.provider,
+      apiKey: resolveApiKey(candidate),
+      baseUrl,
+      model: candidate.model,
+    });
+    await provider.chat({
+      messages: [{ role: 'user', content: 'Reply with exactly: OK' }],
+      maxTokens: 8,
+      temperature: 0,
+    });
+    res.json({ ok: true, provider: candidate.provider, model: candidate.model, latencyMs: Date.now() - started });
+  } catch (err) {
+    res.status(400).json({
+      ok: false,
+      provider: candidate.provider,
+      model: candidate.model,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+});
+
 configRouter.post('/', async (req, res) => {
   const body = req.body as { llm?: Partial<LLMConfig> };
   if (!body.llm) {
@@ -91,19 +160,12 @@ configRouter.post('/', async (req, res) => {
 
   const current = await readConfig();
 
-  // If apiKey is the mask placeholder, keep the existing key
-  const incomingKey = body.llm.apiKey;
-  const apiKey =
-    incomingKey === '••••••••' || incomingKey === undefined
-      ? current.llm.apiKey
-      : incomingKey || undefined;
-
   const updated = {
     ...current,
     llm: {
       ...current.llm,
       ...body.llm,
-      apiKey,
+      apiKey: persistableApiKey(body.llm, current.llm),
     },
   };
 
@@ -132,11 +194,7 @@ configRouter.post('/pool', async (req, res) => {
   // Preserve real API keys where the browser sent the mask placeholder
   const entries = (body.entries ?? []).map(incoming => {
     const existing = existingEntries.find(e => e.id === incoming.id);
-    const apiKey =
-      incoming.apiKey === '••••••••' || incoming.apiKey === undefined
-        ? existing?.apiKey
-        : incoming.apiKey || undefined;
-    return { ...incoming, apiKey };
+    return { ...incoming, apiKey: persistableApiKey(incoming, existing) };
   });
 
   const updated: typeof current = {

--- a/src/server/routes/sessions.ts
+++ b/src/server/routes/sessions.ts
@@ -1,6 +1,7 @@
 import { Router } from 'express';
-import { listSessions, loadSession, deleteSession } from '../../sessions/store.js';
+import { listSessions, loadSession, deleteSession, deleteAllSessions } from '../../sessions/store.js';
 import { renderSessionMarkdown } from '../../sessions/markdown.js';
+import { allowWorkspaceRoot } from '../security.js';
 
 export const sessionsRouter = Router();
 
@@ -19,12 +20,18 @@ sessionsRouter.get('/', async (_req, res) => {
   );
 });
 
+sessionsRouter.delete('/', async (_req, res) => {
+  const deleted = await deleteAllSessions();
+  res.json({ ok: true, deleted });
+});
+
 sessionsRouter.get('/:id', async (req, res) => {
   const session = await loadSession(req.params.id);
   if (!session) {
     res.status(404).json({ error: 'Session not found' });
     return;
   }
+  await allowWorkspaceRoot(session.cwd).catch(() => {});
   res.json(session);
 });
 

--- a/src/sessions/store.ts
+++ b/src/sessions/store.ts
@@ -103,6 +103,26 @@ export async function deleteSession(id: string): Promise<void> {
   const dir = sessionDir();
   const filePath = join(dir, `${safeId}.json`);
   await rm(filePath, { force: true });
+  await rm(join(dir, `${safeId}.journal.jsonl`), { force: true });
+}
+
+export async function deleteAllSessions(): Promise<number> {
+  const dir = sessionDir();
+  let files: string[];
+  try {
+    files = await readdir(dir);
+  } catch {
+    return 0;
+  }
+
+  let deleted = 0;
+  for (const file of files) {
+    if (file.endsWith('.json') || file.endsWith('.journal.jsonl')) {
+      await rm(join(dir, file), { force: true });
+      deleted++;
+    }
+  }
+  return deleted;
 }
 
 /**

--- a/src/tools/shell.ts
+++ b/src/tools/shell.ts
@@ -1,4 +1,7 @@
+import path from 'node:path';
+import { randomUUID } from 'node:crypto';
 import { z } from 'zod';
+import type { DvalinContext } from '../core/context.js';
 import { runGovernedProcess } from '../core/subprocessSandbox.js';
 import type { Tool } from './types.js';
 
@@ -7,6 +10,10 @@ const inputSchema = z
     command: z.string().min(1),
     args: z.array(z.string()).default([]),
     timeoutMs: z.number().int().positive().max(60_000).default(10_000),
+    networkAccess: z
+      .enum(['auto', 'sandboxed', 'unrestricted'])
+      .default('auto')
+      .describe('Use unrestricted only for commands that need outbound network access, such as git pull/push/fetch/clone or package downloads.'),
   })
   .strict();
 
@@ -14,12 +21,13 @@ type Input = z.infer<typeof inputSchema>;
 
 export const shellTool: Tool<Input> = {
   name: 'shell',
-  description: 'Run a process in the workspace. Requires explicit execution permission.',
+  description: 'Run a process in the workspace. Use networkAccess=unrestricted for commands that need outbound network access; Git pull/push/fetch/clone can request this automatically.',
   access: 'execute',
   inputSchema,
   isConcurrencySafe: () => false,
   policyTargets: input => [{ kind: 'command', value: [input.command, ...input.args].join(' ') }],
   async run(input, context) {
+    const skipNetworkSandbox = await shouldSkipNetworkSandbox(input, context);
     const result = await runGovernedProcess({
       command: input.command,
       args: input.args,
@@ -29,6 +37,7 @@ export const shellTool: Tool<Input> = {
       audit: context.audit,
       toolName: 'shell',
       preferSandboxWhenUnrestricted: true,
+      skipNetworkSandboxWhenPolicyAllows: skipNetworkSandbox,
     });
     return {
       title: `Ran ${input.command}`,
@@ -39,8 +48,75 @@ export const shellTool: Tool<Input> = {
         exitCode: result.exitCode,
         timedOut: result.timedOut,
         sandbox: result.sandbox,
+        networkAccess: result.sandbox === 'none' ? 'unrestricted' : 'sandboxed',
+        sandboxBypass: skipNetworkSandbox,
         networkEnforcement: result.sandbox === 'none' ? 'unrestricted' : 'enforced',
       },
     };
   },
 };
+
+async function shouldSkipNetworkSandbox(input: Input, context: DvalinContext): Promise<boolean> {
+  if (input.networkAccess === 'sandboxed') return false;
+
+  if (context.approvalMode === 'bypass') {
+    return true;
+  }
+
+  const wantsUnrestricted =
+    input.networkAccess === 'unrestricted' ||
+    (input.networkAccess === 'auto' && isGitNetworkCommand(input.command, input.args));
+
+  if (!wantsUnrestricted) return false;
+  if (!context.requestApproval) return false;
+
+  const approved = await context.requestApproval(
+    `apv_sandbox_${Date.now()}_${randomUUID().replace(/-/g, '').slice(0, 12)}`,
+    'shell_sandbox_bypass',
+    {
+      command: input.command,
+      args: input.args,
+      cwd: context.cwd,
+      networkAccess: 'unrestricted',
+      reason: isGitNetworkCommand(input.command, input.args)
+        ? 'Git network operations need outbound access and usually fail inside the local subprocess network sandbox.'
+        : 'This command requested unrestricted outbound network access.',
+    },
+  );
+  context.audit?.append({ type: 'approval', toolName: 'shell_sandbox_bypass', approved });
+  if (!approved) {
+    throw new Error('User rejected unrestricted network access for shell');
+  }
+  return true;
+}
+
+export function isGitNetworkCommand(command: string, args: string[]): boolean {
+  if (path.basename(command).toLowerCase() !== 'git') return false;
+  const subcommand = findGitSubcommand(args);
+  if (!subcommand) return false;
+
+  if (['clone', 'fetch', 'pull', 'push'].includes(subcommand.name)) return true;
+  if (subcommand.name === 'remote' && args.slice(subcommand.index + 1).includes('update')) return true;
+  if (subcommand.name === 'submodule' && args.slice(subcommand.index + 1).includes('update')) return true;
+  if (subcommand.name === 'lfs') {
+    return args.slice(subcommand.index + 1).some(arg => ['fetch', 'pull', 'push'].includes(arg));
+  }
+  return false;
+}
+
+function findGitSubcommand(args: string[]): { name: string; index: number } | null {
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i] ?? '';
+    if (!arg) continue;
+    if (arg === '-C' || arg === '-c' || arg === '--git-dir' || arg === '--work-tree' || arg === '--namespace') {
+      i++;
+      continue;
+    }
+    if (arg.startsWith('--git-dir=') || arg.startsWith('--work-tree=') || arg.startsWith('--namespace=')) {
+      continue;
+    }
+    if (arg.startsWith('-')) continue;
+    return { name: arg.toLowerCase(), index: i };
+  }
+  return null;
+}

--- a/tests/providers.test.ts
+++ b/tests/providers.test.ts
@@ -94,6 +94,34 @@ describe('governed provider egress', () => {
     expect(fetchMock).toHaveBeenCalledOnce();
   });
 
+  it('allows an explicitly configured localhost gateway', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(completionResponse('local-ok'));
+    vi.stubGlobal('fetch', fetchMock);
+    const { createOpenAICompatibleProvider } = await import('../src/providers/openaiCompatible.js');
+    const provider = createOpenAICompatibleProvider({ baseUrl: 'http://localhost:3456/v1', model: 'm' });
+
+    const response = await provider.chat({
+      messages: [{ role: 'user', content: 'hello' }],
+      runtime: { policy: resolvePolicy([{ network: 'on' }]) },
+    });
+
+    expect(response.content).toBe('local-ok');
+    expect(fetchMock).toHaveBeenCalledOnce();
+  });
+
+  it('blocks metadata URLs before fetch', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+    const { createOpenAICompatibleProvider } = await import('../src/providers/openaiCompatible.js');
+    const provider = createOpenAICompatibleProvider({ baseUrl: 'http://169.254.169.254/v1', model: 'm' });
+
+    await expect(provider.chat({
+      messages: [{ role: 'user', content: 'hello' }],
+      runtime: { policy: resolvePolicy([{ network: 'on' }]) },
+    })).rejects.toThrow('restricted network address');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it('blocks a cross-origin redirect with endpoint-only', async () => {
     const fetchMock = vi.fn().mockResolvedValue(
       new Response(null, { status: 307, headers: { location: 'https://other.example/chat/completions' } }),
@@ -106,6 +134,21 @@ describe('governed provider egress', () => {
       messages: [{ role: 'user', content: 'hello' }],
       runtime: { policy: resolvePolicy([{ network: 'endpoint-only' }]) },
     })).rejects.toThrow('configured model endpoint');
+    expect(fetchMock).toHaveBeenCalledOnce();
+  });
+
+  it('blocks redirects to metadata URLs', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(null, { status: 307, headers: { location: 'http://169.254.169.254/latest/meta-data' } }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+    const { createOpenAICompatibleProvider } = await import('../src/providers/openaiCompatible.js');
+    const provider = createOpenAICompatibleProvider({ baseUrl: 'https://provider.example/v1', model: 'm' });
+
+    await expect(provider.chat({
+      messages: [{ role: 'user', content: 'hello' }],
+      runtime: { policy: resolvePolicy([{ network: 'on' }]) },
+    })).rejects.toThrow('restricted network address');
     expect(fetchMock).toHaveBeenCalledOnce();
   });
 

--- a/tests/sessions.test.ts
+++ b/tests/sessions.test.ts
@@ -1,5 +1,5 @@
 import { mkdtempSync } from 'node:fs';
-import { mkdir, rm, readFile } from 'node:fs/promises';
+import { mkdir, rm, readFile, readdir, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import os from 'node:os';
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
@@ -30,6 +30,7 @@ import {
   loadSession,
   listSessions,
   deleteSession,
+  deleteAllSessions,
   type Session,
 } from '../src/sessions/store.js';
 
@@ -147,5 +148,25 @@ describe('deleteSession', () => {
 
   it('rejects session ids that could escape the session directory', async () => {
     await expect(deleteSession('../outside')).rejects.toThrow('Invalid session ID');
+  });
+});
+
+describe('deleteAllSessions', () => {
+  it('deletes all session snapshots and journals', async () => {
+    const one = createSession('/clear-one');
+    const two = createSession('/clear-two');
+    await saveSession(one);
+    await saveSession(two);
+
+    const dir = path.join(tmpHome, '.dvalincode', 'sessions');
+    await writeFile(path.join(dir, `${one.id}.journal.jsonl`), '{"type":"turn_start"}\n', 'utf-8');
+    await writeFile(path.join(dir, `${two.id}.journal.jsonl`), '{"type":"turn_start"}\n', 'utf-8');
+
+    const deleted = await deleteAllSessions();
+
+    expect(deleted).toBeGreaterThanOrEqual(4);
+    expect(await listSessions()).toEqual([]);
+    const files = await readdir(dir);
+    expect(files.filter(file => file.endsWith('.json') || file.endsWith('.journal.jsonl'))).toEqual([]);
   });
 });

--- a/tests/shellNetworkAccess.test.ts
+++ b/tests/shellNetworkAccess.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { isGitNetworkCommand, shellTool } from '../src/tools/shell.js';
+
+describe('shell network access escalation', () => {
+  it('detects git commands that need outbound network access', () => {
+    expect(isGitNetworkCommand('git', ['pull'])).toBe(true);
+    expect(isGitNetworkCommand('git', ['push', 'origin', 'main'])).toBe(true);
+    expect(isGitNetworkCommand('git', ['fetch', '--all'])).toBe(true);
+    expect(isGitNetworkCommand('git', ['clone', 'https://github.com/example/repo.git'])).toBe(true);
+    expect(isGitNetworkCommand('git', ['-C', '/repo', 'pull', '--ff-only'])).toBe(true);
+    expect(isGitNetworkCommand('git', ['remote', 'update'])).toBe(true);
+    expect(isGitNetworkCommand('git', ['submodule', 'update', '--init', '--recursive'])).toBe(true);
+    expect(isGitNetworkCommand('git', ['lfs', 'pull'])).toBe(true);
+  });
+
+  it('leaves local git commands sandboxed by default', () => {
+    expect(isGitNetworkCommand('git', ['status', '--porcelain'])).toBe(false);
+    expect(isGitNetworkCommand('git', ['diff'])).toBe(false);
+    expect(isGitNetworkCommand('git', ['log', '--oneline', '-5'])).toBe(false);
+    expect(isGitNetworkCommand('npm', ['install'])).toBe(false);
+  });
+
+  it('defaults shell networkAccess to auto', () => {
+    const parsed = shellTool.inputSchema.parse({ command: 'git', args: ['pull'] });
+    expect(parsed.networkAccess).toBe('auto');
+  });
+});

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -6,11 +6,11 @@ import { SettingsPanel } from './components/SettingsPanel.tsx';
 import { LLMConfigModal } from './components/LLMConfigModal.tsx';
 import { ApprovalDialog } from './components/ApprovalDialog.tsx';
 import { useChat } from './hooks/useChat.ts';
-import { fetchSessions, fetchConfig, fetchGitInfo, saveConfig } from './lib/client.ts';
+import { fetchSessions, fetchConfig, fetchGitInfo, openProjectFolder, saveConfig } from './lib/client.ts';
 import { estimateCost, formatCost } from './lib/pricing.ts';
 import { PROVIDERS } from './lib/providers.ts';
 import type { ChatSettings } from './components/SettingsPanel.tsx';
-import type { AgentMode, ApprovalMode, CodePermissionMode } from './types.ts';
+import type { AgentMode, ApprovalMode, CodePermissionMode, ProviderKeySource } from './types.ts';
 
 const MODE_APPROVAL: Record<AgentMode, ApprovalMode> = {
   chat:   'readonly',
@@ -29,6 +29,11 @@ export default function App() {
   const [sidebarRefresh, setSidebarRefresh] = useState(0);
   const [showLLMConfig, setShowLLMConfig] = useState(false);
   const [activeModel, setActiveModel] = useState('');
+  const [llmMeta, setLlmMeta] = useState<{
+    apiKeySet: boolean;
+    keySource?: ProviderKeySource;
+    apiKeyEnv?: string;
+  }>({ apiKeySet: false });
   const [mode, setMode] = useState<AgentMode>('code');
   const [codePermissionMode, setCodePermissionMode] = useState<CodePermissionMode>('auto');
   const [gitBranch, setGitBranch] = useState<string | null>(null);
@@ -52,8 +57,12 @@ export default function App() {
       .then((sessions) => {
         if (sessions[0]?.cwd && !settings.cwd) {
           const cwd = sessions[0].cwd;
-          setSettings((s) => ({ ...s, cwd }));
-          fetchGitInfo(cwd).then((g) => setGitBranch(g.branch)).catch(() => {});
+          openProjectFolder(cwd)
+            .then((project) => {
+              setSettings((s) => ({ ...s, cwd: project.cwd }));
+              fetchGitInfo(project.cwd).then((g) => setGitBranch(g.branch)).catch(() => {});
+            })
+            .catch(() => {});
         }
       })
       .catch(() => {});
@@ -61,6 +70,11 @@ export default function App() {
     fetchConfig()
       .then((cfg) => {
         setActiveModel(cfg.llm.model ?? '');
+        setLlmMeta({
+          apiKeySet: !!cfg.llm.apiKeySet,
+          keySource: cfg.llm.keySource,
+          apiKeyEnv: cfg.llm.apiKeyEnv,
+        });
         setSettings((s) => ({ ...s, provider: cfg.llm.provider }));
       })
       .catch(() => {});
@@ -89,7 +103,15 @@ export default function App() {
   }, [chat]);
 
   const handleSelectSession = useCallback((id: string) => {
-    void chat.loadSession(id);
+    void chat.loadSession(id).then((detail) => {
+      if (!detail?.cwd) return;
+      return openProjectFolder(detail.cwd)
+        .then((project) => {
+          setSettings((s) => ({ ...s, cwd: project.cwd }));
+          fetchGitInfo(project.cwd).then((g) => setGitBranch(g.branch)).catch(() => {});
+        })
+        .catch(() => {});
+    });
   }, [chat]);
 
   const handleSend = useCallback(
@@ -143,6 +165,11 @@ export default function App() {
     fetchConfig()
       .then((cfg) => {
         setActiveModel(cfg.llm.model ?? '');
+        setLlmMeta({
+          apiKeySet: !!cfg.llm.apiKeySet,
+          keySource: cfg.llm.keySource,
+          apiKeyEnv: cfg.llm.apiKeyEnv,
+        });
         setSettings((s) => ({ ...s, provider: cfg.llm.provider }));
       })
       .catch(() => {});
@@ -221,7 +248,14 @@ export default function App() {
             )}
           </div>
           <div className="flex items-center gap-2 flex-shrink-0">
-            <SettingsPanel settings={settings} onChange={setSettings} />
+            <SettingsPanel
+              onOpenLLMConfig={() => setShowLLMConfig(true)}
+              activeProvider={settings.provider}
+              activeModel={activeModel}
+              apiKeySet={llmMeta.apiKeySet}
+              keySource={llmMeta.keySource}
+              apiKeyEnv={llmMeta.apiKeyEnv}
+            />
           </div>
         </div>
 

--- a/web/src/components/ApprovalDialog.tsx
+++ b/web/src/components/ApprovalDialog.tsx
@@ -38,6 +38,27 @@ function ApprovalContent({ toolName, input }: { toolName: string; input: unknown
 
   const obj = input as Record<string, unknown>;
 
+  /* shell_sandbox_bypass — explicit unrestricted network approval */
+  if (toolName === 'shell_sandbox_bypass') {
+    const command = typeof obj.command === 'string' ? obj.command : '';
+    const args = Array.isArray(obj.args) ? (obj.args as string[]).join(' ') : '';
+    const full = args ? `${command} ${args}` : command;
+    const reason = typeof obj.reason === 'string' ? obj.reason : 'This command requested unrestricted outbound network access.';
+    return (
+      <div className="bg-bg">
+        <div className="px-4 py-2 border-b border-border text-[11px] text-red-300/80">
+          This will run outside the local subprocess network sandbox. Organization policy still applies.
+        </div>
+        <pre className="px-4 py-3 text-xs font-mono text-orange-200 overflow-x-auto whitespace-pre-wrap break-all">
+          {full}
+        </pre>
+        <div className="px-4 pb-3 text-xs text-muted-fg">
+          {reason}
+        </div>
+      </div>
+    );
+  }
+
   /* edit_file — show unified diff */
   if (toolName === 'edit_file') {
     const filePath = typeof obj.filePath === 'string' ? obj.filePath : undefined;
@@ -109,6 +130,7 @@ function ApprovalContent({ toolName, input }: { toolName: string; input: unknown
 /* ── Main dialog ─────────────────────────────────────────────────── */
 const TOOL_META: Record<string, { icon: string; label: string; bg: string; badge: string; badgeStyle: string }> = {
   shell:       { icon: '⚡', label: 'shell',       bg: 'bg-orange-500/5', badge: 'execute',   badgeStyle: 'text-orange-400 bg-orange-500/10 border-orange-500/20' },
+  shell_sandbox_bypass: { icon: '⚡', label: 'unrestricted network', bg: 'bg-red-500/5', badge: 'sandbox bypass', badgeStyle: 'text-red-300 bg-red-500/10 border-red-500/20' },
   write_file:  { icon: '📝', label: 'write_file',  bg: 'bg-yellow-500/5', badge: 'write',     badgeStyle: 'text-yellow-400 bg-yellow-500/10 border-yellow-500/20' },
   edit_file:   { icon: '✏️',  label: 'edit_file',  bg: 'bg-blue-500/5',   badge: 'edit',      badgeStyle: 'text-blue-400 bg-blue-500/10 border-blue-500/20' },
   delete_file: { icon: '🗑️', label: 'delete_file', bg: 'bg-red-500/5',    badge: 'delete',    badgeStyle: 'text-red-400 bg-red-500/10 border-red-500/20' },
@@ -121,6 +143,7 @@ export function ApprovalDialog({ approval, onRespond }: Props) {
   };
 
   const isDelete = approval.toolName === 'delete_file';
+  const isSandboxBypass = approval.toolName === 'shell_sandbox_bypass';
 
   return (
     <div className="fixed inset-0 z-50 flex items-end justify-center pb-24 px-4 pointer-events-none">
@@ -159,6 +182,7 @@ export function ApprovalDialog({ approval, onRespond }: Props) {
           >
             <Check size={12} />
             {isDelete ? 'Delete' : 'Allow'}
+            {isSandboxBypass ? ' unrestricted' : ''}
           </button>
         </div>
       </div>

--- a/web/src/components/LLMConfigModal.tsx
+++ b/web/src/components/LLMConfigModal.tsx
@@ -6,10 +6,9 @@ import {
 } from 'lucide-react';
 import {
   fetchConfig, saveConfig, fetchProfiles, saveProfile, deleteProfile, applyProfile,
-  fetchPool, savePool,
+  fetchPool, savePool, testProviderConfig,
 } from '../lib/client.ts';
-import type { LLMConfig, ProviderPoolConfig, PoolEntry, RotationPolicy } from '../types.ts';
-import type { Profile } from '../lib/client.ts';
+import type { LLMConfig, ProviderKeySource, ProviderPoolConfig, PoolEntry, Profile, RotationPolicy } from '../types.ts';
 import { PROVIDERS } from '../lib/providers.ts';
 import type { ModelPreset } from '../lib/providers.ts';
 
@@ -31,6 +30,7 @@ const PROVIDER_COLORS: Record<string, string> = {
   moonshot:             'from-sky-600 to-blue-500',
   zhipu:                'from-emerald-700 to-green-500',
   ollama:               'from-slate-600 to-slate-500',
+  'cc-switch':          'from-amber-600 to-lime-500',
   custom:               'from-zinc-600 to-zinc-500',
 };
 
@@ -40,7 +40,7 @@ function ProviderIcon({ id, size = 'md' }: { id: string; size?: 'sm' | 'md' }) {
   const provider = PROVIDERS.find((p) => p.id === id);
   const initials = provider ? provider.name.slice(0, 2).toUpperCase() : id.slice(0, 2).toUpperCase();
   return (
-    <div className={`${cls} rounded-lg bg-gradient-to-br ${gradient} flex items-center justify-center font-bold text-white flex-shrink-0`}>
+    <div aria-hidden="true" className={`${cls} rounded-lg bg-gradient-to-br ${gradient} flex items-center justify-center font-bold text-white flex-shrink-0`}>
       {initials}
     </div>
   );
@@ -70,6 +70,54 @@ function ModelCard({ preset, selected, onClick }: { preset: ModelPreset; selecte
   );
 }
 
+const MASKED_KEY = '••••••••';
+
+const KEY_SOURCE_OPTIONS: Array<{ value: ProviderKeySource; label: string; description: string }> = [
+  { value: 'stored', label: 'Stored key', description: 'Stored locally under ~/.dvalincode and protected by OS account permissions.' },
+  { value: 'env', label: 'Environment', description: 'Read the key from an environment variable at runtime.' },
+  { value: 'gateway', label: 'Gateway', description: 'CC-Switch or another OpenAI-compatible gateway manages keys.' },
+];
+
+function defaultKeySource(needsKey?: boolean): ProviderKeySource {
+  return needsKey === false ? 'gateway' : 'stored';
+}
+
+function defaultEnvName(providerId: string): string {
+  const prefix = providerId.replace(/[^a-z0-9]+/gi, '_').replace(/^_|_$/g, '').toUpperCase();
+  return `${prefix || 'LLM'}_API_KEY`;
+}
+
+function CredentialModeSelector({
+  value,
+  onChange,
+  compact = false,
+}: {
+  value: ProviderKeySource;
+  onChange: (next: ProviderKeySource) => void;
+  compact?: boolean;
+}) {
+  return (
+    <div className={`grid ${compact ? 'grid-cols-3 gap-1' : 'grid-cols-3 gap-1.5'} bg-bg border border-border rounded-xl p-1`}>
+      {KEY_SOURCE_OPTIONS.map((option) => {
+        const active = value === option.value;
+        return (
+          <button
+            key={option.value}
+            type="button"
+            onClick={() => onChange(option.value)}
+            title={option.description}
+            className={`${compact ? 'px-1.5 py-1 text-[10px]' : 'px-2 py-1.5 text-xs'} rounded-lg transition-colors ${
+              active ? 'bg-accent/90 text-white' : 'text-muted-fg hover:text-fg hover:bg-surface-2'
+            }`}
+          >
+            {option.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
 // ── Pool entry row ────────────────────────────────────────────────────────────
 
 function PoolEntryRow({
@@ -83,6 +131,7 @@ function PoolEntryRow({
 }) {
   const [showKey, setShowKey] = useState(false);
   const provider = PROVIDERS.find(p => p.id === entry.provider);
+  const keySource = entry.keySource ?? defaultKeySource(provider?.needsKey);
 
   return (
     <div className={`flex items-start gap-3 rounded-xl border p-3 transition-colors ${
@@ -97,7 +146,15 @@ function PoolEntryRow({
             value={entry.provider}
             onChange={e => {
               const p = PROVIDERS.find(pr => pr.id === e.target.value)!;
-              onChange({ ...entry, provider: e.target.value, baseUrl: p.baseUrl, model: p.models[0]?.model ?? '', apiKey: '' });
+              onChange({
+                ...entry,
+                provider: e.target.value,
+                baseUrl: p.baseUrl,
+                model: p.models[0]?.model ?? '',
+                apiKey: '',
+                apiKeyEnv: undefined,
+                keySource: defaultKeySource(p.needsKey),
+              });
             }}
             className="flex-1 bg-transparent text-xs text-fg outline-none cursor-pointer"
           >
@@ -127,18 +184,46 @@ function PoolEntryRow({
           />
         </div>
 
-        <div className="flex items-center gap-2 bg-bg border border-border rounded-lg px-2.5 py-1.5 focus-within:border-accent/30 transition-colors">
+        <CredentialModeSelector
+          value={keySource}
+          compact
+          onChange={(next) => onChange({
+            ...entry,
+            keySource: next,
+            apiKey: next === 'stored' ? entry.apiKey : undefined,
+            apiKeyEnv: next === 'env' ? entry.apiKeyEnv || defaultEnvName(entry.provider) : undefined,
+          })}
+        />
+
+        {keySource === 'stored' && (
+          <div className="flex items-center gap-2 bg-bg border border-border rounded-lg px-2.5 py-1.5 focus-within:border-accent/30 transition-colors">
+            <input
+              type={showKey ? 'text' : 'password'}
+              value={entry.apiKey ?? ''}
+              onChange={e => onChange({ ...entry, apiKey: e.target.value, keySource: 'stored' })}
+              placeholder={provider?.keyPlaceholder ?? 'api-key'}
+              className="flex-1 bg-transparent text-xs text-fg placeholder-muted-fg font-mono outline-none"
+            />
+            <button type="button" onClick={() => setShowKey(v => !v)} className="text-muted-fg hover:text-fg">
+              {showKey ? <EyeOff size={11} /> : <Eye size={11} />}
+            </button>
+          </div>
+        )}
+
+        {keySource === 'env' && (
           <input
-            type={showKey ? 'text' : 'password'}
-            value={entry.apiKey ?? ''}
-            onChange={e => onChange({ ...entry, apiKey: e.target.value })}
-            placeholder={provider?.keyPlaceholder ?? 'api-key'}
-            className="flex-1 bg-transparent text-xs text-fg placeholder-muted-fg font-mono outline-none"
+            value={entry.apiKeyEnv ?? ''}
+            onChange={e => onChange({ ...entry, apiKeyEnv: e.target.value, apiKey: undefined, keySource: 'env' })}
+            placeholder={defaultEnvName(entry.provider)}
+            className="bg-bg border border-border rounded-lg px-2.5 py-1.5 text-xs text-fg placeholder-muted-fg outline-none focus:border-accent/30 font-mono"
           />
-          <button type="button" onClick={() => setShowKey(v => !v)} className="text-muted-fg hover:text-fg">
-            {showKey ? <EyeOff size={11} /> : <Eye size={11} />}
-          </button>
-        </div>
+        )}
+
+        {keySource === 'gateway' && (
+          <p className="text-[11px] text-muted-fg/75 bg-bg border border-border rounded-lg px-2.5 py-1.5">
+            Credentials are supplied by the gateway at <span className="font-mono">{entry.baseUrl || provider?.baseUrl || 'base URL'}</span>.
+          </p>
+        )}
       </div>
 
       <div className="flex flex-col items-center gap-2 flex-shrink-0 pt-0.5">
@@ -166,12 +251,14 @@ export function LLMConfigModal({ onClose }: Props) {
   const [tab, setTab] = useState<Tab>('single');
 
   // ── Single provider state ──
-  const [draft, setDraft] = useState<LLMConfig>({ provider: 'deepseek', apiKey: '', baseUrl: '', model: '' });
+  const [draft, setDraft] = useState<LLMConfig>({ provider: 'deepseek', apiKey: '', keySource: 'stored', baseUrl: '', model: '' });
   const [showKey, setShowKey] = useState(false);
   const [saving, setSaving] = useState(false);
   const [saved, setSaved] = useState(false);
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(true);
+  const [testing, setTesting] = useState(false);
+  const [testResult, setTestResult] = useState<{ ok: boolean; message: string } | null>(null);
 
   // ── Profiles state ──
   const [profiles, setProfiles] = useState<Record<string, Profile>>({});
@@ -185,6 +272,7 @@ export function LLMConfigModal({ onClose }: Props) {
   const [poolError, setPoolError] = useState('');
 
   const activeProvider = PROVIDERS.find((p) => p.id === draft.provider) ?? PROVIDERS[PROVIDERS.length - 1];
+  const activeKeySource = draft.keySource ?? defaultKeySource(activeProvider.needsKey);
 
   useEffect(() => {
     Promise.all([fetchConfig(), fetchProfiles(), fetchPool()])
@@ -192,7 +280,9 @@ export function LLMConfigModal({ onClose }: Props) {
         const ap = PROVIDERS.find(p => p.id === cfg.llm.provider) ?? PROVIDERS[PROVIDERS.length - 1];
         setDraft({
           provider: cfg.llm.provider,
-          apiKey: cfg.llm.apiKeySet ? '••••••••' : '',
+          apiKey: cfg.llm.apiKeySet ? MASKED_KEY : '',
+          keySource: cfg.llm.keySource ?? defaultKeySource(ap.needsKey),
+          apiKeyEnv: cfg.llm.apiKeyEnv,
           baseUrl: cfg.llm.baseUrl ?? ap.baseUrl,
           model: cfg.llm.model ?? ap.models[0]?.model ?? '',
         });
@@ -206,7 +296,16 @@ export function LLMConfigModal({ onClose }: Props) {
 
   const selectProvider = (id: string) => {
     const p = PROVIDERS.find((pr) => pr.id === id)!;
-    setDraft((d) => ({ ...d, provider: id, baseUrl: p.baseUrl, model: p.models[0]?.model ?? '' }));
+    setTestResult(null);
+    setDraft((d) => ({
+      ...d,
+      provider: id,
+      baseUrl: p.baseUrl,
+      model: p.models[0]?.model ?? '',
+      apiKey: '',
+      apiKeyEnv: undefined,
+      keySource: defaultKeySource(p.needsKey),
+    }));
   };
 
   const handleSaveProfile = async () => {
@@ -216,7 +315,9 @@ export function LLMConfigModal({ onClose }: Props) {
     try {
       const profile: Profile = {
         provider: draft.provider,
-        apiKey: draft.apiKey?.startsWith('••') ? undefined : draft.apiKey || undefined,
+        apiKey: draft.keySource === 'stored' ? draft.apiKey || undefined : undefined,
+        keySource: draft.keySource,
+        apiKeyEnv: draft.keySource === 'env' ? draft.apiKeyEnv || undefined : undefined,
         baseUrl: draft.baseUrl || undefined,
         model: draft.model || undefined,
       };
@@ -231,7 +332,16 @@ export function LLMConfigModal({ onClose }: Props) {
       await applyProfile(name);
       const p = profiles[name];
       if (!p) return;
-      setDraft({ provider: p.provider, apiKey: p.apiKey ?? '', baseUrl: p.baseUrl ?? '', model: p.model ?? '' });
+      const provider = PROVIDERS.find(pr => pr.id === p.provider);
+      setDraft({
+        provider: p.provider,
+        apiKey: p.apiKey ?? '',
+        keySource: p.keySource ?? defaultKeySource(provider?.needsKey),
+        apiKeyEnv: p.apiKeyEnv,
+        baseUrl: p.baseUrl ?? provider?.baseUrl ?? '',
+        model: p.model ?? provider?.models[0]?.model ?? '',
+      });
+      setTestResult(null);
     } catch { /* ignore */ }
   };
 
@@ -254,6 +364,25 @@ export function LLMConfigModal({ onClose }: Props) {
     } finally { setSaving(false); }
   };
 
+  const handleTest = async () => {
+    if (!(draft.model ?? '').trim()) {
+      setTestResult({ ok: false, message: 'Model name is required before testing.' });
+      return;
+    }
+    setTesting(true);
+    setTestResult(null);
+    try {
+      const result = await testProviderConfig(draft);
+      setTestResult(result.ok
+        ? { ok: true, message: `Connected to ${result.provider ?? draft.provider} · ${result.model ?? draft.model} in ${result.latencyMs ?? 0} ms.` }
+        : { ok: false, message: result.error ?? 'Connection test failed.' });
+    } catch (err) {
+      setTestResult({ ok: false, message: err instanceof Error ? err.message : String(err) });
+    } finally {
+      setTesting(false);
+    }
+  };
+
   const addPoolEntry = () => {
     const first = PROVIDERS[0];
     const newEntry: PoolEntry = {
@@ -264,6 +393,7 @@ export function LLMConfigModal({ onClose }: Props) {
       apiKey: '',
       weight: 1,
       enabled: true,
+      keySource: defaultKeySource(first.needsKey),
     };
     setPool(p => ({ ...p, entries: [...p.entries, newEntry] }));
   };
@@ -354,35 +484,82 @@ export function LLMConfigModal({ onClose }: Props) {
 
               <section className="flex flex-col gap-3">
                 <h3 className="text-xs font-semibold text-muted-fg uppercase tracking-wider">Credentials</h3>
-                <label className="flex flex-col gap-1.5">
-                  <span className="text-xs text-muted-fg">
-                    API Key
-                    {!activeProvider.needsKey && (
-                      <span className="ml-2 text-emerald-500/80">(not required for {activeProvider.name})</span>
-                    )}
-                  </span>
-                  <div className="flex items-center gap-2 bg-bg border border-border rounded-xl px-3 py-2.5 focus-within:border-accent/40 transition-colors">
+                <CredentialModeSelector
+                  value={activeKeySource}
+                  onChange={(next) => {
+                    setTestResult(null);
+                    setDraft((d) => ({
+                      ...d,
+                      keySource: next,
+                      apiKey: next === 'stored' ? d.apiKey : undefined,
+                      apiKeyEnv: next === 'env' ? d.apiKeyEnv || defaultEnvName(d.provider) : undefined,
+                    }));
+                  }}
+                />
+
+                {activeKeySource === 'stored' && (
+                  <label className="flex flex-col gap-1.5">
+                    <span className="text-xs text-muted-fg">
+                      API Key
+                      {!activeProvider.needsKey && (
+                        <span className="ml-2 text-emerald-500/80">(optional for {activeProvider.name})</span>
+                      )}
+                    </span>
+                    <div className="flex items-center gap-2 bg-bg border border-border rounded-xl px-3 py-2.5 focus-within:border-accent/40 transition-colors">
+                      <input
+                        type={showKey ? 'text' : 'password'}
+                        value={draft.apiKey ?? ''}
+                        onChange={(e) => {
+                          setTestResult(null);
+                          setDraft((d) => ({ ...d, apiKey: e.target.value, keySource: 'stored' }));
+                        }}
+                        placeholder={activeProvider.keyPlaceholder}
+                        className="flex-1 bg-transparent outline-none text-sm text-fg placeholder-muted-fg font-mono"
+                      />
+                      <button type="button" onClick={() => setShowKey((v) => !v)} className="text-muted-fg hover:text-fg transition-colors flex-shrink-0">
+                        {showKey ? <EyeOff size={14} /> : <Eye size={14} />}
+                      </button>
+                    </div>
+                  </label>
+                )}
+
+                {activeKeySource === 'env' && (
+                  <label className="flex flex-col gap-1.5">
+                    <span className="text-xs text-muted-fg">Environment variable</span>
                     <input
-                      type={showKey ? 'text' : 'password'}
-                      value={draft.apiKey ?? ''}
-                      onChange={(e) => setDraft((d) => ({ ...d, apiKey: e.target.value }))}
-                      placeholder={activeProvider.keyPlaceholder}
-                      className="flex-1 bg-transparent outline-none text-sm text-fg placeholder-muted-fg font-mono"
+                      value={draft.apiKeyEnv ?? ''}
+                      onChange={(e) => {
+                        setTestResult(null);
+                        setDraft((d) => ({ ...d, apiKeyEnv: e.target.value, apiKey: undefined, keySource: 'env' }));
+                      }}
+                      placeholder={defaultEnvName(draft.provider)}
+                      className="bg-bg border border-border rounded-xl px-3 py-2.5 text-sm text-fg placeholder-muted-fg outline-none focus:border-accent/40 transition-colors font-mono"
                     />
-                    <button type="button" onClick={() => setShowKey((v) => !v)} className="text-muted-fg hover:text-fg transition-colors flex-shrink-0">
-                      {showKey ? <EyeOff size={14} /> : <Eye size={14} />}
-                    </button>
+                  </label>
+                )}
+
+                {activeKeySource === 'gateway' && (
+                  <div className="flex items-start gap-2 text-xs text-muted-fg bg-elevated border border-border rounded-xl px-3 py-2.5">
+                    <ChevronRight size={12} className="mt-0.5 flex-shrink-0" />
+                    <span>Use this for CC-Switch, LiteLLM, one-api, or an internal OpenAI-compatible gateway. DvalinCode will not store an API key for this provider.</span>
                   </div>
-                </label>
+                )}
+
                 <label className="flex flex-col gap-1.5">
                   <span className="text-xs text-muted-fg">Base URL</span>
                   <input
                     value={draft.baseUrl ?? ''}
-                    onChange={(e) => setDraft((d) => ({ ...d, baseUrl: e.target.value }))}
+                    onChange={(e) => {
+                      setTestResult(null);
+                      setDraft((d) => ({ ...d, baseUrl: e.target.value }));
+                    }}
                     placeholder={activeProvider.baseUrl || 'https://your-endpoint/v1'}
                     className="bg-bg border border-border rounded-xl px-3 py-2.5 text-sm text-fg placeholder-muted-fg outline-none focus:border-accent/40 transition-colors font-mono"
                   />
                 </label>
+                <p className="text-[11px] text-muted-fg/70">
+                  Stored keys remain local in <code>~/.dvalincode/config.json</code>; the browser only receives masked key status.
+                </p>
               </section>
 
               <section className="flex flex-col gap-3">
@@ -391,7 +568,10 @@ export function LLMConfigModal({ onClose }: Props) {
                   <span className="text-xs text-muted-fg">Model name</span>
                   <input
                     value={draft.model ?? ''}
-                    onChange={(e) => setDraft((d) => ({ ...d, model: e.target.value }))}
+                    onChange={(e) => {
+                      setTestResult(null);
+                      setDraft((d) => ({ ...d, model: e.target.value }));
+                    }}
                     placeholder={activeProvider.models[0]?.model ?? 'model-name'}
                     className="bg-bg border border-border rounded-xl px-3 py-2.5 text-sm text-fg placeholder-muted-fg outline-none focus:border-accent/40 transition-colors font-mono"
                   />
@@ -403,7 +583,10 @@ export function LLMConfigModal({ onClose }: Props) {
                         key={preset.model}
                         preset={preset}
                         selected={draft.model === preset.model}
-                        onClick={() => setDraft(d => ({ ...d, model: preset.model }))}
+                        onClick={() => {
+                          setTestResult(null);
+                          setDraft(d => ({ ...d, model: preset.model }));
+                        }}
                       />
                     ))}
                   </div>
@@ -431,7 +614,9 @@ export function LLMConfigModal({ onClose }: Props) {
                         <ProviderIcon id={p.provider} size="sm" />
                         <div className="flex-1 min-w-0">
                           <div className="text-xs font-semibold text-fg truncate">{name}</div>
-                          <div className="text-[11px] text-muted-fg font-mono truncate">{p.provider} · {p.model ?? '—'}</div>
+                          <div className="text-[11px] text-muted-fg font-mono truncate">
+                            {p.provider} · {p.model ?? '—'} · {p.keySource ?? 'stored'}
+                          </div>
                         </div>
                         <button onClick={() => void handleApplyProfile(name)} className="text-[11px] px-2 py-1 rounded border border-accent/30 text-accent hover:bg-accent/10 transition-colors">Apply</button>
                         <button onClick={() => void handleDeleteProfile(name)} className="p-1 text-muted-fg hover:text-red-400 transition-colors"><Trash2 size={12} /></button>
@@ -453,7 +638,7 @@ export function LLMConfigModal({ onClose }: Props) {
                     className="flex items-center gap-1 px-3 py-1.5 text-xs rounded-lg border border-border-strong text-muted-fg hover:text-fg hover:border-accent/40 disabled:opacity-40 transition-colors"
                   >
                     {savingProfile ? <Loader size={11} className="animate-spin" /> : <Plus size={11} />}
-                    Save
+                    Save Profile
                   </button>
                 </div>
               </section>
@@ -534,12 +719,27 @@ export function LLMConfigModal({ onClose }: Props) {
             <>
               {error ? (
                 <div className="flex items-center gap-1.5 text-xs text-red-400 flex-1"><AlertTriangle size={12} />{error}</div>
+              ) : testResult ? (
+                <div className={`flex items-center gap-1.5 text-xs flex-1 min-w-0 ${
+                  testResult.ok ? 'text-emerald-400' : 'text-red-400'
+                }`}>
+                  {testResult.ok ? <Check size={12} /> : <AlertTriangle size={12} />}
+                  <span className="truncate">{testResult.message}</span>
+                </div>
               ) : (
                 <div className="flex items-center gap-2 text-xs text-muted-fg flex-1">
                   <ProviderIcon id={draft.provider} size="sm" />
                   <span className="font-mono truncate">{draft.model || '—'}</span>
                 </div>
               )}
+              <button
+                onClick={() => void handleTest()}
+                disabled={testing || saving}
+                className="px-4 py-2 text-sm border border-border-strong text-muted-fg hover:text-fg hover:border-accent/40 disabled:opacity-50 rounded-xl transition-colors flex items-center gap-2"
+              >
+                {testing ? <Loader size={13} className="animate-spin" /> : null}
+                Test
+              </button>
               <button onClick={onClose} className="px-4 py-2 text-sm text-muted-fg hover:text-fg transition-colors">Cancel</button>
               <button
                 onClick={() => void handleSave()}

--- a/web/src/components/SettingsPanel.tsx
+++ b/web/src/components/SettingsPanel.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
-import { X, Settings, Monitor, Sun, Moon, Download, Upload, BookOpen, Trash2 } from 'lucide-react';
-import type { ApprovalMode, SkillSummary } from '../types.ts';
+import { X, Settings, Monitor, Sun, Moon, Download, Upload, BookOpen, Trash2, KeyRound, Server, Terminal } from 'lucide-react';
+import type { ApprovalMode, ProviderKeySource, SkillSummary } from '../types.ts';
 import { getStoredTheme, setTheme, type Theme } from '../lib/theme.ts';
 import { deleteSkill, downloadDataExport, downloadSkill, fetchSkills, importDataBundle, importSkillBundle } from '../lib/client.ts';
 
@@ -218,9 +218,21 @@ export type ChatSettings = {
 };
 
 type Props = {
-  settings: ChatSettings;
-  onChange: (s: ChatSettings) => void;
+  onOpenLLMConfig: () => void;
+  activeProvider?: string;
+  activeModel?: string;
+  apiKeySet?: boolean;
+  keySource?: ProviderKeySource;
+  apiKeyEnv?: string;
 };
+
+type SettingsTab = 'general' | 'llm' | 'data';
+
+function keySourceSummary(source?: ProviderKeySource, apiKeySet?: boolean, apiKeyEnv?: string): string {
+  if (source === 'gateway') return 'Gateway managed';
+  if (source === 'env') return apiKeyEnv ? `Env: ${apiKeyEnv}` : 'Environment variable';
+  return apiKeySet ? 'Stored locally' : 'No key saved';
+}
 
 export function SettingsButton({ onClick }: { onClick: () => void }) {
   return (
@@ -234,19 +246,32 @@ export function SettingsButton({ onClick }: { onClick: () => void }) {
   );
 }
 
-export function SettingsPanel({ settings, onChange }: Props) {
+export function SettingsPanel({
+  onOpenLLMConfig,
+  activeProvider,
+  activeModel,
+  apiKeySet,
+  keySource,
+  apiKeyEnv,
+}: Props) {
   const [open, setOpen] = useState(false);
-  const [draft, setDraft] = useState(settings);
+  const [tab, setTab] = useState<SettingsTab>('general');
 
-  const save = () => {
-    onChange(draft);
+  const openProviderConfig = () => {
     setOpen(false);
+    onOpenLLMConfig();
   };
+
+  const tabs: Array<{ id: SettingsTab; label: string; icon: typeof Settings }> = [
+    { id: 'general', label: 'General', icon: Settings },
+    { id: 'llm', label: 'LLM Providers', icon: Server },
+    { id: 'data', label: 'Data & Skills', icon: BookOpen },
+  ];
 
   return (
     <>
       <button
-        onClick={() => { setDraft(settings); setOpen(true); }}
+        onClick={() => { setTab('general'); setOpen(true); }}
         className="p-1.5 rounded-lg hover:bg-surface-2 text-muted-fg hover:text-fg transition-colors"
         title="Settings"
       >
@@ -255,7 +280,7 @@ export function SettingsPanel({ settings, onChange }: Props) {
 
       {open && (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm">
-          <div className="bg-surface border border-border rounded-xl w-[28rem] shadow-2xl">
+          <div className="bg-surface border border-border rounded-xl w-[34rem] max-w-[calc(100vw-2rem)] shadow-2xl overflow-hidden">
             <div className="flex items-center justify-between px-5 py-4 border-b border-border">
               <h2 className="font-semibold text-fg">Settings</h2>
               <button onClick={() => setOpen(false)} className="text-muted-fg hover:text-fg">
@@ -263,35 +288,80 @@ export function SettingsPanel({ settings, onChange }: Props) {
               </button>
             </div>
 
-            <div className="px-5 py-4 flex flex-col gap-4">
-              <ThemeSwitcher />
+            <div className="flex border-b border-border px-5 pt-3 gap-1">
+              {tabs.map(({ id, label, icon: Icon }) => (
+                <button
+                  key={id}
+                  onClick={() => setTab(id)}
+                  className={`flex items-center gap-1.5 px-3 py-2 text-xs font-medium rounded-t-lg transition-colors ${
+                    tab === id ? 'text-fg border-b-2 border-accent -mb-px' : 'text-muted-fg hover:text-fg'
+                  }`}
+                >
+                  <Icon size={12} />
+                  {label}
+                </button>
+              ))}
+            </div>
 
-              <label className="flex flex-col gap-1.5">
-                <span className="text-xs text-muted-fg font-medium">Working directory (cwd)</span>
-                <input
-                  value={draft.cwd}
-                  onChange={(e) => setDraft({ ...draft, cwd: e.target.value })}
-                  className="bg-elevated border border-border rounded-lg px-3 py-2 text-sm text-fg outline-none focus:border-accent/40 font-mono"
-                  placeholder="/path/to/project"
-                />
-              </label>
+            <div className="px-5 py-4 flex flex-col gap-4 max-h-[70vh] overflow-y-auto">
+              {tab === 'general' && (
+                <>
+                  <ThemeSwitcher />
 
-              <label className="flex flex-col gap-1.5">
-                <span className="text-xs text-muted-fg font-medium">Provider</span>
-                <input
-                  value={draft.provider}
-                  onChange={(e) => setDraft({ ...draft, provider: e.target.value })}
-                  className="bg-elevated border border-border rounded-lg px-3 py-2 text-sm text-fg outline-none focus:border-accent/40"
-                  placeholder="deepseek"
-                />
-              </label>
+                  <p className="text-xs text-muted-fg/60 bg-elevated border border-border rounded px-2.5 py-2">
+                    Approval mode is controlled by the switcher in the top bar.
+                  </p>
+                </>
+              )}
 
-              <p className="text-xs text-muted-fg/60 bg-elevated border border-border rounded px-2.5 py-2">
-                Approval mode is controlled by the switcher in the top bar.
-              </p>
+              {tab === 'llm' && (
+                <div className="flex flex-col gap-4">
+                  <div className="rounded-lg border border-border bg-elevated px-3 py-3">
+                    <div className="flex items-start gap-3">
+                      <Server size={16} className="text-accent mt-0.5 flex-shrink-0" />
+                      <div className="flex-1 min-w-0">
+                        <div className="text-xs font-semibold text-fg">Active provider</div>
+                        <div className="text-sm text-fg font-mono truncate mt-0.5">
+                          {activeProvider || 'provider not set'} · {activeModel || 'model not set'}
+                        </div>
+                        <div className="flex items-center gap-1.5 text-[11px] text-muted-fg mt-1">
+                          <KeyRound size={11} />
+                          <span className="truncate">{keySourceSummary(keySource, apiKeySet, apiKeyEnv)}</span>
+                        </div>
+                      </div>
+                      <button
+                        onClick={openProviderConfig}
+                        className="px-3 py-1.5 text-xs rounded-lg bg-accent/90 hover:bg-accent text-white transition-colors"
+                      >
+                        Configure
+                      </button>
+                    </div>
+                  </div>
 
-              <DataSection />
-              <SkillsSection />
+                  <div className="rounded-lg border border-border bg-elevated px-3 py-3 flex flex-col gap-2">
+                    <div className="flex items-center gap-2 text-xs font-semibold text-fg">
+                      <Terminal size={13} className="text-accent" />
+                      CLI provider switching
+                    </div>
+                    <p className="text-xs text-muted-fg/75">
+                      The CLI reads the same saved provider config as the web app.
+                    </p>
+                    <code className="text-[11px] bg-bg border border-border rounded px-2 py-1.5 text-muted-fg overflow-x-auto">
+                      dvalincode provider set deepseek --env DEEPSEEK_API_KEY
+                    </code>
+                    <code className="text-[11px] bg-bg border border-border rounded px-2 py-1.5 text-muted-fg overflow-x-auto">
+                      dvalincode provider set cc-switch --base-url http://localhost:3456/v1 --gateway
+                    </code>
+                  </div>
+                </div>
+              )}
+
+              {tab === 'data' && (
+                <>
+                  <DataSection />
+                  <SkillsSection />
+                </>
+              )}
             </div>
 
             <div className="flex justify-end gap-2 px-5 py-4 border-t border-border">
@@ -299,13 +369,7 @@ export function SettingsPanel({ settings, onChange }: Props) {
                 onClick={() => setOpen(false)}
                 className="px-4 py-2 text-sm text-muted-fg hover:text-fg transition-colors"
               >
-                Cancel
-              </button>
-              <button
-                onClick={save}
-                className="px-4 py-2 text-sm bg-accent/90 hover:bg-accent text-white rounded-lg transition-colors"
-              >
-                Save
+                Close
               </button>
             </div>
           </div>

--- a/web/src/components/Sidebar.tsx
+++ b/web/src/components/Sidebar.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
-import { ChevronLeft, ChevronRight } from 'lucide-react';
-import { fetchSessions, deleteSession } from '../lib/client.ts';
+import { AlertTriangle, ChevronLeft, ChevronRight, Loader2, Trash2, X } from 'lucide-react';
+import { fetchSessions, deleteSession, deleteAllSessions } from '../lib/client.ts';
 import { ModeSwitcher } from './ModeSwitcher.tsx';
 import { SidebarChat } from './SidebarChat.tsx';
 import { SidebarCowork } from './SidebarCowork.tsx';
@@ -33,6 +33,8 @@ export function Sidebar({
 }: Props) {
   const [sessions, setSessions] = useState<SessionMeta[]>([]);
   const [collapsed, setCollapsed] = useState(false);
+  const [clearConfirm, setClearConfirm] = useState(false);
+  const [clearing, setClearing] = useState(false);
 
   const load = async () => {
     try {
@@ -51,6 +53,22 @@ export function Sidebar({
     await deleteSession(id);
     setSessions((prev) => prev.filter((s) => s.id !== id));
     if (id === currentSessionId) onNewChat();
+  };
+
+  const handleClearAll = async () => {
+    if (!clearConfirm) {
+      setClearConfirm(true);
+      return;
+    }
+    setClearing(true);
+    try {
+      await deleteAllSessions();
+      setSessions([]);
+      setClearConfirm(false);
+      onNewChat();
+    } finally {
+      setClearing(false);
+    }
   };
 
   /* ── Collapsed state ─────────────────────────────────────────── */
@@ -124,6 +142,45 @@ export function Sidebar({
           />
         )}
       </div>
+
+      {sessions.length > 0 && (
+        <div className="border-t border-border px-3 py-2 flex-shrink-0">
+          {clearConfirm ? (
+            <div className="rounded-lg border border-red-500/20 bg-red-500/10 px-2 py-2">
+              <div className="flex items-start gap-1.5 text-[11px] text-red-300">
+                <AlertTriangle size={12} className="mt-0.5 flex-shrink-0" />
+                <span className="flex-1">Clear all {sessions.length} sessions?</span>
+              </div>
+              <div className="mt-2 flex gap-1.5">
+                <button
+                  onClick={() => setClearConfirm(false)}
+                  disabled={clearing}
+                  className="flex-1 flex items-center justify-center gap-1 px-2 py-1.5 text-[11px] rounded-md border border-border text-muted-fg hover:text-fg hover:bg-surface-2 disabled:opacity-50"
+                >
+                  <X size={11} />
+                  Cancel
+                </button>
+                <button
+                  onClick={() => void handleClearAll()}
+                  disabled={clearing}
+                  className="flex-1 flex items-center justify-center gap-1 px-2 py-1.5 text-[11px] rounded-md border border-red-500/25 bg-red-500/10 text-red-300 hover:bg-red-500/15 disabled:opacity-50"
+                >
+                  {clearing ? <Loader2 size={11} className="animate-spin" /> : <Trash2 size={11} />}
+                  Clear
+                </button>
+              </div>
+            </div>
+          ) : (
+            <button
+              onClick={() => void handleClearAll()}
+              className="w-full flex items-center justify-center gap-1.5 px-3 py-2 text-xs rounded-lg border border-border text-muted-fg hover:text-red-300 hover:border-red-500/25 hover:bg-red-500/10 transition-colors"
+            >
+              <Trash2 size={12} />
+              Clear all sessions
+            </button>
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/web/src/components/SidebarCode.tsx
+++ b/web/src/components/SidebarCode.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import {
-  Plus, MessageSquare, Trash2, Zap, ChevronRight, X, Check, Download,
+  Plus, MessageSquare, Trash2, Zap, ChevronRight, X, Check, Download, FolderOpen,
 } from 'lucide-react';
 import type { SessionMeta } from '../types.ts';
 import { fetchPlaybook, savePlaybook, downloadSessionMarkdown } from '../lib/client.ts';
@@ -9,6 +9,7 @@ import { SecurityRemediation } from './SecurityRemediation.tsx';
 // ── Local-storage routines ────────────────────────────────────────────────────
 
 type Routine = { name: string; prompt: string };
+type ProjectGroup = { cwd: string; name: string; sessions: SessionMeta[]; updatedAt: string };
 
 const DEFAULT_ROUTINES: Routine[] = [
   { name: 'Run tests',   prompt: 'Run the test suite and report any failures with details.' },
@@ -45,6 +46,10 @@ function timeAgo(iso: string): string {
   const h = Math.floor(m / 60);
   if (h < 24) return `${h}h ago`;
   return `${Math.floor(h / 24)}d ago`;
+}
+
+function projectName(cwd: string): string {
+  return cwd.split(/[\\/]/).filter(Boolean).pop() ?? cwd;
 }
 
 function SessionRow({
@@ -164,6 +169,7 @@ export function SidebarCode({
   const [addingRoutine, setAddingRoutine] = useState(false);
   const [projectRoutines, setProjectRoutines] = useState<Routine[]>([]);
   const [exportToast, setExportToast] = useState(false);
+  const [expandedProjects, setExpandedProjects] = useState<Set<string>>(() => new Set());
 
   useEffect(() => {
     if (!cwd) { setProjectRoutines([]); return; }
@@ -185,6 +191,45 @@ export function SidebarCode({
   // My routines: exclude any whose name matches a project routine label
   const projectLabels = new Set(projectRoutines.map((r) => r.name));
   const myRoutines = routines.filter((r) => !projectLabels.has(r.name));
+  const projectGroups = Object.values(
+    sessions.reduce<Record<string, ProjectGroup>>((acc, session) => {
+      const existing = acc[session.cwd];
+      if (existing) {
+        existing.sessions.push(session);
+        if (new Date(session.updatedAt).getTime() > new Date(existing.updatedAt).getTime()) {
+          existing.updatedAt = session.updatedAt;
+        }
+      } else {
+        acc[session.cwd] = {
+          cwd: session.cwd,
+          name: projectName(session.cwd),
+          sessions: [session],
+          updatedAt: session.updatedAt,
+        };
+      }
+      return acc;
+    }, {}),
+  ).sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime());
+
+  const activeSession = sessions.find((session) => session.id === currentSessionId);
+
+  useEffect(() => {
+    const cwdToExpand = activeSession?.cwd ?? cwd ?? projectGroups[0]?.cwd;
+    if (!cwdToExpand) return;
+    setExpandedProjects((prev) => {
+      if (prev.has(cwdToExpand)) return prev;
+      return new Set([...prev, cwdToExpand]);
+    });
+  }, [activeSession?.cwd, cwd, projectGroups[0]?.cwd]);
+
+  const toggleProject = (projectCwd: string) => {
+    setExpandedProjects((prev) => {
+      const next = new Set(prev);
+      if (next.has(projectCwd)) next.delete(projectCwd);
+      else next.add(projectCwd);
+      return next;
+    });
+  };
 
   return (
     <>
@@ -303,15 +348,38 @@ export function SidebarCode({
         {sessions.length === 0 ? (
           <p className="text-xs text-muted-fg/50 px-3 py-3 text-center">No sessions yet</p>
         ) : (
-          <div className="flex flex-col gap-0.5">
-            {sessions.map((s) => (
-              <SessionRow
-                key={s.id}
-                session={s}
-                active={s.id === currentSessionId}
-                onSelect={() => onSelectSession(s.id)}
-                onDelete={(e) => onDeleteSession(e, s.id)}
-              />
+          <div className="flex flex-col gap-1">
+            {projectGroups.map((project) => (
+              <div key={project.cwd} className="rounded-lg">
+                <button
+                  onClick={() => toggleProject(project.cwd)}
+                  title={project.cwd}
+                  className="w-full flex items-center gap-2 px-2 py-1.5 rounded-lg text-xs text-muted-fg hover:text-fg hover:bg-surface-2 transition-colors"
+                >
+                  <FolderOpen size={12} className="text-orange-400/70 flex-shrink-0" />
+                  <span className="flex-1 font-medium truncate text-left">{project.name}</span>
+                  <span className="text-[10px] opacity-55 flex-shrink-0">{project.sessions.length}</span>
+                  <ChevronRight
+                    size={11}
+                    className={`opacity-40 flex-shrink-0 transition-transform ${
+                      expandedProjects.has(project.cwd) ? 'rotate-90' : ''
+                    }`}
+                  />
+                </button>
+                {expandedProjects.has(project.cwd) && (
+                  <div className="ml-2 flex flex-col gap-0.5">
+                    {project.sessions.map((s) => (
+                      <SessionRow
+                        key={s.id}
+                        session={s}
+                        active={s.id === currentSessionId}
+                        onSelect={() => onSelectSession(s.id)}
+                        onDelete={(e) => onDeleteSession(e, s.id)}
+                      />
+                    ))}
+                  </div>
+                )}
+              </div>
             ))}
           </div>
         )}

--- a/web/src/components/WorkspaceControls.tsx
+++ b/web/src/components/WorkspaceControls.tsx
@@ -7,8 +7,11 @@ type Props = {
   onCwdChange: (cwd: string) => void;
 };
 
+type WorkspaceAction = 'menu' | 'clone' | 'worktree';
+
 export function WorkspaceControls({ cwd, onCwdChange }: Props) {
   const [open, setOpen] = useState(false);
+  const [action, setAction] = useState<WorkspaceAction>('menu');
   const ref = useRef<HTMLDivElement>(null);
 
   const [gitUrl, setGitUrl] = useState('');
@@ -36,6 +39,7 @@ export function WorkspaceControls({ cwd, onCwdChange }: Props) {
       const result = await action();
       onCwdChange(result.cwd);
       setOpen(false);
+      setAction('menu');
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));
     } finally {
@@ -44,14 +48,21 @@ export function WorkspaceControls({ cwd, onCwdChange }: Props) {
   };
 
   const folderName = cwd ? cwd.split(/[\\/]/).pop() : undefined;
+  const defaultWorktreePath = cwd && branch.trim()
+    ? `${cwd}-${branch.trim().replace(/[^a-zA-Z0-9._-]+/g, '-')}`
+    : '';
 
-  const inputClass = 'w-full bg-elevated border border-border rounded-lg px-2.5 py-1.5 text-xs text-fg placeholder-muted-fg outline-none focus:border-accent/40';
-  const buttonClass = 'w-full flex items-center justify-center gap-1.5 py-1.5 text-xs rounded-lg border transition-colors disabled:opacity-45 bg-accent/10 hover:bg-accent/15 border-accent/25 text-accent';
+  const inputClass = 'w-full bg-elevated border border-border rounded-lg px-2.5 py-2 text-xs text-fg placeholder-muted-fg outline-none focus:border-accent/40';
+  const buttonClass = 'w-full flex items-center justify-center gap-1.5 py-2 text-xs rounded-lg border transition-colors disabled:opacity-45 bg-accent/10 hover:bg-accent/15 border-accent/25 text-accent';
+  const actionClass = 'w-full flex items-center gap-2.5 px-3 py-2.5 text-left rounded-lg border border-border bg-elevated text-fg hover:bg-surface-2 hover:border-accent/30 transition-colors disabled:opacity-45 disabled:hover:bg-elevated disabled:hover:border-border';
 
   return (
     <div ref={ref} className="relative flex-shrink-0">
       <button
-        onClick={() => setOpen((v) => !v)}
+        onClick={() => {
+          setOpen((v) => !v);
+          setAction('menu');
+        }}
         title={cwd ?? 'Set workspace'}
         className="flex items-center gap-1.5 text-[11px] text-muted-fg hover:text-fg transition-colors group"
       >
@@ -61,77 +72,141 @@ export function WorkspaceControls({ cwd, onCwdChange }: Props) {
       </button>
 
       {open && (
-        <div className="absolute bottom-full left-0 mb-1 w-64 bg-surface border border-border rounded-xl shadow-2xl z-50 overflow-hidden">
+        <div className="absolute bottom-full left-0 mb-1 w-72 bg-surface border border-border rounded-xl shadow-2xl z-50 overflow-hidden">
           <div className="px-3 py-1.5 border-b border-border flex items-center justify-between text-[11px] text-muted-fg">
-            <span>Workspace</span>
+            {action === 'menu' ? (
+              <span>Project</span>
+            ) : (
+              <button
+                onClick={() => { setAction('menu'); setError(''); }}
+                className="hover:text-fg transition-colors"
+              >
+                ← Project
+              </button>
+            )}
             {folderName && <span className="truncate max-w-[120px] opacity-60">{folderName}</span>}
           </div>
 
-          <div className="p-3 flex flex-col gap-1.5">
-            <button
-              onClick={() => void run('open', () => openProjectFolder())}
-              disabled={busy !== null}
-              className={buttonClass}
-              title="Open local folder"
-            >
-              {busy === 'open' ? <Loader2 size={11} className="animate-spin" /> : <FolderOpen size={11} />}
-              Open folder
-            </button>
+          <div className="p-3 flex flex-col gap-2">
+            {action === 'menu' && (
+              <>
+                <button
+                  onClick={() => void run('open', () => openProjectFolder())}
+                  disabled={busy !== null}
+                  className={actionClass}
+                  title="Open local folder"
+                >
+                  {busy === 'open' ? <Loader2 size={13} className="animate-spin text-accent" /> : <FolderOpen size={13} className="text-accent flex-shrink-0" />}
+                  <span className="flex-1 min-w-0">
+                    <span className="block text-xs font-medium">Open folder</span>
+                    <span className="block text-[10px] text-muted-fg truncate">Use a local project</span>
+                  </span>
+                  <ChevronDown size={10} className="-rotate-90 opacity-40" />
+                </button>
 
-            <input
-              value={gitUrl}
-              onChange={(e) => setGitUrl(e.target.value)}
-              placeholder="Git URL"
-              className={inputClass}
-            />
-            <input
-              value={parentDir}
-              onChange={(e) => setParentDir(e.target.value)}
-              placeholder="Parent folder"
-              className={inputClass}
-            />
-            <button
-              onClick={() => void run('clone', () => cloneGitProject(gitUrl, parentDir || undefined))}
-              disabled={busy !== null || !gitUrl.trim()}
-              className={buttonClass}
-              title="Clone Git project"
-            >
-              {busy === 'clone' ? <Loader2 size={11} className="animate-spin" /> : <GitPullRequest size={11} />}
-              Import Git
-            </button>
+                <button
+                  onClick={() => { setAction('clone'); setError(''); }}
+                  disabled={busy !== null}
+                  className={actionClass}
+                  title="Import Git project"
+                >
+                  <GitPullRequest size={13} className="text-accent flex-shrink-0" />
+                  <span className="flex-1 min-w-0">
+                    <span className="block text-xs font-medium">Import Git</span>
+                    <span className="block text-[10px] text-muted-fg truncate">Clone into DvalinCode projects</span>
+                  </span>
+                  <ChevronDown size={10} className="-rotate-90 opacity-40" />
+                </button>
 
-            <div className="grid grid-cols-2 gap-1.5">
-              <input
-                value={branch}
-                onChange={(e) => setBranch(e.target.value)}
-                placeholder="Branch"
-                className={inputClass}
-              />
-              <label className="flex items-center gap-1.5 text-[10px] text-muted-fg bg-elevated border border-border rounded-lg px-2">
+                <button
+                  onClick={() => { setAction('worktree'); setError(''); }}
+                  disabled={busy !== null || !cwd}
+                  className={actionClass}
+                  title="Create Git worktree"
+                >
+                  <GitBranch size={13} className="text-accent flex-shrink-0" />
+                  <span className="flex-1 min-w-0">
+                    <span className="block text-xs font-medium">Add worktree</span>
+                    <span className="block text-[10px] text-muted-fg truncate">{cwd ? 'Create from current project' : 'Open a project first'}</span>
+                  </span>
+                  <ChevronDown size={10} className="-rotate-90 opacity-40" />
+                </button>
+              </>
+            )}
+
+            {action === 'clone' && (
+              <>
                 <input
-                  type="checkbox"
-                  checked={createBranch}
-                  onChange={(e) => setCreateBranch(e.target.checked)}
-                  className="accent-current"
+                  value={gitUrl}
+                  onChange={(e) => setGitUrl(e.target.value)}
+                  placeholder="Git repository URL"
+                  className={inputClass}
                 />
-                New
-              </label>
-            </div>
-            <input
-              value={worktreePath}
-              onChange={(e) => setWorktreePath(e.target.value)}
-              placeholder="Worktree path"
-              className={inputClass}
-            />
-            <button
-              onClick={() => void run('worktree', () => createGitWorktree(cwd ?? '', branch, worktreePath, createBranch))}
-              disabled={busy !== null || !cwd || !branch.trim() || !worktreePath.trim()}
-              className={buttonClass}
-              title="Create Git worktree"
-            >
-              {busy === 'worktree' ? <Loader2 size={11} className="animate-spin" /> : <GitBranch size={11} />}
-              Add worktree
-            </button>
+                <details className="group">
+                  <summary className="cursor-pointer list-none text-[11px] text-muted-fg hover:text-fg px-1 py-0.5">
+                    Destination folder
+                  </summary>
+                  <input
+                    value={parentDir}
+                    onChange={(e) => setParentDir(e.target.value)}
+                    placeholder="Default: ~/.dvalincode/projects"
+                    className={`${inputClass} mt-1`}
+                  />
+                </details>
+                <button
+                  onClick={() => void run('clone', () => cloneGitProject(gitUrl, parentDir || undefined))}
+                  disabled={busy !== null || !gitUrl.trim()}
+                  className={buttonClass}
+                  title="Clone Git project"
+                >
+                  {busy === 'clone' ? <Loader2 size={11} className="animate-spin" /> : <GitPullRequest size={11} />}
+                  Import Git
+                </button>
+              </>
+            )}
+
+            {action === 'worktree' && (
+              <>
+                <input
+                  value={branch}
+                  onChange={(e) => {
+                    setBranch(e.target.value);
+                    if (!worktreePath) {
+                      const next = cwd && e.target.value.trim()
+                        ? `${cwd}-${e.target.value.trim().replace(/[^a-zA-Z0-9._-]+/g, '-')}`
+                        : '';
+                      setWorktreePath(next);
+                    }
+                  }}
+                  placeholder="Branch name"
+                  className={inputClass}
+                />
+                <input
+                  value={worktreePath}
+                  onChange={(e) => setWorktreePath(e.target.value)}
+                  placeholder={defaultWorktreePath || 'Worktree path'}
+                  className={inputClass}
+                />
+                <label className="flex items-center gap-2 text-[11px] text-muted-fg bg-elevated border border-border rounded-lg px-2.5 py-2">
+                  <input
+                    type="checkbox"
+                    checked={createBranch}
+                    onChange={(e) => setCreateBranch(e.target.checked)}
+                    className="accent-current"
+                  />
+                  Create a new branch
+                </label>
+                <button
+                  onClick={() => void run('worktree', () => createGitWorktree(cwd ?? '', branch, worktreePath, createBranch))}
+                  disabled={busy !== null || !cwd || !branch.trim() || !worktreePath.trim()}
+                  className={buttonClass}
+                  title="Create Git worktree"
+                >
+                  {busy === 'worktree' ? <Loader2 size={11} className="animate-spin" /> : <GitBranch size={11} />}
+                  Add worktree
+                </button>
+              </>
+            )}
 
             {error && (
               <div className="px-2 py-1.5 rounded-lg bg-red-500/10 border border-red-500/20 text-[10px] text-red-300">

--- a/web/src/hooks/useChat.ts
+++ b/web/src/hooks/useChat.ts
@@ -316,9 +316,11 @@ export function useChat(opts: UseChatOptions = {}) {
       const uiMessages = mapBackendMessages(detail.messages);
       setMessages(uiMessages);
       setCurrentSessionId(id);
+      return detail;
     } catch {
       // Session load failed — just set the ID and start fresh
       setCurrentSessionId(id);
+      return undefined;
     }
   }, []);
 

--- a/web/src/lib/client.ts
+++ b/web/src/lib/client.ts
@@ -1,4 +1,4 @@
-import type { ServerEvent, SessionMeta, AppConfig, BackendChatMessage, ApprovalMode, AgentMode, ProviderPoolConfig, CodePermissionMode, SarifImportResult, RemediationFinding, RemediationWorktreeResult, RemediationCase, RemediationCaseStatus, SkillSummary } from '../types.ts';
+import type { ServerEvent, SessionMeta, AppConfig, BackendChatMessage, ApprovalMode, AgentMode, ProviderPoolConfig, CodePermissionMode, SarifImportResult, RemediationFinding, RemediationWorktreeResult, RemediationCase, RemediationCaseStatus, SkillSummary, LLMConfig, Profile } from '../types.ts';
 
 const WS_URL = `${location.protocol === 'https:' ? 'wss' : 'ws'}://${location.host}/ws`;
 
@@ -118,6 +118,13 @@ export async function deleteSession(id: string): Promise<void> {
   await fetch(`/api/sessions/${id}`, { method: 'DELETE' });
 }
 
+export async function deleteAllSessions(): Promise<number> {
+  const res = await fetch('/api/sessions', { method: 'DELETE' });
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  const data = (await res.json().catch(() => ({}))) as { deleted?: number };
+  return data.deleted ?? 0;
+}
+
 /** Trigger a browser download of a URL that sets Content-Disposition. */
 function triggerDownload(url: string): void {
   const a = document.createElement('a');
@@ -199,6 +206,27 @@ export async function saveConfig(config: AppConfig): Promise<AppConfig> {
   });
   if (!res.ok) throw new Error(`HTTP ${res.status}`);
   return res.json() as Promise<AppConfig>;
+}
+
+export type ProviderTestResult = {
+  ok: boolean;
+  provider?: string;
+  model?: string;
+  latencyMs?: number;
+  error?: string;
+};
+
+export async function testProviderConfig(llm: Partial<LLMConfig>): Promise<ProviderTestResult> {
+  const res = await fetch('/api/config/test', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ llm }),
+  });
+  const data = (await res.json().catch(() => ({}))) as ProviderTestResult;
+  if (!res.ok) {
+    return { ...data, ok: false, error: data.error ?? `HTTP ${res.status}` };
+  }
+  return data;
 }
 
 export type SessionDetail = {
@@ -305,13 +333,6 @@ export async function createRemediationWorktree(cwd: string, finding: Remediatio
 }
 
 // ── Profiles ─────────────────────────────────────────────────────────────────
-
-export type Profile = {
-  provider: string;
-  apiKey?: string;
-  baseUrl?: string;
-  model?: string;
-};
 
 export async function fetchProfiles(): Promise<Record<string, Profile>> {
   try {

--- a/web/src/lib/providers.ts
+++ b/web/src/lib/providers.ts
@@ -194,6 +194,18 @@ export const PROVIDERS: Provider[] = [
     ],
   },
   {
+    id: 'cc-switch',
+    name: 'CC-Switch',
+    baseUrl: 'http://localhost:3456/v1',
+    keyPlaceholder: 'managed by gateway',
+    needsKey: false,
+    models: [
+      { label: 'Gateway default', model: 'deepseek-chat', description: 'Routed by gateway' },
+      { label: 'Fast lane', model: 'gpt-4o-mini', description: 'Low-cost routing' },
+      { label: 'Reasoning lane', model: 'anthropic/claude-sonnet-4-6', description: 'Strong coding route' },
+    ],
+  },
+  {
     id: 'custom',
     name: 'Custom',
     baseUrl: '',

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -2,6 +2,19 @@ export type LLMConfig = {
   provider: string;
   apiKey?: string;
   apiKeySet?: boolean;
+  keySource?: ProviderKeySource;
+  apiKeyEnv?: string;
+  baseUrl?: string;
+  model?: string;
+};
+
+export type ProviderKeySource = 'stored' | 'env' | 'gateway';
+
+export type Profile = {
+  provider: string;
+  apiKey?: string;
+  keySource?: ProviderKeySource;
+  apiKeyEnv?: string;
   baseUrl?: string;
   model?: string;
 };
@@ -12,6 +25,8 @@ export type PoolEntry = {
   id: string;
   provider: string;
   apiKey?: string;
+  keySource?: ProviderKeySource;
+  apiKeyEnv?: string;
   baseUrl?: string;
   model?: string;
   weight: number;
@@ -26,6 +41,7 @@ export type ProviderPoolConfig = {
 
 export type AppConfig = {
   llm: LLMConfig;
+  profiles?: Record<string, Profile>;
   pool?: ProviderPoolConfig;
 };
 


### PR DESCRIPTION
## Summary
- add provider key-source management across GUI and CLI, including stored/env/gateway modes, CC-Switch-style gateway support, provider testing, and provider pool credential modes
- allow Code shell git network operations to request an explicit unrestricted-network approval, with Bypass Permissions opening available local execution permissions under policy
- simplify project/workspace controls, auto-register opened session roots, group Code sessions by project, add clear-all sessions, and bump release version to v0.12.0
- refine references wording for prior-art attribution

## Validation
- npm run check
- npm run web:build

## Release
- intended stable tag: v0.12.0
- intended GUI pre-release tag: gui-v0.12.0
