### PR TITLE
fix: auto-approve bypass permissions

### DIFF
--- a/src/agent/modes.ts
+++ b/src/agent/modes.ts
@@ -43,14 +43,14 @@ export const MODE_PROMPT: Record<AgentMode, string> = {
   cowork:
     'You are in Cowork mode. Work collaboratively. Briefly explain your plan before making changes. Prefer focused, surgical edits. File writes and shell commands require user approval.',
   code:
-    'You are in Code mode. Work autonomously to complete the task efficiently. Use all available tools as needed. Git and GitHub CLI (gh) operations are supported through shell. For git fetch/pull/push/clone, gh operations, or package downloads that need outbound network access, use shell with networkAccess="unrestricted" so the user can approve running outside the local subprocess network sandbox when required.',
+    'You are in Code mode. Work autonomously to complete the task efficiently. Use all available tools as needed. Git and GitHub CLI (gh) operations are supported through shell. For git fetch/pull/push/clone, gh operations, or package downloads that need outbound network access, use shell with networkAccess="unrestricted"; the selected permission mode determines whether runtime approval is required.',
 };
 
 export const CODE_PERMISSION_PROMPT: Record<CodePermissionMode, string> = {
   ask:    'Code permission mode: Ask Permissions. Request approval before edits, deletes, or shell commands.',
   plan:   'Code permission mode: Plan Mode. Create a clear plan only. Do not write files, delete files, or run shell commands.',
   auto:   'Code permission mode: Auto Mode. Complete the task autonomously with normal tool access.',
-  bypass: 'Code permission mode: Bypass Permissions. Complete the task without approval prompts. When policy permits, shell commands may run with unrestricted subprocess network access instead of the local network sandbox.',
+  bypass: 'Code permission mode: Bypass Permissions. Automatically approve every runtime permission request without prompting, including unrestricted subprocess network access. Organization policy restrictions remain enforced.',
 };
 
 /** Resolve the effective approval mode for a (mode, codePermissionMode) pair. */

--- a/src/core/context.ts
+++ b/src/core/context.ts
@@ -55,7 +55,13 @@ export function createDvalinContext(options: DvalinContextOptions = {}): DvalinC
     allowExecute,
     maxBytes: options.maxBytes ?? 256_000,
     approvalMode: mode ?? 'full-auto',
-    requestApproval: options.requestApproval,
+    // Bypass is a runtime-wide auto-approval mode, not merely permission to
+    // use write/execute tools. Keep this at the shared context chokepoint so
+    // current and future approval sources cannot accidentally surface a
+    // per-action prompt (including unrestricted shell network access).
+    requestApproval: mode === 'bypass'
+      ? async () => true
+      : options.requestApproval,
     audit: options.audit,
     policy: options.policy ?? permissivePolicy(),
     signal: options.signal,

--- a/tests/agent/session.test.ts
+++ b/tests/agent/session.test.ts
@@ -10,6 +10,7 @@ import {
 } from '../../src/agent/modes.js';
 import { expandAtMentions } from '../../src/agent/session.js';
 import { createDefaultToolRegistry } from '../../src/tools/registry.js';
+import { createDvalinContext } from '../../src/core/context.js';
 
 describe('resolveApprovalMode', () => {
   it('maps non-code modes directly', () => {
@@ -44,6 +45,22 @@ describe('resolveApprovalMode', () => {
     }
     expect(MODE_TOOLS.cowork).toBeNull();
     expect(CODE_PERMISSION_APPROVAL.plan).toBe('readonly');
+  });
+
+  it('auto-approves every runtime request in bypass mode', async () => {
+    let prompts = 0;
+    const context = createDvalinContext({
+      approvalMode: 'bypass',
+      requestApproval: async () => {
+        prompts++;
+        return false;
+      },
+    });
+
+    await expect(context.requestApproval?.('approval-1', 'shell_sandbox_bypass', {
+      networkAccess: 'unrestricted',
+    })).resolves.toBe(true);
+    expect(prompts).toBe(0);
   });
 });
 

--- a/tests/policyEnforcement.test.ts
+++ b/tests/policyEnforcement.test.ts
@@ -84,6 +84,17 @@ describe('policy enforcement at the tool chokepoint', () => {
     await expect(registry().run('fake_shell', { command: 'ls' }, ctx)).rejects.toBeInstanceOf(PolicyViolationError);
   });
 
+  it('does not let bypass auto-approval override organization policy', async () => {
+    const ctx = createDvalinContext({
+      approvalMode: 'bypass',
+      policy: resolvePolicy([{ commands: { deny: ['^rm\\b'] } }]),
+      requestApproval: async () => true,
+    });
+    await expect(registry().run('fake_shell', { command: 'rm -rf build' }, ctx)).rejects.toBeInstanceOf(
+      PolicyViolationError,
+    );
+  });
+
   it('reports the offending rule on the error', async () => {
     const ctx = createDvalinContext({
       approvalMode: 'full-auto',


### PR DESCRIPTION
## What changed

- make Bypass Permissions auto-approve every runtime permission request at the shared context boundary
- include unrestricted subprocess network access in the no-prompt behavior
- clarify Code mode prompts so the selected permission mode controls approval behavior
- retain organization policy enforcement even while interactive approvals are bypassed

## Why

The shell tool already special-cased unrestricted network access, but Bypass was not implemented as a runtime-wide auto-approval rule. Other or future approval sources could therefore still surface per-action prompts.

## Validation

- npm run build
- npm run typecheck
- npm test (41 files, 241 tests)