### PR TITLE
feat(eval): Phase 2 — official SWE-bench Docker evaluation harness

### DIFF
--- a/eval/swebench/README.md
+++ b/eval/swebench/README.md
@@ -48,6 +48,38 @@ enforced and every tool call lands in the audit chain (`dvalincode report`).
 Provider/model come from `~/.dvalincode/config.json` and are recorded in the
 result.
 
+### Phase 2 — official Docker evaluation
+
+The local-venv path above measures the *agent under governance*, but it grades
+in a `python3.11` venv that can't reproduce each repo's intended environment —
+**40–60% of Lite instances can't even run their tests there** (see
+[`results/FINDINGS.md`](results/FINDINGS.md)). Phase 2 keeps the agent run on the
+host under full governance and moves only the **grading** into the official
+SWE-bench per-instance Docker images, so the resolved verdict is comparable to
+published numbers *and* every instance gets a faithful environment.
+
+```bash
+# 1. Produce patches for the whole selection. --no-precheck skips the venv gate
+#    so env-broken instances still run and yield a patch to grade:
+bash eval/swebench/run-batch.sh --tier friendly --sample 30 --no-precheck
+
+# 2. Grade those patches in Docker with the official harness:
+bash eval/swebench/run-eval-docker.sh results/batches/<ts>
+#    → predictions.jsonl · <model>.<run_id>.json (official report) · SUMMARY.official.md
+```
+
+Requires **Docker** (daemon running) and the **`swebench`** package — the script
+bootstraps it into a cached `.venv-tools` venv, or point `SWEBENCH_PY` at a
+python that already has it. `SUMMARY.official.md` puts the official resolved rate
+next to the on-host governance/cost metrics (tokens, iterations, audit head) and
+flags every instance where the local venv and official Docker disagree.
+
+| Helper | Role |
+|---|---|
+| `predictions.mjs` | batch `agent.diff`s → SWE-bench `predictions.jsonl` |
+| `run-eval-docker.sh` | preflight (docker + swebench) → `swebench.harness.run_evaluation` → summary |
+| `summarize-official.mjs` | official report × our per-instance records → `SUMMARY.official.md` |
+
 ## What gets recorded
 
 `results/<instance_id>/<timestamp>/`:
@@ -65,10 +97,12 @@ result.
 
 ## Honest caveats (read before quoting numbers)
 
-- **Not the official harness.** Official SWE-bench evaluation runs each
-  instance in a purpose-built Docker image; this harness uses a local venv
-  (`PYTHON`, default `python3.11`). Environment drift is possible. Use the
-  official harness for any reportable/comparable numbers.
+- **Two harnesses, two numbers.** The default local-venv path
+  (`run-one`/`run-batch`) is a fast smoke harness — a `python3.11` venv,
+  environment drift possible, **not comparable** to published numbers. For
+  reportable/comparable numbers use **Phase 2** (`run-eval-docker.sh`), which
+  grades the same patches in the official per-instance Docker images. Quote
+  local-venv numbers only with this caveat.
 - **pytest-runnable repos only.** Full pytest ids are used as-is; bare
   test-name entries (sympy style) are resolved against the test file in
   `test_patch` — only when it touches exactly one file. Django-style ids and

