### PR TITLE
fix: continue agent until task completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,21 @@ not claim third-party ISO certification.
 
 ---
 
+## ⭐ What's New in v0.12.4 — finish the task before stopping
+
+- **Process narration no longer ends a task** — responses such as “let me
+  verify the file” are recognized as pending work, and the agent immediately
+  continues with the promised action instead of treating them as a final answer.
+- **Truncated responses automatically recover** — provider finish reasons are
+  preserved, so output cut off by a token limit triggers another model step.
+- **Normal coding turns get room to finish** — the per-turn action limit is now
+  an emergency 100-action guard rather than a routine 15-action stopping point;
+  stricter organization policy limits still take precedence.
+- **Completion is explicit** — Code mode is instructed to return a tool-free
+  answer only after the requested work and focused validation are complete.
+
+---
+
 ## ⭐ What's New in v0.12.3 — resilient long-running Code mode
 
 - **Long coding turns keep going** — Code mode now compacts context during an

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dvalincode",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dvalincode",
-      "version": "0.12.3",
+      "version": "0.12.4",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.6.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dvalincode",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "description": "A local-first, provider-neutral CLI foundation for agentic coding workflows.",
   "type": "module",
   "license": "MIT",

--- a/src/agent/runner.ts
+++ b/src/agent/runner.ts
@@ -27,6 +27,24 @@ export class TurnInterruptedError extends Error {
   }
 }
 
