### PR TITLE
fix(gui): blank desktop window; install DvalinCode.app from the one-line installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,7 +311,7 @@ not claim third-party ISO certification.
 curl -fsSL https://raw.githubusercontent.com/arthurpanhku/dvalincode/main/scripts/install.sh | bash
 ```
 
-Detects your OS + arch, downloads the right binary, installs to `~/.dvalincode/`, and adds it to your `PATH`. After reload:
+Detects your OS + arch, downloads the right binary, installs to `~/.dvalincode/`, and adds it to your `PATH`. On macOS it also installs the native **DvalinCode.app** into `/Applications` (skip with `DVALINCODE_NO_APP=1`), so the desktop window launches straight from Launchpad. After reload:
 
 ```sh
 source ~/.zshrc    # or ~/.bashrc

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -291,7 +291,7 @@ DvalinCode 维护项目级治理证据，便于开源用户和企业安全评审
 curl -fsSL https://raw.githubusercontent.com/arthurpanhku/dvalincode/main/scripts/install.sh | bash
 ```
 
-自动检测系统和架构、下载对应二进制、安装到 `~/.dvalincode/`、添加到 `PATH`。重新加载 shell 后：
+自动检测系统和架构、下载对应二进制、安装到 `~/.dvalincode/`、添加到 `PATH`。macOS 上还会把原生桌面应用 **DvalinCode.app** 装进 `/Applications`（可用 `DVALINCODE_NO_APP=1` 跳过），装完即可直接从启动台打开图形界面。重新加载 shell 后：
 
 ```sh
 source ~/.zshrc    # 或 ~/.bashrc

--- a/scripts/build-gui.sh
+++ b/scripts/build-gui.sh
@@ -35,7 +35,10 @@ case "$ICON_VARIANT" in
 esac
 ICON_SOURCE="${DVALINCODE_ICON_SOURCE:-web/public/app-icon-${ICON_VARIANT}.svg}"
 MACOS_ICON="${RELEASE_DIR}/tmp/AppIcon.icns"
+# Both entrypoints are compiled into one binary: the main entry runs the
+# embedded server, the worker entry runs the blocking webview loop.
 ENTRY="src/gui/index.ts"
+WORKER_ENTRY="src/gui/webview-worker.ts"
 
 # "-" = ad-hoc (default); "Developer ID Application: NAME (TEAMID)" for
 # notarization, wired from DVALINCODE_SIGN_IDENTITY by the release workflow.
@@ -128,7 +131,7 @@ for i in "${!BUN_TARGETS[@]}"; do
   $is_windows && bin_file="${bin_name}.exe" || bin_file="${bin_name}"
 
   echo "▶ Compiling ${bin_file}  (${bun_target})"
-  build_args=("$ENTRY" --compile --minify --target="$bun_target" --outfile "${RELEASE_DIR}/tmp/${bin_file}")
+  build_args=("$ENTRY" "$WORKER_ENTRY" --compile --minify --target="$bun_target" --outfile "${RELEASE_DIR}/tmp/${bin_file}")
   if $is_windows && is_windows_host; then
     build_args+=(--windows-icon="$ICON_SOURCE" --windows-title="DvalinCode" --windows-version="${VERSION}.0")
   fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -8,10 +8,15 @@
 #   2. Downloads the matching release archive from GitHub.
 #   3. Extracts to ~/.dvalincode/.
 #   4. Adds ~/.dvalincode/bin to your PATH (via ~/.bashrc / ~/.zshrc).
+#   5. macOS only: installs the desktop app (DvalinCode.app) into
+#      /Applications (or ~/Applications if /Applications isn't writable),
+#      from the latest gui-v* release.
 #
 # Environment variables:
-#   DVALINCODE_VERSION=v0.2.0   # pin to a specific version
-#   DVALINCODE_HOME=~/foo       # install to a different directory
+#   DVALINCODE_VERSION=v0.2.0       # pin to a specific version
+#   DVALINCODE_HOME=~/foo           # install to a different directory
+#   DVALINCODE_NO_APP=1             # macOS: skip installing DvalinCode.app
+#   DVALINCODE_GUI_VERSION=v0.12.0  # macOS: pin the desktop app version
 
 set -euo pipefail
 
@@ -150,6 +155,78 @@ case "$PLATFORM" in
     ;;
 esac
 