--- a/eval/swebench/predictions.mjs
+++ b/eval/swebench/predictions.mjs
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+// Collect a batch's per-instance agent patches into a SWE-bench predictions
+// file for the official Docker harness (Phase 2). One JSON object per line:
+//   {"instance_id", "model_name_or_path", "model_patch"}
+// model_patch is the agent's staged diff (agent.diff) — the same repo-relative
+// git diff the official harness applies at /testbed in each per-instance image.
+//
+// Usage: node predictions.mjs <batch-dir> [out.jsonl]
+// Env:   MODEL_NAME=dvalincode   (model_name_or_path recorded in predictions)
+import { readdirSync, readFileSync, writeFileSync, existsSync } from 'node:fs';
+import path from 'node:path';
+
+const batch = process.argv[2];
+if (!batch) {
+  console.error('usage: node predictions.mjs <batch-dir> [out.jsonl]');
+  process.exit(2);
+}
+const out = process.argv[3] || path.join(batch, 'predictions.jsonl');
+const modelName = process.env.MODEL_NAME || 'dvalincode';
+
+const lines = [];
+let empty = 0;
+let missing = 0;
+const agentModels = new Set();
+for (const ent of readdirSync(batch, { withFileTypes: true })) {
+  if (!ent.isDirectory()) continue;
+  const dir = path.join(batch, ent.name);
+  const diffPath = path.join(dir, 'agent.diff');
+  if (!existsSync(diffPath)) { missing++; continue; } // agent never ran (env-skipped)
+  const patch = readFileSync(diffPath, 'utf8');
+  if (!patch.trim()) { empty++; continue; }            // agent produced no change
+
+  // instance_id from result.json (authoritative), else the directory name.
+  let instanceId = ent.name;
+  const rj = path.join(dir, 'result.json');
+  if (existsSync(rj)) {
+    try {
+      const r = JSON.parse(readFileSync(rj, 'utf8'));
+      if (r.instance_id) instanceId = r.instance_id;
+      if (r.agent?.model) agentModels.add(r.agent.model);
+    } catch { /* keep the directory-name fallback */ }
+  }
+  lines.push(JSON.stringify({
+    instance_id: instanceId,
+    model_name_or_path: modelName,
+    model_patch: patch,
+  }));
+}
+
+if (!lines.length) {
+  console.error(`no non-empty agent.diff found under ${batch}`);
+  process.exit(1);
+}
+writeFileSync(out, lines.join('\n') + '\n');
+console.log(`wrote ${lines.length} prediction(s) → ${out}`);
+console.log(`  model_name_or_path: ${modelName}${agentModels.size ? `  (agent model(s): ${[...agentModels].join(', ')})` : ''}`);
+if (empty)   console.log(`  skipped ${empty} instance(s) with an empty patch (agent produced no change)`);
+if (missing) console.log(`  skipped ${missing} dir(s) with no agent.diff (agent never ran — env-skipped)`);

--- a/eval/swebench/results/FINDINGS.md
+++ b/eval/swebench/results/FINDINGS.md
@@ -2,9 +2,41 @@
 
 Cross-run observations from the smoke harness. One section per run; newest
 first. Numbers here are from the **local-venv smoke harness** (see
-[README](../README.md) caveats) — not official-harness comparable.
+[README](../README.md) caveats) — not official-harness comparable, *except*
+Phase 2 sections, which grade in the official Docker harness.
 
 <!-- runs appended below -->
+
+## 2026-07-14 — Phase 2: official Docker evaluation harness landed (infra; awaiting a live run)
+
+New path that fixes the two gaps every run below hit: the **local venv can't
+reproduce each repo's environment** (43–60% `env_broken_at_test`) and its
+numbers are **not official-comparable**. Phase 2 keeps the agent run on the host
+under full governance (seatbelt + audit chain) and moves only the **grading**
+into the official SWE-bench per-instance Docker images.
+
+**Flow** — `run-batch.sh … --no-precheck` (agent runs on every instance, even
+env-broken ones, producing a patch) → `run-eval-docker.sh <batch>` →
+`predictions.jsonl` → `swebench.harness.run_evaluation` (per-instance Docker) →
+`SUMMARY.official.md` (official resolved rate × on-host tokens/iterations/audit
+head, flagging every local-vs-official drift).
+
+**Why grade-only, not agent-in-container.** The eval measures the *governance
+tax*, which lives in the macOS seatbelt sandbox + audit chain — both host-side.
+Running the agent inside a Linux container would forfeit exactly what we're
+measuring, so the agent stays on host; only the verdict moves to Docker.
+
+**Status: infrastructure complete and structurally verified; no official numbers
+yet.** The dev host had no Docker daemon, so the live Docker run is pending.
+Verified without Docker: predictions generation (empty-patch and env-skipped
+instances correctly excluded), the official-report parser + `SUMMARY.official.md`
+incl. drift detection, preflight (fails fast + actionable when the daemon is
+down), and `bash -n` / `node --check` on all scripts. The `--no-precheck` toggle
+is gated so the default local-venv path stays byte-identical. **First real
+Phase 2 numbers land here after a run on a Docker-capable host.**
+
+New files: `predictions.mjs`, `run-eval-docker.sh`, `summarize-official.mjs`;
+`run-one.sh` / `run-batch.sh` gained the gated `--no-precheck` / `SKIP_PRECHECK`.
 
 ## 2026-07-14 — friendly-tier baseline · ×30 · **5/30 (16.7%)** · **5/16 (31%) fair**
 

