### PR TITLE
release: v0.12.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 <p align="center">
   <a href="https://github.com/arthurpanhku/dvalincode/releases/latest"><img src="https://img.shields.io/github/v/release/arthurpanhku/dvalincode?style=for-the-badge&color=818cf8&label=Release" alt="Release"></a>
   <a href="https://github.com/arthurpanhku/dvalincode/releases"><img src="https://img.shields.io/github/downloads/arthurpanhku/dvalincode/total?style=for-the-badge&color=blue&label=Downloads" alt="Downloads"></a>
-  <a href="#-tests"><img src="https://img.shields.io/badge/Tests-203%20%2F%20203%20%E2%9C%93-success?style=for-the-badge" alt="Tests"></a>
+  <a href="#-tests"><img src="https://img.shields.io/badge/Tests-213%20%2F%20213%20%E2%9C%93-success?style=for-the-badge" alt="Tests"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-green?style=for-the-badge" alt="License"></a>
   <a href="https://scorecard.dev/viewer/?uri=github.com/arthurpanhku/dvalincode"><img src="https://api.scorecard.dev/projects/github.com/arthurpanhku/dvalincode/badge" alt="OpenSSF Scorecard"></a>
   <a href="docs/governance/ISO-42001-AIMS.md"><img src="https://img.shields.io/badge/ISO%2FIEC%2042001-AIMS%20Aligned-0F766E?style=for-the-badge" alt="ISO/IEC 42001 AIMS aligned"></a>
@@ -462,7 +462,7 @@ RESTORE → COMPACT → COMMAND → BUILD → RUN → SAVE → RESPOND → DONE
 npm test
 ```
 
-**203 tests · 36 files · all green.**
+**213 tests · 39 files · all green.**
 
 ---
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -9,7 +9,7 @@
 <p align="center">
   <a href="https://github.com/arthurpanhku/dvalincode/releases/latest"><img src="https://img.shields.io/github/v/release/arthurpanhku/dvalincode?style=for-the-badge&color=818cf8&label=Release" alt="Release"></a>
   <a href="https://github.com/arthurpanhku/dvalincode/releases"><img src="https://img.shields.io/github/downloads/arthurpanhku/dvalincode/total?style=for-the-badge&color=blue&label=Downloads" alt="Downloads"></a>
-  <a href="#-测试"><img src="https://img.shields.io/badge/Tests-203%20%2F%20203%20%E2%9C%93-success?style=for-the-badge" alt="Tests"></a>
+  <a href="#-测试"><img src="https://img.shields.io/badge/Tests-213%20%2F%20213%20%E2%9C%93-success?style=for-the-badge" alt="Tests"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-green?style=for-the-badge" alt="License"></a>
   <a href="https://scorecard.dev/viewer/?uri=github.com/arthurpanhku/dvalincode"><img src="https://api.scorecard.dev/projects/github.com/arthurpanhku/dvalincode/badge" alt="OpenSSF Scorecard"></a>
   <a href="docs/governance/ISO-42001-AIMS.md"><img src="https://img.shields.io/badge/ISO%2FIEC%2042001-AIMS%20Aligned-0F766E?style=for-the-badge" alt="ISO/IEC 42001 AIMS aligned"></a>
@@ -444,7 +444,7 @@ RESTORE → COMPACT → COMMAND → BUILD → RUN → SAVE → RESPOND → DONE
 npm test
 ```
 
-**203 个测试 · 36 个文件 · 全部通过。**
+**213 个测试 · 39 个文件 · 全部通过。**
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dvalincode",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dvalincode",
-      "version": "0.12.0",
+      "version": "0.12.1",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.6.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dvalincode",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "A local-first, provider-neutral CLI foundation for agentic coding workflows.",
   "type": "module",
   "license": "MIT",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -23,7 +23,7 @@ export function buildProgram(): Command {
   program
     .name('dvalincode')
     .description('Local-first coding agent — terminal UI by default, `serve` for the web GUI')
-    .version('0.11.0');
+    .version('0.12.1');
 
   registerScanCommand(program);
   registerToolsCommand(program, registry);

--- a/src/core/trust.ts
+++ b/src/core/trust.ts
@@ -27,7 +27,7 @@ import {
  */
 
 /** Keep in lockstep with the version in src/cli.ts. */
-const VERSION = '0.11.0';
+const VERSION = '0.12.1';
 
 export type TrustReport = {
   version: string;


### PR DESCRIPTION
Patch release over `v0.12.0`, bundling the fixes merged since the last tag.

## Version bump
- `package.json` / `package-lock.json`: `0.12.0` → `0.12.1`
- `src/cli.ts` and `src/core/trust.ts`: `0.11.0` → `0.12.1` — these had **drifted** (never bumped to 0.12.0); this brings them back into lockstep with `package.json`.

## Docs
- Test badge + tests section refreshed to **213 tests / 39 files** (was 203 / 36) in `README.md` and `README.zh-CN.md`.

## Changes shipped since v0.12.0
- fix: make CLI exit and interrupt reliable (#85)
- fix: align `run_check` subprocess sandbox with shell on macOS (#83)
- docs: blog post, homepage refresh, README previews

## Release flow
Once merged, tag `v0.12.1` on the merge commit and push it — `.github/workflows/release.yml` builds the all-platform CLI + web bundle and publishes the GitHub Release.

`npm run check` green locally: typecheck clean, 213/213 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)