### PR TITLE
feat: self-update via `dvalincode update`

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 <p align="center">
   <a href="https://github.com/arthurpanhku/dvalincode/releases/latest"><img src="https://img.shields.io/github/v/release/arthurpanhku/dvalincode?style=for-the-badge&color=818cf8&label=Release" alt="Release"></a>
   <a href="https://github.com/arthurpanhku/dvalincode/releases"><img src="https://img.shields.io/github/downloads/arthurpanhku/dvalincode/total?style=for-the-badge&color=blue&label=Downloads" alt="Downloads"></a>
-  <a href="#-tests"><img src="https://img.shields.io/badge/Tests-213%20%2F%20213%20%E2%9C%93-success?style=for-the-badge" alt="Tests"></a>
+  <a href="#-tests"><img src="https://img.shields.io/badge/Tests-229%20%2F%20229%20%E2%9C%93-success?style=for-the-badge" alt="Tests"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-green?style=for-the-badge" alt="License"></a>
   <a href="https://scorecard.dev/viewer/?uri=github.com/arthurpanhku/dvalincode"><img src="https://api.scorecard.dev/projects/github.com/arthurpanhku/dvalincode/badge" alt="OpenSSF Scorecard"></a>
   <a href="docs/governance/ISO-42001-AIMS.md"><img src="https://img.shields.io/badge/ISO%2FIEC%2042001-AIMS%20Aligned-0F766E?style=for-the-badge" alt="ISO/IEC 42001 AIMS aligned"></a>
@@ -340,6 +340,22 @@ Verify against `SHA256SUMS.txt` (included in each release).
 
 > **macOS Gatekeeper:** binaries are unsigned. On first run, either clear the quarantine flag with `xattr -dr com.apple.quarantine ~/.dvalincode`, or right-click the binary in Finder → Open → confirm.
 
+### Staying up to date
+
+DvalinCode updates itself — no need to re-run the installer:
+
+```sh
+dvalincode update --check   # is a newer release out? (read-only)
+dvalincode update           # download, verify, and install the latest
+```
+
+It finds the newest release on GitHub, and for a binary install downloads the
+matching archive, **verifies it against the release's `SHA256SUMS.txt` before
+swapping anything in**, then replaces `~/.dvalincode/` in place. npm installs are
+updated via `npm i -g`, and source checkouts are pointed at `git pull`. Add
+`-y` to skip the prompt, `--prerelease` to track pre-releases, or `--json` for
+scripting.
+
 ---
 
 ## 🎬 First-time setup
@@ -462,7 +478,7 @@ RESTORE → COMPACT → COMMAND → BUILD → RUN → SAVE → RESPOND → DONE
 npm test
 ```
 
-**213 tests · 39 files · all green.**
+**229 tests · 40 files · all green.**
 
 ---
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -9,7 +9,7 @@
 <p align="center">
   <a href="https://github.com/arthurpanhku/dvalincode/releases/latest"><img src="https://img.shields.io/github/v/release/arthurpanhku/dvalincode?style=for-the-badge&color=818cf8&label=Release" alt="Release"></a>
   <a href="https://github.com/arthurpanhku/dvalincode/releases"><img src="https://img.shields.io/github/downloads/arthurpanhku/dvalincode/total?style=for-the-badge&color=blue&label=Downloads" alt="Downloads"></a>
-  <a href="#-测试"><img src="https://img.shields.io/badge/Tests-213%20%2F%20213%20%E2%9C%93-success?style=for-the-badge" alt="Tests"></a>
+  <a href="#-测试"><img src="https://img.shields.io/badge/Tests-229%20%2F%20229%20%E2%9C%93-success?style=for-the-badge" alt="Tests"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-green?style=for-the-badge" alt="License"></a>
   <a href="https://scorecard.dev/viewer/?uri=github.com/arthurpanhku/dvalincode"><img src="https://api.scorecard.dev/projects/github.com/arthurpanhku/dvalincode/badge" alt="OpenSSF Scorecard"></a>
   <a href="docs/governance/ISO-42001-AIMS.md"><img src="https://img.shields.io/badge/ISO%2FIEC%2042001-AIMS%20Aligned-0F766E?style=for-the-badge" alt="ISO/IEC 42001 AIMS aligned"></a>
@@ -320,6 +320,17 @@ dvalincode serve --host 0.0.0.0 --no-open   # 部署到服务器，供远程/浏
 
 > **macOS Gatekeeper：** 二进制未签名。首次运行可执行 `xattr -dr com.apple.quarantine ~/.dvalincode`，或在 Finder 中右键 → 打开一次。
 
+### 保持更新
+
+DvalinCode 可自我更新，无需重新运行安装脚本：
+
+```sh
+dvalincode update --check   # 检查是否有新版本（只读）
+dvalincode update           # 下载、校验并安装最新版本
+```
+
+它会在 GitHub 上找到最新 release；对二进制安装，会下载对应平台的归档，**在替换任何文件之前先用 release 的 `SHA256SUMS.txt` 校验**，然后就地替换 `~/.dvalincode/`。npm 安装通过 `npm i -g` 更新，源码检出则提示 `git pull`。可用 `-y` 跳过确认、`--prerelease` 跟踪预发布、`--json` 用于脚本。
+
 ---
 
 ## 🎬 首次配置
@@ -444,7 +455,7 @@ RESTORE → COMPACT → COMMAND → BUILD → RUN → SAVE → RESPOND → DONE
 npm test
 ```
 