--- a/eval/swebench/run-batch.sh
+++ b/eval/swebench/run-batch.sh
@@ -9,6 +9,9 @@
 # Usage:
 #   bash eval/swebench/run-batch.sh [--repo sympy] [--limit N] [--sample N]
 #                                   [--resume results/batches/<ts>] [--ids a,b,c]
+#                                   [--tier friendly|heavy|old-python] [--no-precheck]
+#   --no-precheck: skip the local venv gate so the agent runs on every instance;
+#                  grade the patches faithfully with run-eval-docker.sh (Phase 2).
 # Env: PYTHON=python3.11  AGENT_TIMEOUT_MIN=15  INSTANCE_TIMEOUT_MIN=20
 set -euo pipefail
 
@@ -18,7 +21,7 @@ PYTHON="${PYTHON:-python3.11}"
 AGENT_TIMEOUT_MIN="${AGENT_TIMEOUT_MIN:-15}"
 INSTANCE_TIMEOUT_MIN="${INSTANCE_TIMEOUT_MIN:-20}"
 
-REPO_FILTER="" LIMIT="" SAMPLE="" RESUME="" IDS="" TIER=""
+REPO_FILTER="" LIMIT="" SAMPLE="" RESUME="" IDS="" TIER="" NOPRE=0
 while [ $# -gt 0 ]; do
   case "$1" in
     --repo)   REPO_FILTER="$2"; shift 2 ;;
@@ -27,6 +30,7 @@ while [ $# -gt 0 ]; do
     --resume) RESUME="$2"; shift 2 ;;
     --ids)    IDS="$2"; shift 2 ;;
     --tier)   TIER="$2"; shift 2 ;;   # friendly | heavy | old-python
+    --no-precheck) NOPRE=1; shift ;;  # skip venv precheck; grade via run-eval-docker.sh (Phase 2)
     *) echo "unknown arg: $1" >&2; exit 2 ;;
   esac
 done
