### PR TITLE
fix(web): contain chat auto-scroll, add Fix-finding feedback, stop iCloud autofill popup

### DIFF
--- a/web/src/components/ChatThread.tsx
+++ b/web/src/components/ChatThread.tsx
@@ -12,10 +12,17 @@ type Props = {
 };
 
 export function ChatThread({ messages, connected, mode, onProceed }: Props) {
-  const bottomRef = useRef<HTMLDivElement>(null);
+  const scrollRef = useRef<HTMLDivElement>(null);
 
+  // Keep the thread pinned to the latest message — but scroll only this pane
+  // (not the whole document, as scrollIntoView would), and only when the user
+  // is already near the bottom, so sending from elsewhere (e.g. the sidebar's
+  // "Fix finding") or reading older history doesn't yank the viewport.
   useEffect(() => {
-    bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
+    const el = scrollRef.current;
+    if (!el) return;
+    const nearBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 120;
+    if (nearBottom) el.scrollTop = el.scrollHeight;
   }, [messages]);
 
   if (messages.length === 0) {
@@ -38,7 +45,7 @@ export function ChatThread({ messages, connected, mode, onProceed }: Props) {
   }
 
   return (
-    <div className="flex-1 overflow-y-auto px-6 py-6">
+    <div ref={scrollRef} className="flex-1 overflow-y-auto px-6 py-6">
       <div className="max-w-2xl mx-auto">
         {messages.map((msg, i) => {
           if (msg.role === 'compact') {
@@ -65,7 +72,6 @@ export function ChatThread({ messages, connected, mode, onProceed }: Props) {
             />
           );
         })}
-        <div ref={bottomRef} />
       </div>
     </div>
   );

--- a/web/src/components/Composer.tsx
+++ b/web/src/components/Composer.tsx
@@ -402,6 +402,15 @@ export function Composer({ onSend, onClear, onInterrupt, disabled, sending, plac
               placeholder={placeholder ?? 'Ask DvalinCode… ( / for commands · @ for files )'}
               disabled={disabled}
               rows={1}
+              // Keep macOS iCloud Keychain / password managers off the prompt box.
+              name="dvalincode-prompt"
+              autoComplete="off"
+              autoCorrect="off"
+              autoCapitalize="off"
+              spellCheck={false}
+              data-1p-ignore
+              data-lpignore="true"
+              data-form-type="other"
               className="flex-1 bg-transparent resize-none outline-none text-fg placeholder-muted-fg text-sm leading-relaxed min-h-[24px] disabled:opacity-50"
             />
             {sending ? (

--- a/web/src/components/LLMConfigModal.tsx
+++ b/web/src/components/LLMConfigModal.tsx
@@ -202,6 +202,16 @@ function PoolEntryRow({
               value={entry.apiKey ?? ''}
               onChange={e => onChange({ ...entry, apiKey: e.target.value, keySource: 'stored' })}
               placeholder={provider?.keyPlaceholder ?? 'api-key'}
+              // An API key isn't a login credential — keep iCloud Keychain and
+              // password managers from offering to autofill/save it.
+              name="dvalincode-api-key"
+              autoComplete="off"
+              autoCorrect="off"
+              autoCapitalize="off"
+              spellCheck={false}
+              data-1p-ignore
+              data-lpignore="true"
+              data-form-type="other"
               className="flex-1 bg-transparent text-xs text-fg placeholder-muted-fg font-mono outline-none"
             />
             <button type="button" onClick={() => setShowKey(v => !v)} className="text-muted-fg hover:text-fg">

--- a/web/src/components/SecurityRemediation.tsx
+++ b/web/src/components/SecurityRemediation.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
-import { AlertTriangle, FileSearch, FileWarning, GitBranch, Loader2, ShieldCheck, Upload, Wrench } from 'lucide-react';
+import { AlertTriangle, Check, FileSearch, FileWarning, GitBranch, Loader2, ShieldCheck, Upload, Wrench } from 'lucide-react';
 import {
   createRemediationWorktree,
   fetchRemediationCases,
@@ -191,7 +191,11 @@ export function SecurityRemediation({ cwd, onSend, onCwdChange }: Props) {
 
       {findings.length > 0 && (
         <div className="mt-1.5 flex flex-col gap-1">
-          {findings.map((finding) => (
+          {findings.map((finding) => {
+            const linkedCase = caseByFindingId.get(finding.id);
+            const fixing = linkedCase?.status === 'fixing';
+            const verified = linkedCase?.status === 'verified';
+            return (
             <div key={finding.id} className="group rounded-lg border border-border/60 bg-elevated/60 px-2 py-1.5">
               <div className="flex items-start gap-1.5">
                 <FileWarning size={11} className="text-orange-400/80 mt-0.5 flex-shrink-0" />
@@ -201,6 +205,11 @@ export function SecurityRemediation({ cwd, onSend, onCwdChange }: Props) {
                       {finding.securitySeverity ?? finding.severity}
                     </span>
                     <span className="text-[10px] font-mono text-muted-fg truncate">{finding.ruleId}</span>
+                    {linkedCase && (fixing || verified) && (
+                      <span className={`ml-auto flex-shrink-0 px-1.5 py-0.5 rounded border text-[9px] uppercase ${statusClass(linkedCase.status)}`}>
+                        {linkedCase.status}
+                      </span>
+                    )}
                   </div>
                   <div className="mt-1 text-[10px] text-fg line-clamp-2">
                     {finding.message}
@@ -212,10 +221,15 @@ export function SecurityRemediation({ cwd, onSend, onCwdChange }: Props) {
               </div>
               <button
                 onClick={() => void sendFinding(finding)}
-                className="mt-1.5 w-full flex items-center justify-center gap-1.5 px-2 py-1 rounded-md bg-orange-500/10 hover:bg-orange-500/20 text-orange-300 border border-orange-500/20 text-[10px] transition-colors"
+                title={fixing ? 'Sent to the agent — click to send again' : 'Send this finding to the agent to fix'}
+                className={`mt-1.5 w-full flex items-center justify-center gap-1.5 px-2 py-1 rounded-md border text-[10px] transition-colors ${
+                  fixing
+                    ? 'bg-blue-500/10 hover:bg-blue-500/20 text-blue-300 border-blue-500/20'
+                    : 'bg-orange-500/10 hover:bg-orange-500/20 text-orange-300 border-orange-500/20'
+                }`}
               >
-                <Wrench size={10} />
-                Fix finding
+                {fixing ? <Check size={10} /> : <Wrench size={10} />}
+                {fixing ? 'Fix requested' : 'Fix finding'}
               </button>
               <button
                 onClick={() => void prepareWorktree(finding)}
@@ -231,7 +245,8 @@ export function SecurityRemediation({ cwd, onSend, onCwdChange }: Props) {
                 </div>
               )}
             </div>
-          ))}
+            );
+          })}
           {hiddenCount > 0 && (
             <div className="text-[10px] text-muted-fg/50 px-2">
               {hiddenCount} more findings imported


### PR DESCRIPTION
Fixes two issues reported from the Code-mode security panel.

## 1. "Fix finding" jumped the whole page to the bottom
`ChatThread` auto-scrolled by calling `scrollIntoView()` on a bottom sentinel, which scrolls **every** scrollable ancestor including the document. So clicking **Fix finding** in the sidebar (which sends a message) lurched the entire layout down — even though the user was looking at the sidebar, and even if they'd scrolled up to read history.

Now it scrolls **only the thread pane**, and **only when already near the bottom**, so sending from elsewhere or reading older messages no longer yanks the viewport.

## 2. "Fix finding" gave no feedback → felt inert / broken
The click's effect only showed in the separate **Cases** list; the finding card itself never changed, so it looked like nothing happened (just the page jump). The card now reflects the linked case status (**FIXING/VERIFIED** badge) and the button switches to **"✓ Fix requested"** once sent.

## 3. macOS "enable iCloud password autofill" popup over the prompt box
The composer `<textarea>` and the LLM **API-key** input had no autofill opt-out, arming WKWebView's iCloud Keychain bar. Both now set `autoComplete="off"` + a benign `name` + `data-1p-ignore` / `data-lpignore` / `data-form-type="other"`. (An API key isn't a login credential; the prompt box isn't a field at all.)

## Verification
Ran the app (server + web) and reproduced the flow in-browser:
- Local scan → **Fix finding**: the card shows **"Fix requested"** with a FIXING badge, the prompt is sent to the agent, and **`window.scrollY` stays `0`** (no document jump). The other cards stay "Fix finding".
- Confirmed the composer textarea carries the autofill opt-out attributes in the DOM.
- `web` build (`tsc && vite build`) clean.

Web-only change; no backend/`src` files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)