### PR TITLE
fix: align run_check subprocess sandbox with shell on macOS

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -23,7 +23,6 @@ Issues are the source of truth for status; this file is the map. Want one of the
 | **Read-only Explore subagent** | Parallel read-only exploration that inherits the parent policy and gets its own audit chain linked to the parent run. | [#54](https://github.com/arthurpanhku/dvalincode/issues/54) |
 | **Remediation worktree under the sandbox profile** | Close the documented exemption for the two local git calls (needs sandbox write access to the remediation dir first). | [#55](https://github.com/arthurpanhku/dvalincode/issues/55) |
 | **MCP discovery audit anchoring** | Tool *calls* are audited per run; anchor the pre-run discovery connection into the chain as well. | [#56](https://github.com/arthurpanhku/dvalincode/issues/56) |
-| **`run_check` / `shell` sandbox parity under `network: on`** | Remove the documented asymmetry, or make it a policy choice. | [#50](https://github.com/arthurpanhku/dvalincode/issues/50) |
 
 ## Later
 

--- a/docs/EGRESS-THREAT-MODEL.md
+++ b/docs/EGRESS-THREAT-MODEL.md
@@ -78,18 +78,10 @@ There is no advisory fallback for `off` or `endpoint-only`. If DvalinCode
 cannot establish the required isolation, it fails closed before launching the
 requested command.
 
-With `network: on`, current behavior is preserved. macOS continues to use its
-existing default Seatbelt wrapper when available; other platforms may run the
-child without a network sandbox.
-
-**`shell` vs `run_check` asymmetry under `network: on`.** `shell` preserves its
-legacy default of always wrapping in Seatbelt on macOS (network denied) even
-when policy is `on`; `run_check` does not opt into that default and therefore
-runs unsandboxed under `on`. This is deliberate — `shell` is the stricter of
-the two and the difference only narrows blast radius — but it means a trust
-report can show `shell: enforced` next to `run_check: unrestricted` at the same
-`network: on` level. Under `endpoint-only` or `off` both are isolated or fail
-closed identically.
+With `network: on`, macOS continues to wrap both `shell` and `run_check` in
+Seatbelt when available (network denied in the child even though policy permits
+egress). Other platforms may run the child without a network sandbox. Under
+`endpoint-only` or `off`, both tools are isolated or fail closed identically.
 
 ### Remediation subprocesses (v0.9.0)
 
@@ -160,7 +152,7 @@ best-effort defense in depth and must not be described as complete redaction.
 | Audit log for a provider call | Contains no prompt, response body, headers, API key, path, or query |
 | Audit log for a tool call | Contains no file content, replacement text, memory content, or shell arguments |
 | Policy resolution | Existing narrowing tests and canonical hash behavior remain unchanged |
-| Trust report | States the actual provider and shell enforcement status for this platform |
+| Trust report | States the actual provider, shell, and run_check enforcement status for this platform |
 | `run_security_scan` local scan | Runs fully in-process; performs no subprocess and no network I/O |
 | `prepare_remediation_worktree` | Runs only fixed-argv local git; writes only inside `~/.dvalincode/projects/remediations`; applies no fix |
 | Future remediation fix-execution step | Routed through `runGovernedProcess` and audited; a direct `execFile`/`spawn` is a release blocker |

--- a/docs/POLICY-REFERENCE.md
+++ b/docs/POLICY-REFERENCE.md
@@ -52,7 +52,7 @@ requests, MCP, and subprocess egress under restricted postures).
 |---|---|---|---|
 | **`off`** | Blocked | Blocked | Air-gapped or fully offline review |
 | **`endpoint-only`** | Allowed only to the configured model origin (redirects revalidated) | Blocked | Default enterprise posture — model calls OK, no arbitrary exfil |
-| **`on`** | Unrestricted | Unrestricted (subject to OS shell sandbox defaults on macOS) | Developer machines, trusted networks |
+| **`on`** | Unrestricted | Unrestricted (subject to OS subprocess sandbox defaults on macOS) | Developer machines, trusted networks |
 
 Under `endpoint-only` and `off`, shell and `run_check` subprocesses run inside an OS
 network sandbox when available (Seatbelt on macOS, Bubblewrap on Linux). See

--- a/src/core/subprocessSandbox.ts
+++ b/src/core/subprocessSandbox.ts
@@ -25,7 +25,7 @@ export type GovernedProcessOptions = {
   policy: ResolvedPolicy;
   audit?: AuditSink;
   toolName: string;
-  /** Preserve shell's existing default Seatbelt behavior when network is unrestricted. */
+  /** Use Seatbelt on macOS even when policy permits egress (shell and run_check default). */
   preferSandboxWhenUnrestricted?: boolean;
   /**
    * When org policy permits general egress (network:on), launch without the

--- a/src/core/trust.ts
+++ b/src/core/trust.ts
@@ -66,16 +66,11 @@ export function buildTrustReport(cwd: string = process.cwd()): TrustReport {
   const engine: 'bun' | 'node' = process.versions.bun ? 'bun' : 'node';
   const capabilities = detectSubprocessSandboxCapabilities();
   const requiresSubprocessIsolation = !checkEgress(loaded.policy, false).allowed;
-  const shellPlan = selectSubprocessSandbox(
+  const subprocessPlan = selectSubprocessSandbox(
     process.platform,
     requiresSubprocessIsolation,
     capabilities,
     true,
-  );
-  const runCheckPlan = selectSubprocessSandbox(
-    process.platform,
-    requiresSubprocessIsolation,
-    capabilities,
   );
   return {
     version: VERSION,
@@ -94,8 +89,8 @@ export function buildTrustReport(cwd: string = process.cwd()): TrustReport {
     audit: { dir: defaultAuditDir(), runCount: listRuns().length },
     networkEnforcement: {
       provider: providerEnforcement(loaded.policy.network),
-      shell: shellEnforcement(shellPlan),
-      runCheck: shellEnforcement(runCheckPlan),
+      shell: shellEnforcement(subprocessPlan),
+      runCheck: shellEnforcement(subprocessPlan),
     },
     mcp: mcpPosture(loaded.policy),
     dependencies: readOwnDependencies(),

--- a/src/tools/runCheck.ts
+++ b/src/tools/runCheck.ts
@@ -59,6 +59,7 @@ export const runCheckTool: Tool<Input> = {
       policy: context.policy,
       audit: context.audit,
       toolName: 'run_check',
+      preferSandboxWhenUnrestricted: true,
     });
     return {
       title: `run_check ${input.kind}`,

--- a/tests/core/trust.test.ts
+++ b/tests/core/trust.test.ts
@@ -24,7 +24,7 @@ describe('trust report', () => {
     expect(report.version).toBeTruthy();
     expect(report.runtime.platform).toBe(process.platform);
     expect(report.networkEnforcement.provider.status).toBe('unrestricted');
-    expect(report.networkEnforcement.runCheck.status).toBe('unrestricted');
+    expect(report.networkEnforcement.runCheck.status).toBe(report.networkEnforcement.shell.status);
 
     const text = renderTrustReport(report);
     expect(text).toContain('permissive');

--- a/tests/toolsExtras.test.ts
+++ b/tests/toolsExtras.test.ts
@@ -8,6 +8,7 @@ import { createDefaultToolRegistry } from '../src/tools/registry.js';
 import { projectScriptsTool } from '../src/tools/projectScripts.js';
 import { runCheckTool } from '../src/tools/runCheck.js';
 import { resolvePolicy } from '../src/core/policy.js';
+import { detectSubprocessSandboxCapabilities, selectSubprocessSandbox } from '../src/core/subprocessSandbox.js';
 
 let tmpDir: string;
 
@@ -60,7 +61,8 @@ describe('extra tools', () => {
     expect(result.output).toContain('check ok');
     expect(result.metadata?.exitCode).toBe(0);
     expect(result.metadata?.kind).toBe('custom');
-    expect(result.metadata?.sandbox).toBe('none');
+    const plan = selectSubprocessSandbox(process.platform, false, detectSubprocessSandboxCapabilities(), true);
+    expect(result.metadata?.sandbox).toBe(plan.sandbox);
   });
 
   it('enforces command policy inside run_check before spawning', async () => {


### PR DESCRIPTION
## Summary

- Align `run_check` with `shell` on macOS: both use `preferSandboxWhenUnrestricted` so subprocess sandbox behavior matches at the same network level
- Trust report now shows the same enforcement for `shell` and `run_check` (fixes the mismatch where one could show `enforced` and the other `unrestricted` under `network: on`)
- Updated egress threat model, policy reference, and tests to match

## Test plan

- [x] `npm run check`
- [x] `npm run dev -- trust` — `shell` and `run_check` both show `enforced` under `endpoint-only` on macOS

Closes #50