+# ── macOS: install DvalinCode.app (desktop GUI) ───────────────────────
+# The desktop app (native WKWebView window over the same engine as
+# `dvalincode serve`) ships from the separate gui-v* release track and is
+# fully self-contained. Best-effort: any failure here warns and continues,
+# so it can never break the CLI install. Set DVALINCODE_NO_APP=1 to skip.
+APP_PATH=""
+install_macos_app() {
+  local arch="${PLATFORM#macos-}"
+  local gui_tag gui_ver gui_file gui_url app_src dest
+
+  if [ -n "${DVALINCODE_GUI_VERSION:-}" ]; then
+    gui_tag="gui-${DVALINCODE_GUI_VERSION#gui-}"
+  else
+    gui_tag="$(curl -fsSL "https://api.github.com/repos/${REPO}/releases?per_page=30" 2>/dev/null \
+      | grep -oE '"tag_name": *"gui-v[^"]+"' | head -1 | sed -E 's/.*"(gui-v[^"]+)".*/\1/' || true)"
+  fi
+  if [ -z "$gui_tag" ]; then
+    warn "Could not find a desktop app (gui-v*) release — skipping DvalinCode.app."
+    return 0
+  fi
+
+  gui_ver="${gui_tag#gui-}"
+  gui_file="dvalincode-gui-${gui_ver}-macos-${arch}.tar.gz"
+  gui_url="https://github.com/${REPO}/releases/download/${gui_tag}/${gui_file}"
+
+  log "Downloading desktop app ${C_DIM}${gui_url}${C_RESET}"
+  if ! curl -fSL -o "${TMP}/${gui_file}" "$gui_url"; then
+    warn "Desktop app download failed — skipping DvalinCode.app."
+    return 0
+  fi
+  ok "Downloaded $(du -sh "${TMP}/${gui_file}" | cut -f1)"
+
+  mkdir -p "${TMP}/gui"
+  if ! tar xzf "${TMP}/${gui_file}" -C "${TMP}/gui"; then
+    warn "Could not extract the desktop app archive — skipping DvalinCode.app."
+    return 0
+  fi
+  app_src="$(find "${TMP}/gui" -maxdepth 2 -type d -name 'DvalinCode.app' | head -1)"
+  if [ -z "$app_src" ]; then
+    warn "DvalinCode.app not found inside the archive — skipping."
+    return 0
+  fi
+
+  if [ -d /Applications ] && [ -w /Applications ]; then
+    dest="/Applications"
+  else
+    dest="$HOME/Applications"
+    mkdir -p "$dest"
+  fi
+
+  rm -rf "${dest}/DvalinCode.app"
+  # ditto preserves the code signature; plain cp -R can invalidate it.
+  if command -v ditto >/dev/null 2>&1; then
+    ditto "$app_src" "${dest}/DvalinCode.app"
+  else
+    cp -R "$app_src" "${dest}/DvalinCode.app"
+  fi
+  if command -v xattr >/dev/null 2>&1; then
+    xattr -dr com.apple.quarantine "${dest}/DvalinCode.app" 2>/dev/null || true
+  fi
+  APP_PATH="${dest}/DvalinCode.app"
+  ok "Installed ${C_BOLD}${APP_PATH}${C_RESET}  (${gui_tag})"
+}
+
+case "$PLATFORM" in
+  macos-*)
+    if [ "${DVALINCODE_NO_APP:-0}" != "1" ]; then
+      install_macos_app
+    fi
+    ;;
+esac
+
 # ── PATH setup ────────────────────────────────────────────────────────
 ADD_TO_PATH=true
 case ":$PATH:" in
@@ -180,9 +257,14 @@ fi
 echo
 ok "${C_BOLD}DvalinCode ${VERSION} installed!${C_RESET}"
 echo
+if [ -n "$APP_PATH" ]; then
+  echo "  ${C_DIM}# Desktop app (native window) — find it in Launchpad, or:${C_RESET}"
+  echo "  ${C_BOLD}open \"${APP_PATH}\"${C_RESET}"
+  echo
+fi
 echo "  ${C_DIM}# Reload your shell:${C_RESET}"
 echo "  source ~/.zshrc    ${C_DIM}# or ~/.bashrc${C_RESET}"
 echo
