### PR TITLE
feat: add secure macOS GUI updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -438,6 +438,11 @@ updated via `npm i -g`, and source checkouts are pointed at `git pull`. Add
 `-y` to skip the prompt, `--prerelease` to track pre-releases, or `--json` for
 scripting.
 
+The macOS desktop app checks the separate `gui-v*` release track when it starts.
+When a newer GUI is available, it asks before downloading, verifies the archive
+against `SHA256SUMS-gui.txt`, validates the app version, then replaces and
+restarts `DvalinCode.app`. A failed replacement rolls back to the previous app.
+
 ---
 
 ## 🎬 First-time setup

--- a/src/core/guiUpdate.ts
+++ b/src/core/guiUpdate.ts
@@ -1,0 +1,93 @@
+import path from 'node:path';
+import {
+  RELEASE_REPO,
+  compareSemver,
+  parseSemver,
+  type GithubRelease,
+  type Platform,
+  type Semver,
+} from './selfUpdate.js';
+
+export type GuiReleaseInfo = {
+  tag: string;
+  version: string;
+  htmlUrl: string;
+  assets: Map<string, string>;
+};
+
+type FetchLike = (url: string, init?: { signal?: AbortSignal; headers?: Record<string, string> }) => Promise<{
+  ok: boolean;
+  status: number;
+  statusText: string;
+  json: () => Promise<unknown>;
+}>;
+
+export function parseGuiReleaseTag(tag: string): Semver | null {
+  const match = /^gui-(v\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?)$/.exec(tag.trim());
+  return match ? parseSemver(match[1]) : null;
+}
+
+export function guiAssetName(version: string, platform: Platform): string {
+  const normalized = version.replace(/^v/, '');
+  const extension = platform.os === 'windows' ? 'zip' : 'tar.gz';
+  return `dvalincode-gui-v${normalized}-${platform.os}-${platform.arch}.${extension}`;
+}
+
+export function assertTrustedGuiAssetUrl(value: string, releaseTag: string): string {
+  const url = new URL(value);
+  const expectedPrefix = `/${RELEASE_REPO}/releases/download/${releaseTag}/`;
+  if (url.protocol !== 'https:' || url.hostname !== 'github.com' || !url.pathname.startsWith(expectedPrefix)) {
+    throw new Error(`Desktop GUI release contains an untrusted asset URL: ${url.origin}`);
+  }
+  return url.toString();
+}
+
+export async function fetchLatestGuiRelease(options: {
+  repo?: string;
+  fetchImpl?: FetchLike;
+  signal?: AbortSignal;
+} = {}): Promise<GuiReleaseInfo> {
+  const repo = options.repo ?? RELEASE_REPO;
+  const fetchImpl = options.fetchImpl ?? (globalThis.fetch as unknown as FetchLike);
+  const url = `https://api.github.com/repos/${repo}/releases?per_page=30`;
+  const response = await fetchImpl(url, {
+    headers: { Accept: 'application/vnd.github+json', 'User-Agent': 'dvalincode-gui-update' },
+    ...(options.signal ? { signal: options.signal } : {}),
+  });
+  if (!response.ok) throw new Error(`GitHub API ${response.status} ${response.statusText}`);
+
+  const releases = (await response.json()) as GithubRelease[];
+  const release = releases
+    .filter(candidate => !candidate.draft && parseGuiReleaseTag(candidate.tag_name) !== null)
+    .sort((a, b) => compareSemver(parseGuiReleaseTag(b.tag_name)!, parseGuiReleaseTag(a.tag_name)!))[0];
+  if (!release) throw new Error('No Desktop GUI release was found.');
+
+  return {
+    tag: release.tag_name,
+    version: release.tag_name.replace(/^gui-v/, ''),
+    htmlUrl: release.html_url,
+    assets: new Map(release.assets.map(asset => [asset.name, asset.browser_download_url])),
+  };
+}
+
+export function macAppBundleFromExecutable(executable: string): string | null {
+  const marker = `${path.sep}Contents${path.sep}MacOS${path.sep}`;
+  const markerIndex = executable.lastIndexOf(marker);
+  if (markerIndex < 0) return null;
+  const candidate = executable.slice(0, markerIndex);
+  return candidate.endsWith('.app') ? candidate : null;
+}
+
+export function assertSafeTarEntries(listing: string): void {
+  for (const rawEntry of listing.split('\n')) {
+    const entry = rawEntry.trim();
+    if (!entry) continue;
+    if (entry.includes('\0') || path.posix.isAbsolute(entry)) {
+      throw new Error(`GUI archive contains an unsafe absolute path: ${entry}`);
+    }
+    const segments = entry.replace(/^\.\//, '').split('/');
+    if (segments.includes('..')) {
+      throw new Error(`GUI archive contains path traversal: ${entry}`);
+    }
+  }
+}

--- a/src/gui/index.ts
+++ b/src/gui/index.ts
@@ -14,6 +14,9 @@ if (process.env.DVALINCODE_GUI_ROLE === 'server') {
   const { startServer } = await import('../server/index.js');
   await startServer({ host: '127.0.0.1', port: 0, open: false });
 } else {
+  const { maybeInstallGuiUpdate } = await import('./updater.js');
+  if (await maybeInstallGuiUpdate()) process.exit(0);
+
   const { Webview } = await import('webview-bun');
 
   const child = Bun.spawn([process.execPath], {

--- a/src/gui/updater.ts
+++ b/src/gui/updater.ts
@@ -1,0 +1,179 @@
+import { execFile, spawn } from 'node:child_process';
+import { constants } from 'node:fs';
+import { access, chmod, mkdtemp, readFile, readdir, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { promisify } from 'node:util';
+import {
+  assertSafeTarEntries,
+  assertTrustedGuiAssetUrl,
+  fetchLatestGuiRelease,
+  guiAssetName,
+  macAppBundleFromExecutable,
+} from '../core/guiUpdate.js';
+import { detectPlatform, isNewer, parseSums, sha256File } from '../core/selfUpdate.js';
+import { VERSION } from '../version.js';
+
+const execFileAsync = promisify(execFile);
+const UPDATE_CHECK_TIMEOUT_MS = 5_000;
+const UPDATE_DOWNLOAD_TIMEOUT_MS = 120_000;
+
+export async function maybeInstallGuiUpdate(): Promise<boolean> {
+  if (process.env.DVALINCODE_GUI_DISABLE_UPDATE === '1') return false;
+  if (process.platform !== 'darwin') return false;
+
+  const currentApp = macAppBundleFromExecutable(process.execPath);
+  const platform = detectPlatform();
+  if (!currentApp || !platform || platform.os !== 'macos') return false;
+
+  let accepted = false;
+  let workDir: string | undefined;
+  let installerScheduled = false;
+  try {
+    const release = await fetchLatestGuiRelease({ signal: AbortSignal.timeout(UPDATE_CHECK_TIMEOUT_MS) });
+    if (!isNewer(release.version, VERSION)) return false;
+
+    accepted = await confirmUpdate(VERSION, release.version);
+    if (!accepted) return false;
+
+    await access(path.dirname(currentApp), constants.W_OK);
+    const asset = guiAssetName(release.version, platform);
+    const archiveUrl = release.assets.get(asset);
+    const sumsUrl = release.assets.get('SHA256SUMS-gui.txt');
+    if (!archiveUrl || !sumsUrl) throw new Error(`Desktop GUI release ${release.tag} is incomplete.`);
+
+    workDir = await mkdtemp(path.join(tmpdir(), 'dvalincode-gui-update-'));
+    const archivePath = path.join(workDir, asset);
+    const sumsPath = path.join(workDir, 'SHA256SUMS-gui.txt');
+    await download(assertTrustedGuiAssetUrl(archiveUrl, release.tag), archivePath);
+    await download(assertTrustedGuiAssetUrl(sumsUrl, release.tag), sumsPath);
+
+    const expected = parseSums(await readFile(sumsPath, 'utf8')).get(asset);
+    if (!expected) throw new Error(`${asset} is missing from SHA256SUMS-gui.txt.`);
+    const actual = await sha256File(archivePath);
+    if (actual !== expected) throw new Error(`Checksum mismatch for ${asset}.`);
+
+    const { stdout: listing } = await execFileAsync('/usr/bin/tar', ['-tzf', archivePath], {
+      encoding: 'utf8',
+      maxBuffer: 2 * 1024 * 1024,
+    });
+    assertSafeTarEntries(listing);
+
+    const extractDir = path.join(workDir, 'extract');
+    await execFileAsync('/bin/mkdir', ['-p', extractDir]);
+    await execFileAsync('/usr/bin/tar', ['-xzf', archivePath, '-C', extractDir]);
+    const stagedApp = await findAppBundle(extractDir);
+    if (!stagedApp) throw new Error('Downloaded archive does not contain DvalinCode.app.');
+
+    const { stdout: stagedVersion } = await execFileAsync(
+      '/usr/libexec/PlistBuddy',
+      ['-c', 'Print :CFBundleShortVersionString', path.join(stagedApp, 'Contents', 'Info.plist')],
+      { encoding: 'utf8' },
+    );
+    if (stagedVersion.trim() !== release.version) {
+      throw new Error(`Downloaded app reports ${stagedVersion.trim()}, expected ${release.version}.`);
+    }
+
+    await launchInstallerHelper({ currentApp, stagedApp, workDir });
+    installerScheduled = true;
+    return true;
+  } catch (error) {
+    console.error('dvalincode-gui: update failed:', error);
+    if (accepted) await showUpdateError(error);
+    return false;
+  } finally {
+    if (workDir && !installerScheduled) await rm(workDir, { recursive: true, force: true }).catch(() => {});
+  }
+}
+
+async function download(url: string, destination: string): Promise<void> {
+  const response = await fetch(url, {
+    headers: { Accept: 'application/octet-stream', 'User-Agent': 'dvalincode-gui-update' },
+    signal: AbortSignal.timeout(UPDATE_DOWNLOAD_TIMEOUT_MS),
+  });
+  if (!response.ok) throw new Error(`Download failed: HTTP ${response.status}`);
+  await writeFile(destination, Buffer.from(await response.arrayBuffer()), { mode: 0o600 });
+}
+
+async function confirmUpdate(current: string, latest: string): Promise<boolean> {
+  const script = [
+    'on run argv',
+    'set currentVersion to item 1 of argv',
+    'set latestVersion to item 2 of argv',
+    'display dialog "DvalinCode " & latestVersion & " is available.\\n\\nCurrent version: " & currentVersion & "\\nThe update is checksum-verified and the app will restart." with title "DvalinCode Update" buttons {"Later", "Install and Restart"} default button "Install and Restart" cancel button "Later" with icon note',
+    'return button returned of result',
+    'end run',
+  ].join('\n');
+  try {
+    const { stdout } = await execFileAsync('/usr/bin/osascript', ['-e', script, current, latest], { encoding: 'utf8' });
+    return stdout.trim() === 'Install and Restart';
+  } catch {
+    return false;
+  }
+}
+
+async function showUpdateError(error: unknown): Promise<void> {
+  const message = error instanceof Error ? error.message : String(error);
+  const script = [
+    'on run argv',
+    'display alert "DvalinCode update could not be installed" message (item 1 of argv) as warning',
+    'end run',
+  ].join('\n');
+  await execFileAsync('/usr/bin/osascript', ['-e', script, message.slice(0, 500)]).catch(() => {});
+}
+
+async function findAppBundle(root: string, depth = 0): Promise<string | null> {
+  if (depth > 3) return null;
+  for (const entry of await readdir(root, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    const candidate = path.join(root, entry.name);
+    if (entry.name === 'DvalinCode.app') return candidate;
+    const nested = await findAppBundle(candidate, depth + 1);
+    if (nested) return nested;
+  }
+  return null;
+}
+
+async function launchInstallerHelper(options: {
+  currentApp: string;
+  stagedApp: string;
+  workDir: string;
+}): Promise<void> {
+  const helperPath = path.join(options.workDir, 'install-update.sh');
+  const helper = `#!/bin/sh
+set -u
+parent_pid="$1"
+source_app="$2"
+target_app="$3"
+work_dir="$4"
+backup_app="\${target_app}.dvalincode-backup"
+
+while /bin/kill -0 "$parent_pid" 2>/dev/null; do /bin/sleep 0.2; done
+/bin/rm -rf "$backup_app"
+if [ -e "$target_app" ]; then /bin/mv "$target_app" "$backup_app" || exit 1; fi
+if /usr/bin/ditto "$source_app" "$target_app"; then
+  /usr/bin/xattr -dr com.apple.quarantine "$target_app" 2>/dev/null || true
+  /bin/rm -rf "$backup_app"
+  /usr/bin/open "$target_app"
+  /bin/rm -rf "$work_dir"
+else
+  /bin/rm -rf "$target_app"
+  if [ -e "$backup_app" ]; then /bin/mv "$backup_app" "$target_app"; fi
+  /usr/bin/open "$target_app" 2>/dev/null || true
+  exit 1
+fi
+`;
+  await writeFile(helperPath, helper, { mode: 0o700 });
+  await chmod(helperPath, 0o700);
+  const child = spawn('/bin/sh', [
+    helperPath,
+    String(process.pid),
+    options.stagedApp,
+    options.currentApp,
+    options.workDir,
+  ], {
+    detached: true,
+    stdio: 'ignore',
+  });
+  child.unref();
+}

--- a/tests/guiUpdate.test.ts
+++ b/tests/guiUpdate.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+import {
+  assertSafeTarEntries,
+  assertTrustedGuiAssetUrl,
+  fetchLatestGuiRelease,
+  guiAssetName,
+  macAppBundleFromExecutable,
+  parseGuiReleaseTag,
+} from '../src/core/guiUpdate.js';
+import type { GithubRelease } from '../src/core/selfUpdate.js';
+
+function release(tag: string, draft = false): GithubRelease {
+  return {
+    tag_name: tag,
+    prerelease: false,
+    draft,
+    html_url: `https://github.com/arthurpanhku/dvalincode/releases/tag/${tag}`,
+    assets: [
+      { name: `asset-${tag}`, browser_download_url: `https://example.test/${tag}` },
+    ],
+  };
+}
+
+describe('Desktop GUI updates', () => {
+  it('parses only gui-v release tags', () => {
+    expect(parseGuiReleaseTag('gui-v0.13.0')).toEqual({ major: 0, minor: 13, patch: 0 });
+    expect(parseGuiReleaseTag('v0.13.0')).toBeNull();
+    expect(parseGuiReleaseTag('gui-latest')).toBeNull();
+  });
+
+  it('selects the highest non-draft GUI release', async () => {
+    const fetchImpl = async () => ({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: async () => [release('v9.0.0'), release('gui-v0.13.0'), release('gui-v0.14.0', true), release('gui-v0.12.4')],
+    });
+    const latest = await fetchLatestGuiRelease({ fetchImpl });
+    expect(latest.tag).toBe('gui-v0.13.0');
+    expect(latest.version).toBe('0.13.0');
+  });
+
+  it('uses the GUI release asset naming matrix', () => {
+    expect(guiAssetName('0.13.0', { os: 'macos', arch: 'arm64' }))
+      .toBe('dvalincode-gui-v0.13.0-macos-arm64.tar.gz');
+    expect(guiAssetName('v0.13.0', { os: 'windows', arch: 'x64' }))
+      .toBe('dvalincode-gui-v0.13.0-windows-x64.zip');
+  });
+
+  it('accepts assets only from this repository release path', () => {
+    const asset = 'https://github.com/arthurpanhku/dvalincode/releases/download/gui-v0.13.0/app.tar.gz';
+    expect(assertTrustedGuiAssetUrl(asset, 'gui-v0.13.0')).toBe(asset);
+    expect(() => assertTrustedGuiAssetUrl('https://example.test/app.tar.gz', 'gui-v0.13.0'))
+      .toThrow('untrusted asset URL');
+    expect(() => assertTrustedGuiAssetUrl('https://github.com/evil/repo/releases/download/gui-v0.13.0/app.tar.gz', 'gui-v0.13.0'))
+      .toThrow('untrusted asset URL');
+  });
+
+  it('discovers the containing macOS app bundle', () => {
+    expect(macAppBundleFromExecutable('/Applications/DvalinCode.app/Contents/MacOS/dvalincode-gui-macos-arm64'))
+      .toBe('/Applications/DvalinCode.app');
+    expect(macAppBundleFromExecutable('/tmp/dvalincode-gui-macos-arm64')).toBeNull();
+  });
+
+  it('rejects absolute and traversing tar entries', () => {
+    expect(() => assertSafeTarEntries('dvalincode/DvalinCode.app/Contents/Info.plist\n')).not.toThrow();
+    expect(() => assertSafeTarEntries('../../Applications/DvalinCode.app')).toThrow('path traversal');
+    expect(() => assertSafeTarEntries('/Applications/DvalinCode.app')).toThrow('absolute path');
+  });
+});


### PR DESCRIPTION
## Summary

- check the separate `gui-v*` release track when the macOS desktop app starts
- ask before installing, constrain asset URLs, verify SHA-256, validate archive paths and bundle version
- replace the app after exit, roll back on failure, and restart automatically
- document the desktop update behavior and add unit coverage

## Why

The stable CLI and native desktop app use separate release tracks. The CLI could update itself, but an installed `DvalinCode.app` remained on the old GUI release indefinitely.

## Validation

- `npm run check` — 759 tests passed
- `npm run build:gui:darwin` — arm64 and x64 bundles built
- `shasum -a 256 -c release-gui/SHA256SUMS-gui.txt`
- `codesign --verify --deep --strict` on the arm64 app bundle