@@ -92,6 +96,7 @@ run_instance() { # $1=instance_id $2=results_dir
   set -m
   (
     RESULTS_DIR="$res" PYTHON="$PYTHON" AGENT_TIMEOUT_MIN="$AGENT_TIMEOUT_MIN" \
+      SKIP_PRECHECK="$NOPRE" \
       bash "$HERE/run-one.sh" "$id" > "$res/run.log" 2>&1
   ) &
   pid=$!

--- a/eval/swebench/run-eval-docker.sh
+++ b/eval/swebench/run-eval-docker.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# Phase 2 — official SWE-bench Docker evaluation of a batch's agent patches.
+#
+# The local-venv harness (run-one/run-batch) grades patches in a python3.11
+# venv, which cannot reproduce each repo's intended environment — 40-60% of
+# Lite instances can't even run their tests there (see results/FINDINGS.md).
+# This script hands the agent's patches to the OFFICIAL SWE-bench harness,
+# which builds a per-instance Docker image with the correct interpreter and
+# frozen dependencies and returns a resolved verdict that IS comparable to
+# published SWE-bench Lite numbers.
+#
+# The agent itself still ran on the host under full governance (seatbelt
+# sandbox + audit chain); only the *grading* moves into Docker. So this
+# measures the governance tax against a faithful denominator.
+#
+# Usage:
+#   bash eval/swebench/run-eval-docker.sh <batch-dir>
+#        [--run-id ID] [--max-workers N] [--dataset NAME]
+# Env:
+#   PYTHON=python3.11         interpreter used to bootstrap the swebench tool venv
+#   SWEBENCH_PY=/path/python  use an existing python that already has swebench
+#                             (skips the tool-venv bootstrap)
+#   MODEL_NAME=dvalincode     model_name_or_path recorded in predictions
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PYTHON="${PYTHON:-python3.11}"
+
+BATCH="${1:?usage: run-eval-docker.sh <batch-dir> [--run-id ID] [--max-workers N]}"
+shift || true
+[ -d "$BATCH" ] || { echo "batch dir not found: $BATCH" >&2; exit 1; }
+BATCH="$(cd "$BATCH" && pwd)"   # absolute — the harness runs from inside it
+
+RUN_ID="dvalincode-$(basename "$BATCH")"
+WORKERS=4
+DATASET="princeton-nlp/SWE-bench_Lite"
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --run-id)      RUN_ID="$2"; shift 2 ;;
+    --max-workers) WORKERS="$2"; shift 2 ;;
+    --dataset)     DATASET="$2"; shift 2 ;;
+    *) echo "unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+step() { printf '\n=== %s ===\n' "$*"; }
+
+# ── Preflight: fail fast with actionable messages ───────────────────────────
+step "preflight"
+command -v docker >/dev/null 2>&1 || { echo "docker not found — install Docker and start the daemon" >&2; exit 1; }
+docker info >/dev/null 2>&1 || { echo "docker daemon not reachable — start Docker Desktop / dockerd" >&2; exit 1; }
+
+# swebench interpreter: an existing one (SWEBENCH_PY) or a cached tool venv,
+# mirroring fetch-dataset.mjs's .venv-tools pattern.
+if [ -n "${SWEBENCH_PY:-}" ]; then
+  PY="$SWEBENCH_PY"
+else
+  VENV="$HERE/.venv-tools"
+  PY="$VENV/bin/python"
+  if [ ! -x "$PY" ] || ! "$PY" -c "import swebench" 2>/dev/null; then
+    echo "provisioning tool venv (swebench)…"
+    [ -x "$PY" ] || "$PYTHON" -m venv "$VENV"
+    "$PY" -m pip -q install -U pip
+    "$PY" -m pip -q install swebench
+  fi
+fi
+"$PY" -c "import swebench" 2>/dev/null || { echo "swebench not importable via $PY — run: $PY -m pip install swebench" >&2; exit 1; }
+echo "docker:   $(docker --version)"
+echo "swebench: $("$PY" -c 'import importlib.metadata as m; print(m.version("swebench"))' 2>/dev/null || echo '?') via $PY"
+
+# ── Predictions from the batch's agent patches ──────────────────────────────
+step "collect predictions"
+PRED="$BATCH/predictions.jsonl"
+MODEL_NAME="${MODEL_NAME:-dvalincode}" node "$HERE/predictions.mjs" "$BATCH" "$PRED"
+
+# ── Official evaluation (per-instance Docker images) ────────────────────────
+step "swebench.harness.run_evaluation  ·  run_id=$RUN_ID  ·  workers=$WORKERS"
+# Run from inside the batch dir so the report json + logs/ land there (the
+# harness writes <model_name_or_path>.<run_id>.json into the current directory).
+( cd "$BATCH" && "$PY" -m swebench.harness.run_evaluation \
+    --dataset_name "$DATASET" \
+    --predictions_path "$PRED" \
+    --max_workers "$WORKERS" \
+    --run_id "$RUN_ID" )
+
+REPORT="$(ls -t "$BATCH"/*."$RUN_ID".json 2>/dev/null | head -1 || true)"
+[ -n "$REPORT" ] || { echo "eval finished but no report json (*.$RUN_ID.json) found under $BATCH" >&2; exit 1; }
+echo "official report: $REPORT"
+
+# ── Summarize: official verdict × on-host governance/cost metrics ───────────
+step "summarize"
+node "$HERE/summarize-official.mjs" "$BATCH" "$REPORT"

--- a/eval/swebench/run-one.sh
+++ b/eval/swebench/run-one.sh
@@ -139,28 +139,38 @@ if [ ! -x "$VENV/bin/python" ]; then
   "$VENV/bin/pip" -q install -U pip wheel "setuptools<81"
   "$VENV/bin/pip" -q install "pytest==7.4.4"
 fi
-(cd "$REPO" && "$VENV/bin/pip" -q install -e .)
+# In docker-eval mode (SKIP_PRECHECK=1) a broken venv is fine — the official
+# harness grades the patch (Phase 2), so let the agent run even if the editable
+# install fails here. Default mode still treats it as a hard env failure.
+if ! (cd "$REPO" && "$VENV/bin/pip" -q install -e .); then
+  [ "${SKIP_PRECHECK:-0}" = 1 ] || die "editable install failed" env
+  echo "warn: editable install failed; agent runs without a working venv (Phase 2 Docker will grade)"
+fi
 "$VENV/bin/python" -c "import sys; print('python:', sys.version.split()[0])"
 
 STAGE=precheck