+const PENDING_WORK_NUDGE = [
+  'Runtime completion check: your previous response described work that is still pending.',
+  'Continue the task now by calling the next required tool. Do not merely describe what you will do.',
+  'Only return a response without tool calls when the requested task and its focused validation are complete.',
+].join(' ');
+
+/** Detect a process update that must not be mistaken for a final answer. */
+export function looksLikePendingWork(content: string, finishReason?: string): boolean {
+  if (finishReason === 'length' || finishReason === 'max_tokens') return true;
+  const text = content.trim();
+  if (!text) return true;
+
+  const englishFutureAction = /\b(?:let me|i(?:'ll| will| need to| am going to)|next,?\s+i(?:'ll| will)|now,?\s+i(?:'ll| will))\s+(?:check|inspect|verify|validate|fix|edit|update|add|run|test|implement|continue|review|open|read|write|create|remove|ensure)\b/i;
+  const chineseFutureAction = /(?:让我|我(?:将|会|需要|准备)|接下来|下一步|现在(?:让我|我来|我将|我要)|继续)(?:检查|验证|确认|修复|修改|更新|添加|运行|测试|实现|继续|查看|读取|编写|创建|删除|确保|完成)/;
+  const explicitIncomplete = /\b(?:still need to|work remains|remaining steps?)\b|(?:还需要|尚未完成|仍需|待完成)/i;
+  return englishFutureAction.test(text) || chineseFutureAction.test(text) || explicitIncomplete.test(text);
+}
+
 export class AgentRunner {
   private provider: ProviderAdapter;
   private registry: ToolRegistry;
@@ -154,7 +172,14 @@ export class AgentRunner {
           toolCalls = this.parseToolCalls(response.content);
         }
         if (toolCalls.length === 0) {
-          // No tool calls — this is the final response
+          // Some models occasionally emit a narration such as "let me verify
+          // the file" without the promised tool call. Treat that as an
+          // incomplete checkpoint and immediately ask for the actual action.
+          if (looksLikePendingWork(response.content, response.finishReason)) {
+            messages.push({ role: 'system', content: PENDING_WORK_NUDGE });
+            continue;
+          }
+          // A tool-free response with no pending-work signal is the final answer.
           return { messages, finalResponse: response.content, iterationsUsed: this.iterationCount, usage: totalUsage };
         }
 

--- a/src/agent/session.ts
+++ b/src/agent/session.ts
@@ -352,6 +352,7 @@ async function buildSystemPrompt(opts: {
     '- Prefer focused, surgical changes.',
     '- For simple requests, take the shortest direct path. Do not create a plan, scan broadly, or use extra tools unless the task requires it.',
     '- Use the fewest tool calls needed, run focused validation, and stop when the requested result is complete.',
+    '- A response without a tool call ends the turn. Never use it to announce work you have not performed. If anything remains, call the next tool now; only give the final response after the task and focused validation are complete.',
   ]
     .filter(Boolean)
     .join('\n');

--- a/src/agent/types.ts
+++ b/src/agent/types.ts
@@ -32,7 +32,10 @@ export const DEFAULT_TURN_CONFIG: TurnConfig = {
   // previous limit silently returned the last (often empty) tool-call message
   // as a successful response, which looked like a random interruption.
   maxIterations: 40,
-  maxToolCallsPerTurn: 15,
+  // This is an emergency runaway guard, not a normal stopping point. Simple
+  // tasks are kept small by prompt guidance; real coding tasks may legitimately
+  // need more than 15 actions before they are complete.
+  maxToolCallsPerTurn: 100,
   contextTokenLimit: 128_000,
   compactThreshold: 0.7,
 };

--- a/src/providers/openaiCompatible.ts
+++ b/src/providers/openaiCompatible.ts
@@ -78,6 +78,7 @@ export function createOpenAICompatibleProvider(config: OpenAIConfig): ProviderAd
     let lineBuffer = '';
     const toolCallBuffers = new Map<number, { id: string; name: string; arguments: string }>();
     let usage: { prompt_tokens: number; completion_tokens: number } | undefined;
+    let finishReason: string | undefined;
 
     try {
       while (true) {
@@ -106,8 +107,13 @@ export function createOpenAICompatibleProvider(config: OpenAIConfig): ProviderAd
             usage = u;
           }
 
-          const choices = chunk.choices as Array<{ delta?: { content?: string; tool_calls?: Array<{ index: number; id?: string; function?: { name?: string; arguments?: string } }> } }> | undefined;
-          const delta = choices?.[0]?.delta;
+          const choices = chunk.choices as Array<{
+            delta?: { content?: string; tool_calls?: Array<{ index: number; id?: string; function?: { name?: string; arguments?: string } }> };
+            finish_reason?: string | null;
+          }> | undefined;
+          const choice = choices?.[0];
+          if (choice?.finish_reason) finishReason = choice.finish_reason;
+          const delta = choice?.delta;
           if (!delta) continue;
 
           // Stream text content
@@ -146,6 +152,7 @@ export function createOpenAICompatibleProvider(config: OpenAIConfig): ProviderAd
     return {
       content,
       model,
+      finishReason,
       toolCalls: toolCalls.length > 0 ? toolCalls : undefined,
       usage: usage ? { inputTokens: usage.prompt_tokens, outputTokens: usage.completion_tokens } : undefined,
     };
@@ -165,12 +172,16 @@ export function createOpenAICompatibleProvider(config: OpenAIConfig): ProviderAd
     }
 
     const data = (await response.json()) as {
-      choices: Array<{ message: { content: string; tool_calls?: Array<{ id: string; type: string; function: { name: string; arguments: string } }> } }>;
+      choices: Array<{
+        finish_reason?: string | null;
+        message: { content: string; tool_calls?: Array<{ id: string; type: string; function: { name: string; arguments: string } }> };
+      }>;
       model: string;
       usage?: { prompt_tokens: number; completion_tokens: number };
     };
 
-    const choice = data.choices[0]?.message;
+    const resultChoice = data.choices[0];
+    const choice = resultChoice?.message;
     let toolCalls: ToolCall[] | undefined;
     if (choice?.tool_calls && choice.tool_calls.length > 0) {
       toolCalls = choice.tool_calls.map(tc => ({
@@ -183,6 +194,7 @@ export function createOpenAICompatibleProvider(config: OpenAIConfig): ProviderAd
     return {
       content: choice?.content ?? '',
       model: data.model,
+      finishReason: resultChoice?.finish_reason ?? undefined,
       toolCalls,
       usage: data.usage
         ? { inputTokens: data.usage.prompt_tokens, outputTokens: data.usage.completion_tokens }

--- a/src/providers/types.ts
+++ b/src/providers/types.ts
@@ -55,6 +55,8 @@ export type ChatRequest = {
 export type ChatResponse = {
   content: string;
   model: string;
+  /** Provider stop reason, e.g. stop, tool_calls, or length. */
+  finishReason?: string;
   toolCalls?: ToolCall[];
   usage?: {
     inputTokens: number;

--- a/src/version.ts
+++ b/src/version.ts
@@ -5,4 +5,4 @@
  * Everything that reports a version — the CLI `--version`, the trust report, and
  * the self-update check — imports from here so the copies can never drift.
  */
-export const VERSION = '0.12.3';
+export const VERSION = '0.12.4';

--- a/tests/agent.test.ts
+++ b/tests/agent.test.ts
@@ -7,7 +7,7 @@ import type { ChatMessage, ChatRequest, ProviderAdapter, ChatResponse } from '..
 import { ToolRegistry } from '../src/tools/registry.js';
 import { createDvalinContext } from '../src/core/context.js';
 import type { Tool } from '../src/tools/types.js';
-import { TurnInterruptedError } from '../src/agent/runner.js';
+import { looksLikePendingWork, TurnInterruptedError } from '../src/agent/runner.js';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -48,6 +48,61 @@ function createEchoTool(): Tool<{ text: string }> {
 // ---------------------------------------------------------------------------
 
 describe('AgentRunner', () => {
+  it('recognizes process narration as unfinished work', () => {
+    expect(looksLikePendingWork('现在让我验证 model.py 末尾的完整性：')).toBe(true);
+    expect(looksLikePendingWork('Let me inspect the remaining tests.')).toBe(true);
+    expect(looksLikePendingWork('Partial output', 'length')).toBe(true);
+    expect(looksLikePendingWork('Implemented the fix and all focused tests pass.')).toBe(false);
+    expect(looksLikePendingWork('I will explain the result below.')).toBe(false);
+  });
+
+  it('continues when a tool-free response only announces the next action', async () => {
+    const { AgentRunner } = await import('../src/agent/runner.js');
+    const provider = createMockProvider([
+      '现在让我验证文件末尾的完整性。',
+      '实现已完成，测试通过。',
+    ]);
+    const runner = new AgentRunner({
+      provider,
+      registry: new ToolRegistry(),
+      context: createDvalinContext(),
+      config: { maxIterations: 4, maxToolCallsPerTurn: 100, contextTokenLimit: 128_000, compactThreshold: 0.7 },
+      systemPrompt: 'Complete the task.',
+    });
+
+    const result = await runner.runTurn('修复这个问题', []);
+    expect(result.finalResponse).toBe('实现已完成，测试通过。');
+    expect(result.iterationsUsed).toBe(2);
+    expect(result.messages.some((message) =>
+      message.role === 'system' && message.content.includes('Runtime completion check'),
+    )).toBe(true);
+  });
+
+  it('continues after a provider truncates a tool-free response', async () => {
+    const { AgentRunner } = await import('../src/agent/runner.js');
+    let calls = 0;
+    const provider: ProviderAdapter = {
+      name: 'truncating',
+      async chat() {
+        calls++;
+        return calls === 1
+          ? { content: 'partial', model: 'mock', finishReason: 'length' }
+          : { content: 'complete', model: 'mock', finishReason: 'stop' };
+      },
+    };
+    const runner = new AgentRunner({
+      provider,
+      registry: new ToolRegistry(),
+      context: createDvalinContext(),
+      config: { maxIterations: 4, maxToolCallsPerTurn: 100, contextTokenLimit: 128_000, compactThreshold: 0.7 },
+      systemPrompt: 'Complete the task.',
+    });
+
+    const result = await runner.runTurn('finish it', []);
+    expect(result.finalResponse).toBe('complete');
+    expect(calls).toBe(2);
+  });
+
   it('parses @tool syntax from LLM response', async () => {
     // The provider responds with a single tool call — no further iterations needed
     const provider = createEchoProvider(

--- a/tests/providers.test.ts
+++ b/tests/providers.test.ts
@@ -94,6 +94,22 @@ describe('governed provider egress', () => {
     expect(fetchMock).toHaveBeenCalledOnce();
   });
 
+  it('preserves the provider finish reason for completion gating', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(JSON.stringify({
+      choices: [{ finish_reason: 'length', message: { content: 'partial' } }],
+      model: 'test-model',
+    }), { status: 200, headers: { 'content-type': 'application/json' } }));
+    vi.stubGlobal('fetch', fetchMock);
+    const { createOpenAICompatibleProvider } = await import('../src/providers/openaiCompatible.js');
+    const provider = createOpenAICompatibleProvider({ baseUrl: 'https://provider.example/v1', model: 'm' });
+
+    const response = await provider.chat({
+      messages: [{ role: 'user', content: 'hello' }],
+      runtime: { policy: resolvePolicy([{ network: 'on' }]) },
+    });
+    expect(response.finishReason).toBe('length');
+  });
+
   it('allows an explicitly configured localhost gateway', async () => {
     const fetchMock = vi.fn().mockResolvedValue(completionResponse('local-ok'));
     vi.stubGlobal('fetch', fetchMock);


### PR DESCRIPTION
## What changed

- detect tool-free process narration and automatically continue the agent loop
- preserve provider finish reasons so token-truncated output resumes
- raise the normal action budget from 15 to an emergency 100-action guard
- make completion requirements explicit in the Code mode prompt
- bump the release version to v0.12.4

## Root cause

The runner treated every response without tool calls as final, even when the text only announced the next action. OpenAI-compatible finish reasons were also discarded, so a response truncated for length could look complete. The existing 15-action default could additionally pause legitimate coding work too early.

## Validation

- npm run build
- npm run typecheck
- npm test (41 files, 239 tests)