### PR TITLE
fix: make CLI exit and interrupt reliable

### DIFF
--- a/src/agent/runner.ts
+++ b/src/agent/runner.ts
@@ -129,10 +129,15 @@ export class AgentRunner {
 
       // Execute tool calls
       for (const tc of callsToExecute) {
+        if (signal?.aborted) throw new Error('interrupted');
         try {
           const parsedInput = JSON.parse(tc.arguments);
           onEvent?.({ type: 'tool_call', name: tc.name, id: tc.id, input: parsedInput });
-          const result = await this.registry.run(tc.name, parsedInput, this.context);
+          const result = await this.registry.run(
+            tc.name,
+            parsedInput,
+            signal ? { ...this.context, signal } : this.context,
+          );
 
           // Record undo entry for this tool call
           this.undoStack.push({
@@ -155,6 +160,7 @@ export class AgentRunner {
             name: tc.name,
           });
         } catch (err) {
+          if (signal?.aborted) throw err;
           const error = err instanceof Error ? err.message : String(err);
           onEvent?.({ type: 'tool_error', name: tc.name, id: tc.id, error });
           messages.push({

--- a/src/core/context.ts
+++ b/src/core/context.ts
@@ -14,6 +14,8 @@ export type DvalinContextOptions = {
   audit?: AuditSink;
   /** Resolved org policy. Defaults to permissive (identical to having no policy file). */
   policy?: ResolvedPolicy;
+  /** Optional cancellation signal for the active agent turn. */
+  signal?: AbortSignal;
 };
 
 export type DvalinContext = {
@@ -27,6 +29,8 @@ export type DvalinContext = {
   audit?: AuditSink;
   /** Resolved org policy, enforced at the tool chokepoint. */
   policy: ResolvedPolicy;
+  /** Optional cancellation signal for the active agent turn. */
+  signal?: AbortSignal;
 };
 
 export function createDvalinContext(options: DvalinContextOptions = {}): DvalinContext {
@@ -54,5 +58,6 @@ export function createDvalinContext(options: DvalinContextOptions = {}): DvalinC
     requestApproval: options.requestApproval,
     audit: options.audit,
     policy: options.policy ?? permissivePolicy(),
+    signal: options.signal,
   };
 }

--- a/src/core/subprocessSandbox.ts
+++ b/src/core/subprocessSandbox.ts
@@ -33,6 +33,8 @@ export type GovernedProcessOptions = {
    * network:off and endpoint-only still require isolation.
    */
   skipNetworkSandboxWhenPolicyAllows?: boolean;
+  /** Abort the subprocess when the active agent turn is interrupted. */
+  signal?: AbortSignal;
 };
 
 export async function runGovernedProcess(options: GovernedProcessOptions): Promise<GovernedProcessResult> {
@@ -58,7 +60,7 @@ export async function runGovernedProcess(options: GovernedProcessOptions): Promi
   }
 
   const launch = buildLaunch(options.command, options.args, options.cwd, plan);
-  const result = await spawnProcess(launch.command, launch.args, options.cwd, options.timeoutMs);
+  const result = await spawnProcess(launch.command, launch.args, options.cwd, options.timeoutMs, options.signal);
   return { ...result, sandbox: plan.sandbox };
 }
 
@@ -142,8 +144,14 @@ function spawnProcess(
   args: string[],
   cwd: string,
   timeoutMs: number,
+  signal?: AbortSignal,
 ): Promise<Omit<GovernedProcessResult, 'sandbox'>> {
-  return new Promise(resolve => {
+  return new Promise((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(new Error('interrupted'));
+      return;
+    }
+
     const child = spawn(command, args, {
       cwd,
       shell: false,
@@ -152,6 +160,8 @@ function spawnProcess(
 
     let output = '';
     let timedOut = false;
+    let interrupted = false;
+    let killTimer: NodeJS.Timeout | undefined;
     const append = (chunk: Buffer) => {
       output += chunk.toString('utf8');
       if (output.length > 32_000) {
@@ -164,14 +174,38 @@ function spawnProcess(
       child.kill('SIGTERM');
     }, timeoutMs);
 
+    const cleanup = () => {
+      clearTimeout(timer);
+      if (killTimer) clearTimeout(killTimer);
+      signal?.removeEventListener('abort', onAbort);
+    };
+
+    const onAbort = () => {
+      interrupted = true;
+      child.kill('SIGTERM');
+      killTimer = setTimeout(() => {
+        child.kill('SIGKILL');
+      }, 1_500);
+      killTimer.unref?.();
+    };
+    signal?.addEventListener('abort', onAbort, { once: true });
+
     child.stdout.on('data', append);
     child.stderr.on('data', append);
     child.on('error', error => {
-      clearTimeout(timer);
+      cleanup();
+      if (interrupted) {
+        reject(new Error('interrupted'));
+        return;
+      }
       resolve({ output: error.message, exitCode: 1, timedOut });
     });
     child.on('close', code => {
-      clearTimeout(timer);
+      cleanup();
+      if (interrupted) {
+        reject(new Error('interrupted'));
+        return;
+      }
       resolve({ output: output.trimEnd(), exitCode: code, timedOut });
     });
   });

--- a/src/tools/runCheck.ts
+++ b/src/tools/runCheck.ts
@@ -60,6 +60,7 @@ export const runCheckTool: Tool<Input> = {
       audit: context.audit,
       toolName: 'run_check',
       preferSandboxWhenUnrestricted: true,
+      signal: context.signal,
     });
     return {
       title: `run_check ${input.kind}`,

--- a/src/tools/shell.ts
+++ b/src/tools/shell.ts
@@ -38,6 +38,7 @@ export const shellTool: Tool<Input> = {
       toolName: 'shell',
       preferSandboxWhenUnrestricted: true,
       skipNetworkSandboxWhenPolicyAllows: skipNetworkSandbox,
+      signal: context.signal,
     });
     return {
       title: `Ran ${input.command}`,

--- a/src/tui/app.ts
+++ b/src/tui/app.ts
@@ -11,6 +11,8 @@ import * as R from './render.js';
 
 export type TuiOptions = { cwd?: string; mode?: AgentMode };
 
+type AskLine = (query: string) => Promise<string | null>;
+
 /** Launch the interactive terminal agent. Drives the same `runAgentTurn` the
  * web GUI uses, with stdout streaming and stdin approval. */
 export async function runTui(opts: TuiOptions = {}): Promise<void> {
@@ -19,13 +21,32 @@ export async function runTui(opts: TuiOptions = {}): Promise<void> {
   let codePermissionMode: CodePermissionMode = 'ask';
   let sessionId: string | undefined;
   let activeAbort: AbortController | null = null;
+  let interruptRequested = false;
+  let exiting = false;
+  let closed = false;
 
   const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
-  const ask = (query: string): Promise<string> => new Promise(resolve => rl.question(query, resolve));
+  const ask: AskLine = (query: string) => askLine(rl, query, () => closed);
+
+  const shutdown = (): void => {
+    exiting = true;
+    activeAbort?.abort();
+    if (!closed) rl.close();
+  };
+
+  const forceExit = (): void => {
+    process.stdout.write(chalk.yellow('\n  forcing exit\n'));
+    shutdown();
+    process.exit(130);
+  };
 
   process.stdout.write(R.banner());
 
-  await ensureConfigured(rl, ask);
+  const configured = await ensureConfigured(rl, ask);
+  if (!configured) {
+    shutdown();
+    return;
+  }
 
   let providerModel = 'unconfigured';
   try {
@@ -39,17 +60,29 @@ export async function runTui(opts: TuiOptions = {}): Promise<void> {
   // Ctrl-C: interrupt a running turn, or exit at an idle prompt.
   rl.on('SIGINT', () => {
     if (activeAbort) {
+      if (interruptRequested) {
+        forceExit();
+        return;
+      }
+      interruptRequested = true;
       activeAbort.abort();
+      process.stdout.write(chalk.yellow('\n  interrupt requested — press Ctrl-C again to force exit\n'));
     } else {
       process.stdout.write('\n');
-      rl.close();
+      shutdown();
     }
   });
-  rl.on('close', () => process.exit(0));
+  rl.on('close', () => {
+    closed = true;
+    exiting = true;
+  });
 
   // Approval gate for Cowork / Code-Ask writes and commands.
   const requestApproval = async (_id: string, toolName: string, input: unknown): Promise<boolean> => {
-    const answer = await ask('\n' + R.approvalLine(toolName, input));
+    const signal = activeAbort?.signal;
+    const answer = await askLine(rl, '\n' + R.approvalLine(toolName, input), () => closed, signal);
+    if (signal?.aborted) throw new Error('interrupted');
+    if (answer === null) return false;
     return /^y(es)?$/i.test(answer.trim());
   };
 
@@ -98,6 +131,7 @@ export async function runTui(opts: TuiOptions = {}): Promise<void> {
       }
     } finally {
       activeAbort = null;
+      interruptRequested = false;
     }
   }
 
@@ -116,6 +150,10 @@ export async function runTui(opts: TuiOptions = {}): Promise<void> {
 
   /** Returns true if handled locally; false to forward to the agent (e.g. /git). */
   function handleLocal(line: string): boolean {
+    if (isExitCommand(line)) {
+      shutdown();
+      return true;
+    }
     if (!line.startsWith('/')) return false;
     const sp = line.indexOf(' ');
     const cmd = sp === -1 ? line.slice(1) : line.slice(1, sp);
@@ -123,7 +161,7 @@ export async function runTui(opts: TuiOptions = {}): Promise<void> {
     switch (cmd) {
       case 'exit':
       case 'quit':
-        rl.close();
+        shutdown();
         return true;
       case 'clear':
         sessionId = undefined;
@@ -142,9 +180,11 @@ export async function runTui(opts: TuiOptions = {}): Promise<void> {
 
   // Main REPL loop.
   // eslint-disable-next-line no-constant-condition
-  while (true) {
+  while (!exiting) {
     process.stdout.write('\n' + R.statusLine(mode, providerModel, cwdDisplay) + '\n');
-    const line = (await ask(chalk.cyan('› '))).trim();
+    const answer = await ask(chalk.cyan('› '));
+    if (answer === null) break;
+    const line = answer.trim();
     if (!line) continue;
     if (handleLocal(line)) continue;
     await runTurn(line);
@@ -155,42 +195,94 @@ export async function runTui(opts: TuiOptions = {}): Promise<void> {
  * user through a minimal provider setup and persist it to config. */
 async function ensureConfigured(
   rl: readline.Interface,
-  ask: (q: string) => Promise<string>,
-): Promise<void> {
+  ask: AskLine,
+): Promise<boolean> {
   const cfg = await readConfig();
   const preset = findPreset(cfg.llm.provider);
   const needsKey = preset?.needsKey ?? true;
-  if (cfg.llm.apiKey || !needsKey) return;
+  if (cfg.llm.apiKey || !needsKey) return true;
 
   process.stdout.write(chalk.bold("\n  No LLM provider configured. Let's set one up.\n\n"));
   process.stdout.write('  Providers: ' + PROVIDER_PRESETS.map(p => p.id).join(', ') + '\n');
 
-  const providerId = (await ask('  Provider [deepseek]: ')).trim() || 'deepseek';
+  const providerAnswer = await ask('  Provider [deepseek]: ');
+  if (providerAnswer === null) return false;
+  const providerId = providerAnswer.trim() || 'deepseek';
   const chosen = findPreset(providerId) ?? findPreset('deepseek')!;
 
   let apiKey = '';
   if (chosen.needsKey) {
-    apiKey = (await askMasked(rl, '  API key: ')).trim();
+    const apiKeyAnswer = await askMasked(rl, '  API key: ');
+    if (apiKeyAnswer === null) return false;
+    apiKey = apiKeyAnswer.trim();
   }
-  const model = (await ask(`  Model [${chosen.defaultModel}]: `)).trim() || chosen.defaultModel;
+  const modelAnswer = await ask(`  Model [${chosen.defaultModel}]: `);
+  if (modelAnswer === null) return false;
+  const model = modelAnswer.trim() || chosen.defaultModel;
 
   await writeConfig({
     llm: { provider: chosen.id, apiKey: apiKey || undefined, baseUrl: chosen.baseUrl, model },
   });
   process.stdout.write(chalk.dim('  ✓ saved to ~/.dvalincode/config.json\n'));
+  return true;
 }
 
 /** Ask without echoing the typed characters (for API keys). */
-function askMasked(rl: readline.Interface, query: string): Promise<string> {
+function askMasked(rl: readline.Interface, query: string): Promise<string | null> {
   return new Promise(resolve => {
     const iface = rl as unknown as { _writeToOutput?: (s: string) => void };
     const original = iface._writeToOutput;
-    rl.question(query, answer => {
+    let settled = false;
+    const finish = (answer: string | null) => {
+      if (settled) return;
+      settled = true;
+      rl.off('close', onClose);
       iface._writeToOutput = original;
       process.stdout.write('\n');
       resolve(answer);
-    });
+    };
+    const onClose = () => finish(null);
+    rl.once('close', onClose);
+    try {
+      rl.question(query, answer => finish(answer));
+    } catch {
+      finish(null);
+    }
     // After the query is printed, suppress echo of subsequent keystrokes.
     iface._writeToOutput = () => {};
   });
+}
+
+function askLine(
+  rl: readline.Interface,
+  query: string,
+  isClosed: () => boolean,
+  signal?: AbortSignal,
+): Promise<string | null> {
+  if (isClosed()) return Promise.resolve(null);
+  if (signal?.aborted) return Promise.resolve(null);
+  return new Promise(resolve => {
+    let settled = false;
+    const finish = (answer: string | null) => {
+      if (settled) return;
+      settled = true;
+      rl.off('close', onClose);
+      signal?.removeEventListener('abort', onAbort);
+      resolve(answer);
+    };
+    const onClose = () => finish(null);
+    const onAbort = () => finish(null);
+    rl.once('close', onClose);
+    signal?.addEventListener('abort', onAbort, { once: true });
+    try {
+      rl.question(query, answer => finish(answer));
+    } catch {
+      finish(null);
+    }
+  });
+}
+
+export function isExitCommand(line: string): boolean {
+  const value = line.trim().toLowerCase();
+  return value === 'exit' || value === 'quit' || value === ':q' || value === '/exit' || value === '/quit';
 }

--- a/tests/e2e/app-shell.e2e.ts
+++ b/tests/e2e/app-shell.e2e.ts
@@ -4,7 +4,7 @@ test('loads the DvalinCode app shell', async ({ page }) => {
   await page.goto('/');
 
   await expect(page.getByRole('heading', { name: 'DvalinCode' })).toBeVisible();
-  await expect(page.getByRole('button', { name: /Chat/ })).toBeVisible();
-  await expect(page.getByRole('button', { name: /Cowork/ })).toBeVisible();
-  await expect(page.getByRole('button', { name: /Code/ })).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Chat', exact: true })).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Cowork', exact: true })).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Code', exact: true })).toBeVisible();
 });

--- a/tests/subprocessAbort.test.ts
+++ b/tests/subprocessAbort.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { resolvePolicy } from '../src/core/policy.js';
+import { runGovernedProcess } from '../src/core/subprocessSandbox.js';
+
+describe('governed subprocess cancellation', () => {
+  it('terminates a running child when the active turn is aborted', async () => {
+    const controller = new AbortController();
+    const started = Date.now();
+    const run = runGovernedProcess({
+      command: process.execPath,
+      args: ['-e', 'setInterval(() => {}, 1000)'],
+      cwd: process.cwd(),
+      timeoutMs: 10_000,
+      policy: resolvePolicy([{ network: 'on' }]),
+      toolName: 'shell',
+      signal: controller.signal,
+    });
+
+    setTimeout(() => controller.abort(), 50);
+
+    await expect(run).rejects.toThrow('interrupted');
+    expect(Date.now() - started).toBeLessThan(3_000);
+  });
+});

--- a/tests/tuiExit.test.ts
+++ b/tests/tuiExit.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { isExitCommand } from '../src/tui/app.js';
+
+describe('TUI exit commands', () => {
+  it('accepts bare and slash exit commands', () => {
+    for (const input of ['exit', ' exit ', 'quit', ':q', '/exit', '/quit']) {
+      expect(isExitCommand(input)).toBe(true);
+    }
+  });
+
+  it('does not treat ordinary messages as exit commands', () => {
+    for (const input of ['please exit later', '/git', '/help', 'q']) {
+      expect(isExitCommand(input)).toBe(false);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Make the TUI exit cleanly from bare `exit`, `quit`, `:q`, `/exit`, and `/quit` instead of forwarding bare `exit` to the model.
- Replace the `readline close -> process.exit(0)` hard-exit path with an explicit shutdown state so EOF/closed stdin returns normally.
- Wire the active turn `AbortSignal` into tool context, `shell`, `run_check`, and `runGovernedProcess` so Ctrl-C can terminate running subprocesses instead of leaving the CLI stuck.
- Add a second Ctrl-C force-exit fallback while a turn is active.
- Stabilize the app shell e2e selector for the `Code` mode button.

## Why

On macOS, the interactive CLI could get stuck when a turn or subprocess did not stop cleanly, leaving users unable to exit normally. The CLI also documented `/exit`, but did not support the common bare `exit` command.

## Validation

- `npm run check` — 39 files, 213 tests passed
- `npm run build`
- `npm run test:e2e`
- Manual TTY smoke: `npm run dev -- tui`, then type `exit` -> process exits with code 0
- Pipe smoke: `exit` and `/exit` both exit with code 0

## Notes

The subprocess abort path sends SIGTERM first, then SIGKILL after 1.5s if needed. This keeps normal cleanup possible but gives the user a reliable escape hatch.