-step "4/7 pre-check: F2P must FAIL with held-out tests applied, at base source"
-git -C "$REPO" apply "$WS/test.patch"
-set +e
-(cd "$REPO" && "$VENV/bin/python" -m pytest -q $F2P) > "$RES/pre-f2p.log" 2>&1
-PRE=$?
-set -e
-# Remove the held-out tests again — the agent must not see them.
-for f in $TESTFILES; do git -C "$REPO" checkout -q "$BASE" -- "$f" 2>/dev/null || true; done
-PRE_OUTCOME="$(pytest_outcome "$PRE" "$RES/pre-f2p.log")"
-if [ "$PRE_OUTCOME" = "pass" ]; then
-  die "FAIL_TO_PASS already passes at base source — bad instance or env drift" precheck_unexpected
+if [ "${SKIP_PRECHECK:-0}" = 1 ]; then
+  step "4/7 pre-check: SKIPPED (docker-eval mode — official Docker harness grades at base)"
+else
+  step "4/7 pre-check: F2P must FAIL with held-out tests applied, at base source"
+  git -C "$REPO" apply "$WS/test.patch"
+  set +e
+  (cd "$REPO" && "$VENV/bin/python" -m pytest -q $F2P) > "$RES/pre-f2p.log" 2>&1
+  PRE=$?
+  set -e
+  # Remove the held-out tests again — the agent must not see them.
+  for f in $TESTFILES; do git -C "$REPO" checkout -q "$BASE" -- "$f" 2>/dev/null || true; done
+  PRE_OUTCOME="$(pytest_outcome "$PRE" "$RES/pre-f2p.log")"
+  if [ "$PRE_OUTCOME" = "pass" ]; then
+    die "FAIL_TO_PASS already passes at base source — bad instance or env drift" precheck_unexpected
+  fi
+  if [ "$PRE_OUTCOME" = "error" ]; then
+    # Collection/usage/dependency error — the test never ran, so this instance
+    # can't measure the agent. Skip before burning agent tokens on a dead env.
+    die "F2P did not execute at base (pytest exit $PRE — collection/env broken)" env_broken_at_test
+  fi
+  echo "ok: F2P fails at base source (pytest exit $PRE)"
 fi
-if [ "$PRE_OUTCOME" = "error" ]; then
-  # Collection/usage/dependency error — the test never ran, so this instance
-  # can't measure the agent. Skip before burning agent tokens on a dead env.
-  die "F2P did not execute at base (pytest exit $PRE — collection/env broken)" env_broken_at_test
-fi
-echo "ok: F2P fails at base source (pytest exit $PRE)"
 
 STAGE=agent
 step "5/7 agent run (Code mode / bypass; provider from ~/.dvalincode/config.json)"

