### PR TITLE
fix: normalize npm CLI bin path

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "license": "MIT",
   "bin": {
-    "dvalincode": "./dist/index.js"
+    "dvalincode": "dist/index.js"
   },
   "files": [
     "dist",


### PR DESCRIPTION
## Summary
- normalize the npm CLI bin path to the canonical package-relative form
- prevent npm 11 from rewriting package metadata during future publishes

## Verification
- npm publish dvalincode@0.14.0 succeeded with this normalized metadata
- npm registry smoke test reports 0.14.0