-**213 个测试 · 39 个文件 · 全部通过。**
+**229 个测试 · 40 个文件 · 全部通过。**
 
 ---
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,5 @@
 import { Command } from 'commander';
+import { VERSION } from './version.js';
 import { registerAskCommand } from './commands/ask.js';
 import { registerChatCommand } from './commands/chat.js';
 import { registerInitCommand } from './commands/init.js';
@@ -14,6 +15,7 @@ import { registerServeCommand } from './commands/serve.js';
 import { registerTuiCommand } from './commands/tui.js';
 import { registerDataCommands } from './commands/data.js';
 import { registerProviderCommand } from './commands/provider.js';
+import { registerUpdateCommand } from './commands/update.js';
 import { createDefaultToolRegistry } from './tools/registry.js';
 
 export function buildProgram(): Command {
@@ -23,7 +25,7 @@ export function buildProgram(): Command {
   program
     .name('dvalincode')
     .description('Local-first coding agent — terminal UI by default, `serve` for the web GUI')
-    .version('0.12.1');
+    .version(VERSION);
 
   registerScanCommand(program);
   registerToolsCommand(program, registry);
@@ -40,6 +42,7 @@ export function buildProgram(): Command {
   registerTuiCommand(program);
   registerDataCommands(program);
   registerProviderCommand(program);
+  registerUpdateCommand(program);
 
   // Bare invocation: launch the terminal agent in an interactive TTY,
   // otherwise fall back to help (e.g. piped or non-interactive contexts).

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -1,0 +1,291 @@
+import type { Command } from 'commander';
+import { fileURLToPath } from 'node:url';
+import { Readable } from 'node:stream';
+import { pipeline } from 'node:stream/promises';
+import { createWriteStream } from 'node:fs';
+import { mkdir, rm, rename, chmod, readdir, stat, readFile } from 'node:fs/promises';
+import { execFile, spawn } from 'node:child_process';
+import { promisify } from 'node:util';
+import { createInterface } from 'node:readline/promises';
+import path from 'node:path';
+import { VERSION } from '../version.js';
+import {
+  RELEASE_REPO,
+  RELEASE_HOSTS,
+  assetName,
+  detectInstall,
+  detectPlatform,
+  fetchLatestRelease,
+  isNewer,
+  parseSums,
+  sha256File,
+  type InstallInfo,
+  type ReleaseInfo,
+} from '../core/selfUpdate.js';
+
+const execFileAsync = promisify(execFile);
+
+type UpdateOptions = {
+  check?: boolean;
+  yes?: boolean;
+  force?: boolean;
+  json?: boolean;
+  prerelease?: boolean;
+};
+
+export function registerUpdateCommand(program: Command): void {
+  program
+    .command('update')
+    .alias('upgrade')
+    .description('Update DvalinCode to the latest release on GitHub')
+    .option('--check', 'only check whether a newer version exists; do not modify anything')
+    .option('-y, --yes', 'apply the update without an interactive confirmation')
+    .option('--force', 'reinstall even if already on the latest version')
+    .option('--prerelease', 'include prereleases when resolving the latest version')
+    .option('--json', 'print the update status as JSON (implies --check)')
+    .action(async (options: UpdateOptions) => {
+      try {
+        await runUpdate(options);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        if (options.json) {
+          console.log(JSON.stringify({ ok: false, error: message }, null, 2));
+        } else {
+          console.error(`update: ${message}`);
+        }
+        process.exitCode = 1;
+      }
+    });
+}
+
+async function runUpdate(options: UpdateOptions): Promise<void> {
+  const current = VERSION;
+  const moduleDir = path.dirname(fileURLToPath(import.meta.url));
+  const install = detectInstall({ moduleDir });
+
+  if (!options.json) {
+    console.log(`Contacting ${RELEASE_HOSTS.join(', ')} for the latest release…`);
+  }
+
+  const release = await fetchLatestRelease({
+    includePrerelease: options.prerelease,
+    signal: AbortSignal.timeout(20_000),
+  });
+
+  const updateAvailable = isNewer(release.version, current);
+
+  // ── check / json: report and stop ─────────────────────────────────────────
+  if (options.json) {
+    console.log(
+      JSON.stringify(
+        {
+          ok: true,
+          current,
+          latest: release.version,
+          updateAvailable,
+          prerelease: release.prerelease,
+          installMethod: install.method,
+          releaseUrl: release.htmlUrl,
+        },
+        null,
+        2,
+      ),
+    );
+    return;
+  }
+
+  console.log(`  current  ${current}`);
+  console.log(`  latest   ${release.version}${release.prerelease ? ' (prerelease)' : ''}`);
+  console.log('');
+
+  if (!updateAvailable && !options.force) {
+    console.log(`✓ You're on the latest version (${current}).`);
+    return;
+  }
+
+  if (options.check) {
+    console.log(
+      updateAvailable
+        ? `↑ Update available: ${current} → ${release.version}\n  Run \`dvalincode update\` to install it.`
+        : `Re-run without --check to reinstall ${release.version}.`,
+    );
+    return;
+  }
+
+  // ── Confirm ────────────────────────────────────────────────────────────────
+  const verb = updateAvailable ? `Update ${current} → ${release.version}` : `Reinstall ${release.version}`;
+  if (!options.yes) {
+    const ok = await confirm(`${verb} via the ${install.method} install?`);
+    if (!ok) {
+      console.log('Aborted.');
+      return;
+    }
+  }
+
+  // ── Apply per install method ───────────────────────────────────────────────
+  switch (install.method) {
+    case 'binary':
+      await applyBinaryUpdate(install, release);
+      break;
+    case 'npm':
+      await applyNpmUpdate(release);
+      break;
+    case 'source':
+      printSourceGuidance(install, release);
+      break;
+    default:
+      printManualGuidance(release);
+  }
+}
+
+// ── binary: download, verify checksum, swap in place ─────────────────────────
+
+async function applyBinaryUpdate(install: InstallInfo, release: ReleaseInfo): Promise<void> {
+  const root = install.root!;
+  const targetBinary = install.binary!;
+
+  const platform = detectPlatform();
+  if (!platform) {
+    throw new Error(`No published binary for ${process.platform}/${process.arch}.`);
+  }
+  if (platform.os === 'windows') {
+    // A running .exe can't replace itself; guide the user to the installer instead.
+    printManualGuidance(release);
+    return;
+  }
+
+  const asset = assetName(release.version, platform);
+  const archiveUrl = release.assets.get(asset);
+  const sumsUrl = release.assets.get('SHA256SUMS.txt');
+  if (!archiveUrl) throw new Error(`Release ${release.tag} has no asset ${asset}.`);
+  if (!sumsUrl) throw new Error(`Release ${release.tag} has no SHA256SUMS.txt to verify against.`);
+
+  // Work inside the install dir so the final rename is a same-filesystem atomic swap.
+  const workDir = path.join(root, `.update-${process.pid}`);
+  await rm(workDir, { recursive: true, force: true });
+  await mkdir(workDir, { recursive: true });
+
+  try {
+    const archivePath = path.join(workDir, asset);
+    console.log(`Downloading ${asset}…`);
+    await download(archiveUrl, archivePath);
+    const sumsPath = path.join(workDir, 'SHA256SUMS.txt');
+    await download(sumsUrl, sumsPath);
+
+    console.log('Verifying checksum…');
+    const expected = parseSums(await readFile(sumsPath, 'utf8')).get(asset);
+    if (!expected) throw new Error(`${asset} is not listed in SHA256SUMS.txt.`);
+    const actual = await sha256File(archivePath);
+    if (actual !== expected) {
+      throw new Error(`Checksum mismatch for ${asset}:\n  expected ${expected}\n  got      ${actual}`);
+    }
+    console.log('  ✓ sha256 verified');
+
+    console.log('Extracting…');
+    await execFileAsync('tar', ['xzf', archivePath, '-C', workDir]);
+
+    const archiveRoot = await findArchiveRoot(workDir);
+    const newBinary = await findBinary(archiveRoot);
+    const newWeb = path.join(archiveRoot, 'web');
+    if (!(await exists(newWeb))) throw new Error('Extracted archive is missing web/.');
+
+    // Swap: replace the running binary (atomic rename over the same inode path)
+    // and the adjacent web/ directory.
+    await chmod(newBinary, 0o755);
+    await rename(newBinary, targetBinary);
+    await rm(path.join(root, 'web'), { recursive: true, force: true });
+    await rename(newWeb, path.join(root, 'web'));
+
+    // Best-effort: clear macOS quarantine so Gatekeeper doesn't flag the swap.
+    if (process.platform === 'darwin') {
+      await execFileAsync('xattr', ['-dr', 'com.apple.quarantine', root]).catch(() => {});
+    }
+
+    console.log('');
+    console.log(`✓ Updated to ${release.version}. Run \`dvalincode --version\` to confirm.`);
+  } finally {
+    await rm(workDir, { recursive: true, force: true });
+  }
+}
+
+// ── npm: delegate to the package manager ─────────────────────────────────────
+
+async function applyNpmUpdate(release: ReleaseInfo): Promise<void> {
+  const spec = `dvalincode@${release.version}`;
+  const npm = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+  console.log(`Running: npm install -g ${spec}`);
+  const code = await new Promise<number>((resolve, reject) => {
+    const child = spawn(npm, ['install', '-g', spec], { stdio: 'inherit' });
+    child.on('error', reject);
+    child.on('close', c => resolve(c ?? 1));
+  });
+  if (code !== 0) throw new Error(`npm exited with code ${code}.`);
+  console.log(`✓ Updated to ${release.version}.`);
+}
+
+function printSourceGuidance(install: InstallInfo, release: ReleaseInfo): void {
+  console.log('This looks like a source checkout — update it with git:');
+  console.log(`  git -C ${install.root} pull`);
+  console.log(`  npm install && npm run build   # rebuild at ${release.version}`);
+}
+
+function printManualGuidance(release: ReleaseInfo): void {
+  console.log('Update by re-running the installer:');
+  console.log(
+    '  curl -fsSL https://raw.githubusercontent.com/' +
+      RELEASE_REPO +
+      '/main/scripts/install.sh | bash',
+  );
+  console.log('');
+  console.log(`Or download ${release.version} manually: ${release.htmlUrl}`);
+}
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+async function download(url: string, dest: string): Promise<void> {
+  const res = await fetch(url, {
+    headers: { 'User-Agent': 'dvalincode-update' },
+    redirect: 'follow',
+    signal: AbortSignal.timeout(120_000),
+  });
+  if (!res.ok || !res.body) {
+    throw new Error(`Download failed (${res.status} ${res.statusText}) for ${url}`);
+  }
+  await pipeline(Readable.fromWeb(res.body as never), createWriteStream(dest));
+}
+
+async function findArchiveRoot(dir: string): Promise<string> {
+  const entries = await readdir(dir, { withFileTypes: true });
+  const match = entries.find(e => e.isDirectory() && e.name.startsWith('dvalincode-'));
+  if (!match) throw new Error('Could not find the extracted dvalincode-* directory.');
+  return path.join(dir, match.name);
+}
+
+async function findBinary(archiveRoot: string): Promise<string> {
+  const entries = await readdir(archiveRoot, { withFileTypes: true });
+  const bin = entries.find(
+    e => e.isFile() && e.name.startsWith('dvalincode-') && !e.name.endsWith('.sh') && !e.name.endsWith('.bat'),
+  );
+  if (!bin) throw new Error('Could not find the binary inside the extracted archive.');
+  return path.join(archiveRoot, bin.name);
+}
+
+async function exists(p: string): Promise<boolean> {
+  try {
+    await stat(p);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function confirm(question: string): Promise<boolean> {
+  if (!process.stdin.isTTY) return false;
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  try {
+    const answer = (await rl.question(`${question} [y/N] `)).trim().toLowerCase();
+    return answer === 'y' || answer === 'yes';
+  } finally {
+    rl.close();
+  }
+}

--- a/src/core/selfUpdate.ts
+++ b/src/core/selfUpdate.ts
@@ -1,0 +1,243 @@
+/**
+ * Self-update core — the testable logic behind `dvalincode update`.
+ *
+ * The CLI ships as a self-contained Bun binary published to GitHub Releases
+ * (see scripts/build-release.sh): each release carries
+ * `dvalincode-vX.Y.Z-<os>-<arch>.{tar.gz,zip}` assets plus a `SHA256SUMS.txt`.
+ * This module knows how to find the latest release, name the asset for the
+ * current platform, and verify a download against the published checksum.
+ *
+ * Everything here is pure or dependency-injected (the GitHub fetch is passed
+ * in) so it can be unit-tested without network access. The orchestration —
+ * downloading, extracting, and swapping files — lives in commands/update.ts.
+ */
+
+import { createHash } from 'node:crypto';
+import { createReadStream } from 'node:fs';
+import path from 'node:path';
+
+/** The single repo the CLI updates from. */
+export const RELEASE_REPO = 'arthurpanhku/dvalincode';
+
+/** Host contacted for release metadata + downloads — surfaced to the user for transparency. */
+export const RELEASE_HOSTS = ['api.github.com', 'github.com'] as const;
+
+// ── Version comparison ────────────────────────────────────────────────────────
+
+export type Semver = { major: number; minor: number; patch: number; pre?: string };
+
+/** Parse `v1.2.3` / `1.2.3` / `1.2.3-rc.1`. Returns null for anything else (e.g. `gui-v1.2.3`). */
+export function parseSemver(tag: string): Semver | null {
+  const m = /^v?(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?$/.exec(tag.trim());
+  if (!m) return null;
+  const pre = m[4];
+  return { major: Number(m[1]), minor: Number(m[2]), patch: Number(m[3]), ...(pre ? { pre } : {}) };
+}
+
+/** >0 if a>b, <0 if a<b, 0 if equal. A stable release outranks a prerelease of the same core. */
+export function compareSemver(a: Semver, b: Semver): number {
+  if (a.major !== b.major) return a.major - b.major;
+  if (a.minor !== b.minor) return a.minor - b.minor;
+  if (a.patch !== b.patch) return a.patch - b.patch;
+  if (a.pre && !b.pre) return -1;
+  if (!a.pre && b.pre) return 1;
+  if (a.pre && b.pre) return a.pre === b.pre ? 0 : a.pre < b.pre ? -1 : 1;
+  return 0;
+}
+
+/** True when `latest` is a strictly newer version than `current`. Unparseable inputs → false. */
+export function isNewer(latest: string, current: string): boolean {
+  const l = parseSemver(latest);
+  const c = parseSemver(current);
+  if (!l || !c) return false;
+  return compareSemver(l, c) > 0;
+}
+
+// ── Platform → asset name ─────────────────────────────────────────────────────
+
+export type Platform = { os: 'macos' | 'linux' | 'windows'; arch: 'arm64' | 'x64' };
+
+/** Map Node's platform/arch onto the published release matrix. null = no published build. */
+export function detectPlatform(
+  platform: NodeJS.Platform = process.platform,
+  arch: string = process.arch,
+): Platform | null {
+  let os: Platform['os'];
+  switch (platform) {
+    case 'darwin':
+      os = 'macos';
+      break;
+    case 'linux':
+      os = 'linux';
+      break;
+    case 'win32':
+      os = 'windows';
+      break;
+    default:
+      return null;
+  }
+  let a: Platform['arch'];
+  switch (arch) {
+    case 'arm64':
+      a = 'arm64';
+      break;
+    case 'x64':
+      a = 'x64';
+      break;
+    default:
+      return null;
+  }
+  // Only Windows x64 is published (mirrors scripts/install.sh).
+  if (os === 'windows' && a === 'arm64') return null;
+  return { os, arch: a };
+}
+
+/** Archive filename for a version+platform, e.g. `dvalincode-v0.12.1-macos-arm64.tar.gz`. */
+export function assetName(version: string, p: Platform): string {
+  const v = version.startsWith('v') ? version : `v${version}`;
+  const ext = p.os === 'windows' ? 'zip' : 'tar.gz';
+  return `dvalincode-${v}-${p.os}-${p.arch}.${ext}`;
+}
+
+// ── Checksums ─────────────────────────────────────────────────────────────────
+
+/** Parse `shasum -a 256` output ("<hex>␠␠<filename>") into filename → lowercase hex. */
+export function parseSums(text: string): Map<string, string> {
+  const map = new Map<string, string>();
+  for (const line of text.split('\n')) {
+    const m = /^([0-9a-fA-F]{64})\s+\*?(.+?)\s*$/.exec(line);
+    if (m) map.set(path.basename(m[2]), m[1].toLowerCase());
+  }
+  return map;
+}
+
+/** Stream a file through SHA-256; returns lowercase hex. */
+export function sha256File(file: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const hash = createHash('sha256');
+    const stream = createReadStream(file);
+    stream.on('error', reject);
+    stream.on('data', chunk => hash.update(chunk));
+    stream.on('end', () => resolve(hash.digest('hex')));
+  });
+}
+
+// ── Install-method detection ──────────────────────────────────────────────────
+
+export type InstallMethod = 'binary' | 'npm' | 'source' | 'unknown';
+export type InstallInfo = {
+  method: InstallMethod;
+  /** For `binary`: the directory holding the runnable binary (the swap target). */
+  root?: string;
+  /** For `binary`: absolute path to the currently running binary. */
+  binary?: string;
+};
+
+/**
+ * Work out how this process was launched so `update` can pick the right mechanism.
+ *
+ * - `binary`  — a Bun `--compile` single-file executable named `dvalincode*`
+ *               (what the installer drops in ~/.dvalincode). `execPath` *is* our binary.
+ * - `npm`     — running under node from a global npm install (module under node_modules/).
+ * - `source`  — running from a git checkout (module under a repo we can `git pull`).
+ *
+ * Injectable args keep it unit-testable.
+ */
+export function detectInstall(opts?: {
+  execPath?: string;
+  moduleDir?: string;
+  isBun?: boolean;
+}): InstallInfo {
+  const execPath = opts?.execPath ?? process.execPath;
+  const isBun = opts?.isBun ?? Boolean(process.versions.bun);
+  const execBase = path.basename(execPath).toLowerCase();
+
+  // A compiled Bun app reports its own path as execPath (not `bun`/`node`).
+  if (isBun && execBase.startsWith('dvalincode')) {
+    return { method: 'binary', root: path.dirname(execPath), binary: execPath };
+  }
+
+  const moduleDir = opts?.moduleDir;
+  if (moduleDir) {
+    const normalized = moduleDir.split(path.sep).join('/');
+    if (normalized.includes('/node_modules/')) return { method: 'npm' };
+    return { method: 'source', root: moduleDir };
+  }
+
+  return { method: 'unknown' };
+}
+
+// ── Release lookup ────────────────────────────────────────────────────────────
+
+/** Minimal shape of a GitHub release we care about. */
+export type GithubRelease = {
+  tag_name: string;
+  prerelease: boolean;
+  draft: boolean;
+  html_url: string;
+  published_at?: string;
+  assets: Array<{ name: string; browser_download_url: string }>;
+};
+
+export type ReleaseInfo = {
+  tag: string;
+  version: string;
+  prerelease: boolean;
+  htmlUrl: string;
+  publishedAt?: string;
+  assets: Map<string, string>;
+};
+
+type FetchLike = (url: string, init?: { signal?: AbortSignal; headers?: Record<string, string> }) => Promise<{
+  ok: boolean;
+  status: number;
+  statusText: string;
+  json: () => Promise<unknown>;
+}>;
+
+function toReleaseInfo(r: GithubRelease): ReleaseInfo {
+  return {
+    tag: r.tag_name,
+    version: r.tag_name.replace(/^v/, ''),
+    prerelease: r.prerelease,
+    htmlUrl: r.html_url,
+    ...(r.published_at ? { publishedAt: r.published_at } : {}),
+    assets: new Map(r.assets.map(a => [a.name, a.browser_download_url])),
+  };
+}
+
+/**
+ * Resolve the release to update to.
+ *
+ * - Stable (default): GitHub's `releases/latest`, which already excludes drafts,
+ *   prereleases, and the separate `gui-*` desktop track.
+ * - `includePrerelease`: scan recent releases and pick the highest semver tag,
+ *   ignoring anything whose tag isn't plain semver (e.g. `gui-v*`).
+ */
+export async function fetchLatestRelease(opts: {
+  repo?: string;
+  includePrerelease?: boolean;
+  fetchImpl?: FetchLike;
+  signal?: AbortSignal;
+}): Promise<ReleaseInfo> {
+  const repo = opts.repo ?? RELEASE_REPO;
+  const doFetch = opts.fetchImpl ?? (globalThis.fetch as unknown as FetchLike);
+  const headers = { Accept: 'application/vnd.github+json', 'User-Agent': 'dvalincode-update' };
+
+  if (!opts.includePrerelease) {
+    const url = `https://api.github.com/repos/${repo}/releases/latest`;
+    const res = await doFetch(url, { headers, ...(opts.signal ? { signal: opts.signal } : {}) });
+    if (!res.ok) throw new Error(`GitHub API ${res.status} ${res.statusText} for ${url}`);
+    return toReleaseInfo((await res.json()) as GithubRelease);
+  }
+
+  const url = `https://api.github.com/repos/${repo}/releases?per_page=30`;
+  const res = await doFetch(url, { headers, ...(opts.signal ? { signal: opts.signal } : {}) });
+  if (!res.ok) throw new Error(`GitHub API ${res.status} ${res.statusText} for ${url}`);
+  const releases = (await res.json()) as GithubRelease[];
+  const candidates = releases
+    .filter(r => !r.draft && parseSemver(r.tag_name) !== null)
+    .sort((a, b) => compareSemver(parseSemver(b.tag_name)!, parseSemver(a.tag_name)!));
+  if (candidates.length === 0) throw new Error('No versioned releases found.');
+  return toReleaseInfo(candidates[0]);
+}

--- a/src/core/trust.ts
+++ b/src/core/trust.ts
@@ -16,6 +16,7 @@ import {
   detectSubprocessSandboxCapabilities,
   selectSubprocessSandbox,
 } from './subprocessSandbox.js';
+import { VERSION } from '../version.js';
 
 /**
  * `dvalincode trust` — the product embodiment of the North Star: the tool issues its
@@ -25,9 +26,6 @@ import {
  *   可审计 — the tamper-evident audit trail and how to verify it
  *   透明   — version, runtime, and (in dev) the dependency surface
  */
-
-/** Keep in lockstep with the version in src/cli.ts. */
-const VERSION = '0.12.1';
 
 export type TrustReport = {
   version: string;

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,0 +1,8 @@
+/**
+ * Single source of truth for the DvalinCode version.
+ *
+ * Bump this on release (kept in step with package.json by the `release:` commit).
+ * Everything that reports a version — the CLI `--version`, the trust report, and
+ * the self-update check — imports from here so the copies can never drift.
+ */
+export const VERSION = '0.12.1';

--- a/tests/selfUpdate.test.ts
+++ b/tests/selfUpdate.test.ts
@@ -1,0 +1,162 @@
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import * as os from 'node:os';
+import { afterAll, describe, expect, it } from 'vitest';
+import {
+  assetName,
+  compareSemver,
+  detectInstall,
+  detectPlatform,
+  fetchLatestRelease,
+  isNewer,
+  parseSemver,
+  parseSums,
+  sha256File,
+  type GithubRelease,
+} from '../src/core/selfUpdate.js';
+
+const tmpDirs: string[] = [];
+afterAll(() => {
+  const { rmSync } = require('node:fs');
+  for (const d of tmpDirs) rmSync(d, { recursive: true, force: true });
+});
+
+describe('parseSemver', () => {
+  it('parses plain and v-prefixed versions', () => {
+    expect(parseSemver('v0.12.1')).toEqual({ major: 0, minor: 12, patch: 1 });
+    expect(parseSemver('1.2.3')).toEqual({ major: 1, minor: 2, patch: 3 });
+    expect(parseSemver('v1.0.0-rc.1')).toEqual({ major: 1, minor: 0, patch: 0, pre: 'rc.1' });
+  });
+
+  it('rejects non-semver tags (e.g. the gui-* track)', () => {
+    expect(parseSemver('gui-v0.12.0')).toBeNull();
+    expect(parseSemver('nightly')).toBeNull();
+    expect(parseSemver('')).toBeNull();
+  });
+});
+
+describe('compareSemver / isNewer', () => {
+  it('orders by major, minor, patch', () => {
+    expect(compareSemver(parseSemver('1.0.0')!, parseSemver('0.9.9')!)).toBeGreaterThan(0);
+    expect(compareSemver(parseSemver('0.12.1')!, parseSemver('0.12.0')!)).toBeGreaterThan(0);
+    expect(compareSemver(parseSemver('0.12.0')!, parseSemver('0.12.0')!)).toBe(0);
+  });
+
+  it('treats a stable release as newer than its prerelease', () => {
+    expect(compareSemver(parseSemver('1.0.0')!, parseSemver('1.0.0-rc.1')!)).toBeGreaterThan(0);
+  });
+
+  it('isNewer only fires on a strictly greater version', () => {
+    expect(isNewer('0.12.1', '0.12.0')).toBe(true);
+    expect(isNewer('0.12.0', '0.12.0')).toBe(false);
+    expect(isNewer('0.11.0', '0.12.0')).toBe(false);
+    expect(isNewer('garbage', '0.12.0')).toBe(false);
+  });
+});
+
+describe('detectPlatform / assetName', () => {
+  it('maps node platform/arch onto the published matrix', () => {
+    expect(detectPlatform('darwin', 'arm64')).toEqual({ os: 'macos', arch: 'arm64' });
+    expect(detectPlatform('linux', 'x64')).toEqual({ os: 'linux', arch: 'x64' });
+    expect(detectPlatform('win32', 'x64')).toEqual({ os: 'windows', arch: 'x64' });
+  });
+
+  it('returns null for unpublished targets', () => {
+    expect(detectPlatform('win32', 'arm64')).toBeNull();
+    expect(detectPlatform('freebsd', 'x64')).toBeNull();
+    expect(detectPlatform('linux', 'ppc64')).toBeNull();
+  });
+
+  it('builds the archive name matching build-release.sh', () => {
+    expect(assetName('0.12.1', { os: 'macos', arch: 'arm64' })).toBe('dvalincode-v0.12.1-macos-arm64.tar.gz');
+    expect(assetName('v0.12.1', { os: 'windows', arch: 'x64' })).toBe('dvalincode-v0.12.1-windows-x64.zip');
+  });
+});
+
+describe('parseSums / sha256File', () => {
+  it('parses shasum output keyed by basename', () => {
+    const text = [
+      'a'.repeat(64) + '  dvalincode-v0.12.1-macos-arm64.tar.gz',
+      'b'.repeat(64) + '  dvalincode-v0.12.1-linux-x64.tar.gz',
+    ].join('\n');
+    const sums = parseSums(text);
+    expect(sums.get('dvalincode-v0.12.1-macos-arm64.tar.gz')).toBe('a'.repeat(64));
+    expect(sums.size).toBe(2);
+  });
+
+  it('computes a file checksum that matches its SHA256SUMS entry', async () => {
+    const dir = mkdtempSync(path.join(os.tmpdir(), 'dvalincode-sum-'));
+    tmpDirs.push(dir);
+    const file = path.join(dir, 'artifact.bin');
+    writeFileSync(file, 'hello dvalin');
+    const hex = await sha256File(file);
+    expect(hex).toMatch(/^[0-9a-f]{64}$/);
+    const sums = parseSums(`${hex}  artifact.bin`);
+    expect(sums.get('artifact.bin')).toBe(hex);
+  });
+});
+
+describe('detectInstall', () => {
+  it('detects a compiled Bun binary as a binary install', () => {
+    const info = detectInstall({ isBun: true, execPath: '/Users/me/.dvalincode/dvalincode' });
+    expect(info.method).toBe('binary');
+    expect(info.root).toBe('/Users/me/.dvalincode');
+    expect(info.binary).toBe('/Users/me/.dvalincode/dvalincode');
+  });
+
+  it('detects a global npm install from the module path', () => {
+    const info = detectInstall({
+      isBun: false,
+      execPath: '/usr/local/bin/node',
+      moduleDir: '/usr/local/lib/node_modules/dvalincode/dist/commands',
+    });
+    expect(info.method).toBe('npm');
+  });
+
+  it('detects a source checkout', () => {
+    const info = detectInstall({
+      isBun: false,
+      execPath: '/usr/local/bin/node',
+      moduleDir: '/home/me/code/dvalincode/dist/commands',
+    });
+    expect(info.method).toBe('source');
+  });
+});
+
+describe('fetchLatestRelease', () => {
+  const release: GithubRelease = {
+    tag_name: 'v0.12.1',
+    prerelease: false,
+    draft: false,
+    html_url: 'https://github.com/arthurpanhku/dvalincode/releases/tag/v0.12.1',
+    published_at: '2026-07-07T00:00:00Z',
+    assets: [
+      { name: 'dvalincode-v0.12.1-macos-arm64.tar.gz', browser_download_url: 'https://example/a' },
+      { name: 'SHA256SUMS.txt', browser_download_url: 'https://example/s' },
+    ],
+  };
+
+  const fakeFetch = (body: unknown) =>
+    (async () => ({ ok: true, status: 200, statusText: 'OK', json: async () => body })) as never;
+
+  it('resolves the stable release via releases/latest', async () => {
+    const info = await fetchLatestRelease({ fetchImpl: fakeFetch(release) });
+    expect(info.version).toBe('0.12.1');
+    expect(info.assets.get('SHA256SUMS.txt')).toBe('https://example/s');
+  });
+
+  it('picks the highest semver and ignores the gui-* track for prereleases', async () => {
+    const list: GithubRelease[] = [
+      { ...release, tag_name: 'gui-v0.13.0' },
+      { ...release, tag_name: 'v0.12.1' },
+      { ...release, tag_name: 'v0.13.0-rc.1', prerelease: true },
+    ];
+    const info = await fetchLatestRelease({ includePrerelease: true, fetchImpl: fakeFetch(list) });
+    expect(info.version).toBe('0.13.0-rc.1');
+  });
+
+  it('throws on a non-ok response', async () => {
+    const failing = (async () => ({ ok: false, status: 404, statusText: 'Not Found', json: async () => ({}) })) as never;
+    await expect(fetchLatestRelease({ fetchImpl: failing })).rejects.toThrow(/404/);
+  });
+});


### PR DESCRIPTION
Adds a `dvalincode update` command (alias `upgrade`) so the CLI can find the latest release on GitHub and update itself — no re-running the installer.

## What it does
```
dvalincode update --check     # is a newer release out? (read-only)
dvalincode update             # download, verify checksum, swap in place
dvalincode update -y          # skip the confirm prompt
dvalincode update --prerelease
dvalincode update --json      # machine-readable status (implies --check)
```

It detects **how it was installed** and does the right thing:
- **binary** (`~/.dvalincode`) → downloads the matching `dvalincode-vX.Y.Z-<os>-<arch>` asset, **verifies it against the release's `SHA256SUMS.txt` before touching anything**, then atomically swaps the binary + `web/` in place. (A running Windows `.exe` can't replace itself → guided to the installer.)
- **npm** → `npm i -g dvalincode@<version>`.
- **source checkout** → points you at `git pull`.

Integrity-first, in keeping with the governance North Star: it verifies the download itself rather than trusting it, and prints the exact hosts it contacts (`api.github.com`, `github.com`).

## Files
- `src/core/selfUpdate.ts` — pure, dependency-injected logic (semver compare, asset naming, `SHA256SUMS` parse + file hash, install detection, release lookup). The GitHub fetch is injectable so it's unit-tested without network.
- `src/commands/update.ts` — orchestration (download / verify / extract / swap).
- `src/version.ts` — **single source of truth** for the version. `cli.ts` and `trust.ts` now import it. This directly fixes the drift found while cutting v0.12.1: both had been left at `0.11.0` while `package.json` moved to `0.12.0`.
- `tests/selfUpdate.test.ts` — 16 tests.
- README / README.zh-CN — new "Staying up to date" section; test badge → 229/40.

## Verification
- `npm run check` green — typecheck clean, **229/229** tests pass.
- `update --check`, `--json`, and `--prerelease` exercised **live against GitHub** (correctly reports up-to-date and detects `installMethod: source` in the dev checkout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)