-echo "  ${C_DIM}# Then start the GUI (opens in your browser):${C_RESET}"
+echo "  ${C_DIM}# Then start the CLI:${C_RESET}"
 echo "  ${C_BOLD}dvalincode${C_RESET}"
 echo

--- a/src/gui/index.ts
+++ b/src/gui/index.ts
@@ -2,18 +2,17 @@
 // web GUI and TUI. Starts the embedded server on an ephemeral localhost port
 // (no browser), then opens an OS-native webview (WKWebView / WebView2 /
 // WebKitGTK via webview-bun) pointed at it. This entry is built only with Bun
-// (`bun build --compile`); it is excluded from the tsc build because it imports
-// `bun:ffi` transitively. The CLI binary never imports this file, so it stays
-// webview-free.
-import { Webview } from 'webview-bun';
+// (`bun build --compile`, together with webview-worker.ts); it is excluded
+// from the tsc build because it imports `bun:ffi` transitively. The CLI binary
+// never imports this file, so it stays webview-free.
+//
+// The server runs here on the main thread; the webview runs in a worker,
+// because webview.run() blocks its thread until the window closes and would
+// otherwise starve the server's event loop (blank window).
 import { startServer } from '../server/index.js';
 
 const { port } = await startServer({ host: '127.0.0.1', port: 0, open: false });
 
-const webview = new Webview(false, { width: 1280, height: 832, hint: 0 /* NONE — resizable */ });
-webview.title = 'DvalinCode';
-webview.navigate(`http://127.0.0.1:${port}`);
-webview.run();
-
-// run() blocks until the window is closed; then tear everything down.
-process.exit(0);
+const worker = new Worker(new URL('./webview-worker.ts', import.meta.url).href);
+worker.onmessage = () => process.exit(0); // window closed — tear everything down
+worker.postMessage({ url: `http://127.0.0.1:${port}` });

--- a/src/gui/webview-worker.ts
+++ b/src/gui/webview-worker.ts
@@ -1,0 +1,17 @@
+// Webview thread for the desktop GUI. webview.run() is a blocking FFI call for
+// the lifetime of the window, so it must not share a thread with the embedded
+// HTTP server — with both on one thread the server's event loop never runs and
+// the window stays blank. The main thread (src/gui/index.ts) runs the server;
+// this worker runs the window. This is the split webview-bun documents for
+// running a web server alongside a webview.
+import { Webview } from 'webview-bun';
+
+declare var self: Worker;
+
+self.onmessage = (event: MessageEvent<{ url: string }>) => {
+  const webview = new Webview(false, { width: 1280, height: 832, hint: 0 /* NONE — resizable */ });
+  webview.title = 'DvalinCode';
+  webview.navigate(event.data.url);
+  webview.run(); // blocks this thread until the window is closed
+  self.postMessage('closed');
+};


### PR DESCRIPTION
## Summary

Two related changes that make the macOS desktop experience work end-to-end:

- **fix(gui): run webview in a worker so the embedded server can respond.** `webview.run()` is a blocking FFI call and ran on the same thread as the embedded HTTP server, so once the window opened the event loop was starved and every request — including the window's own page load — hung forever: the app showed a blank window. This affected every published `gui-v*` build. The fix uses the thread split webview-bun documents: server on the main thread, webview in a Bun worker, both entrypoints compiled into one binary.
- **feat(install): put DvalinCode.app into /Applications on macOS.** The one-line installer now also grabs the desktop app from the latest `gui-v*` release and installs it into `/Applications` (`~/Applications` when not writable), so the native window launches straight from Launchpad after a CLI install. Best-effort: any failure warns and the CLI install still succeeds. `DVALINCODE_NO_APP=1` skips it; `DVALINCODE_GUI_VERSION` pins the version.

## Verification

- Rebuilt the macOS arm64 app locally: with the window open, the server now answers `HTTP 200` in ~7 ms (previously every request hung indefinitely); the UI renders in the native window.
- Ran the installer end-to-end on macOS (sandboxed `$HOME`): CLI installed, `DvalinCode.app` (gui-v0.12.0) landed in `/Applications` with the logo icon and a valid ad-hoc signature.

## After merge

Tag `gui-v0.12.1` to publish fixed desktop builds — the published `gui-v0.12.0` binaries all have the blank-window bug, and the installer picks up the latest `gui-v*` automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)