--- a/eval/swebench/summarize-official.mjs
+++ b/eval/swebench/summarize-official.mjs
@@ -1,0 +1,121 @@
+#!/usr/bin/env node
+// Phase 2 — fold the OFFICIAL SWE-bench Docker verdict together with the
+// on-host governance/cost metrics we recorded per instance, into
+// SUMMARY.official.md. This is the governance-tax read: an official-comparable
+// resolved rate next to the tokens / iterations / wall-clock the agent spent
+// under full governance (seatbelt sandbox + audit chain).
+//
+// Usage: node summarize-official.mjs <batch-dir> <official-report.json>
+import { readdirSync, readFileSync, writeFileSync, existsSync } from 'node:fs';
+import path from 'node:path';
+
+const batch = process.argv[2];
+const reportPath = process.argv[3];
+if (!batch || !reportPath) {
+  console.error('usage: node summarize-official.mjs <batch-dir> <official-report.json>');
+  process.exit(2);
+}
+const report = JSON.parse(readFileSync(reportPath, 'utf8'));
+
+// Official report id-lists (defensive: the schema has varied across versions).
+const ids = (k) => (Array.isArray(report[k]) ? report[k] : []);
+const resolvedIds = new Set(ids('resolved_ids'));
+const unresolvedIds = new Set(ids('unresolved_ids'));
+const errorIds = new Set(ids('error_ids'));
+const emptyIds = new Set(ids('empty_patch_ids'));
+const verdictOf = (id) =>
+  resolvedIds.has(id) ? 'resolved'
+  : errorIds.has(id) ? 'error'
+  : emptyIds.has(id) ? 'empty_patch'
+  : unresolvedIds.has(id) ? 'unresolved'
+  : 'not_submitted';
+
+// Our on-host records (governance/cost) per instance.
+const local = {};
+for (const ent of readdirSync(batch, { withFileTypes: true })) {
+  if (!ent.isDirectory()) continue;
+  const f = path.join(batch, ent.name, 'result.json');
+  if (!existsSync(f)) continue;
+  try {
+    const r = JSON.parse(readFileSync(f, 'utf8'));
+    local[r.instance_id || ent.name] = r;
+  } catch { /* skip unparseable */ }
+}
+
+const num = (x) => (typeof x === 'number' && isFinite(x) ? x : 0);
+const pct = (n, d) => (d ? ((100 * n) / d).toFixed(1) : '0.0');
+
+const submitted = report.submitted_instances ??
+  (resolvedIds.size + unresolvedIds.size + errorIds.size + emptyIds.size);
+const nResolved = report.resolved_instances ?? resolvedIds.size;
+
+// One row per instance we ran or the report mentions, sorted by id.
+const allIds = [...new Set([
+  ...Object.keys(local), ...resolvedIds, ...unresolvedIds, ...errorIds, ...emptyIds,
+])].sort();
+const rows = allIds.map((id) => {
+  const a = local[id]?.agent;
+  const official = verdictOf(id);
+  const localVerdict = id in local
+    ? (local[id].resolved ? 'resolved' : (local[id].stage || 'unresolved'))
+    : '—';
+  const drift = (official === 'resolved') !== Boolean(local[id]?.resolved) ? ' ⚠️' : '';
+  return `| ${id} | **${official}**${drift} | ${localVerdict} | ${a?.iterationsUsed ?? '—'} | ${a ? num(a.usage?.inputTokens).toLocaleString() : '—'} | ${a?.wallSeconds != null ? a.wallSeconds.toFixed(0) : '—'} | ${a?.auditHead ? a.auditHead.slice(0, 12) : '—'} |`;
+});
+
+// Cost aggregates over instances that actually ran the agent.
+let inTok = 0, outTok = 0, wall = 0, withAgent = 0;
+const models = new Set();
+for (const r of Object.values(local)) {
+  const a = r.agent;
+  if (!a) continue;
+  withAgent++;
+  inTok += num(a.usage?.inputTokens);
+  outTok += num(a.usage?.outputTokens);
+  wall += num(a.wallSeconds);
+  if (a.model) models.add(a.model);
+}
+
+// Local-vs-official drift: instances the local venv graded differently.
+let drift = 0;
+for (const id of allIds) {
+  if (!(id in local)) continue;
+  if ((verdictOf(id) === 'resolved') !== Boolean(local[id].resolved)) drift++;
+}
+
+const perResolvedInt = (t) => (nResolved ? Math.round(t / nResolved).toLocaleString() : '—');
+
+const md = `# Official (Docker) summary — \`${path.basename(batch)}\`
+
+Generated ${new Date().toISOString()} · harness: **official SWE-bench Docker** (per-instance images) · report: \`${path.basename(reportPath)}\`.
+
+## Headline
+
+- **Resolved (official): ${nResolved}/${submitted} (${pct(nResolved, submitted)}%)**
+- Agent model(s): ${[...models].map((m) => `\`${m}\``).join(', ') || 'n/a'} — ran on-host under seatbelt + audit chain.
+- Official buckets: resolved ${resolvedIds.size} · unresolved ${unresolvedIds.size} · error ${errorIds.size} · empty_patch ${emptyIds.size}.
+- **Local-vs-official drift: ${drift}** instance(s) the local venv graded differently — the gap Phase 2 exists to close.
+
+## Per-instance — official verdict × on-host governance cost
+
+| Instance | Official | Local | Iters | Input tok | Wall s | Audit head |
+|---|---|---|---|---|---|---|
+${rows.join('\n')}
+
+⚠️ = local venv and official Docker disagree on resolution.
+
+## Governance-tax read (agent instances only)
+
+| Metric | Total | Mean/instance | Per resolved |
+|---|---|---|---|
+| Input tokens | ${inTok.toLocaleString()} | ${withAgent ? Math.round(inTok / withAgent).toLocaleString() : 0} | ${perResolvedInt(inTok)} |
+| Output tokens | ${outTok.toLocaleString()} | ${withAgent ? Math.round(outTok / withAgent).toLocaleString() : 0} | ${perResolvedInt(outTok)} |
+| Wall-clock (s) | ${wall.toFixed(0)} | ${withAgent ? (wall / withAgent).toFixed(1) : 0} | ${nResolved ? (wall / nResolved).toFixed(1) : '—'} |
+
+_Official verdict is Docker-based and comparable to published SWE-bench Lite numbers. Cost/governance metrics are from the on-host agent run (provider-billed tokens; seatbelt-sandboxed; audit chain head recorded per instance)._
+`;
+
+const outPath = path.join(batch, 'SUMMARY.official.md');
+writeFileSync(outPath, md);
+console.log(md);
+console.log(`\nwrote ${outPath}`);


### PR DESCRIPTION
## What

Adds **Phase 2** of the SWE-bench eval: grade agent patches in the **official SWE-bench per-instance Docker images** while the agent still runs on the host under full governance. Only the *grading* moves into Docker.

New files:
- `eval/swebench/predictions.mjs` — a batch's `agent.diff`s → SWE-bench `predictions.jsonl`
- `eval/swebench/run-eval-docker.sh` — preflight (docker + swebench) → `swebench.harness.run_evaluation` → summary
- `eval/swebench/summarize-official.mjs` — official report × our per-instance records → `SUMMARY.official.md`

Changed:
- `run-one.sh` / `run-batch.sh` gain a **gated** `--no-precheck` / `SKIP_PRECHECK` so env-broken instances still run and produce a patch to grade. Default local-venv path is **byte-identical**.
- `README.md` + `results/FINDINGS.md` document Phase 2 and update the "not official" caveat.

## Why

The local-venv smoke harness has two gaps the FINDINGS keep hitting:
1. **Environment fidelity** — 43–60% of Lite instances bucket `env_broken_at_test`; they can't even run their tests under `python3.11` (8 need Python ≤3.9 for `from collections import Mapping` — no dependency pin fixes it).
2. **Not official-comparable** — venv numbers can't be quoted against published SWE-bench Lite.

Phase 2 closes both by handing the patches to the official Docker harness.

## Design note — grade-only, not agent-in-container

The eval measures the **governance tax**, which lives in the macOS seatbelt sandbox + audit chain — both host-side. Running the agent inside a Linux container would forfeit exactly what we're measuring, so the agent stays on host; only the verdict moves to Docker.

## Flow

```
run-batch.sh … --no-precheck            # agent runs on every instance → agent.diff
  → run-eval-docker.sh <batch>          # preflight + official run_evaluation (per-instance Docker)
  → predictions.jsonl                   # {instance_id, model_name_or_path, model_patch}
  → <model>.<run_id>.json               # official report
  → SUMMARY.official.md                 # official resolved rate × on-host tokens/iters/audit head, flags drift
```

## Verification — and one honest caveat

Every non-Docker path is tested: `bash -n` / `node --check` all green; fixtures confirm predictions (correctly skips empty-patch and env-skipped dirs), the official-report parser + `SUMMARY.official.md` (incl. local↔official drift detection), and the preflight (fails fast + actionable when the daemon is down, without installing swebench).

⚠️ **The dev host had no Docker daemon, so the live Docker run has NOT happened yet — there are still zero official-comparable numbers.** This PR is the infrastructure; the first official Lite number lands after a run on a Docker-capable host. Stated the same way in the commit body and FINDINGS.

## Reviewer notes

- Requires Docker (daemon running) + the `swebench` package (script bootstraps a cached `.venv-tools`, or set `SWEBENCH_PY`).
- `swebench.harness.run_evaluation` CLI flags target the current stable interface; if a pinned version differs, that's the one spot to adjust.
- `predictions.jsonl` / report / logs land in the gitignored `results/batches/<ts>/` — no artifacts committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)