### PR TITLE
feat: surface recovered turn notices

### DIFF
--- a/src/server/wsHandler.ts
+++ b/src/server/wsHandler.ts
@@ -36,6 +36,7 @@ type ClientMessage =
 
 type ServerMessage =
   | { type: "session_id"; sessionId: string }
+  | { type: "recovered_turn"; messageId: string; content: string }
   | { type: "token_delta"; content: string }
   | { type: "tool_call"; name: string; id: string; input: unknown }
   | {
@@ -274,6 +275,13 @@ export function handleWebSocket(ws: WebSocket): void {
 
       if (abort.signal.aborted) return;
 
+      for (const recovered of turn.recovered ?? []) {
+        send(ws, {
+          type: "recovered_turn",
+          messageId: recovered.messageId,
+          content: recovered.content,
+        });
+      }
       send(ws, { type: "response", content: turn.result.output });
       if (!turn.replayed && turn.reportMarkdown && turn.result.runId) {
         send(ws, {

--- a/src/tui/app.ts
+++ b/src/tui/app.ts
@@ -115,6 +115,9 @@ export async function runTui(opts: TuiOptions = {}): Promise<void> {
         { onEvent, requestApproval },
       );
       sessionId = turn.sessionId;
+      for (const recovered of turn.recovered ?? []) {
+        process.stdout.write('\n' + R.formatRecoveredTurnNotice(recovered.content) + '\n');
+      }
       if (!sawToken && turn.result.output) {
         process.stdout.write(turn.result.output + '\n');
       } else {

--- a/src/tui/render.ts
+++ b/src/tui/render.ts
@@ -51,6 +51,18 @@ export function formatToolResult(output: string): string {
     .join('\n');
 }
 
+export function formatRecoveredTurnNotice(content: string): string {
+  const quoted = (content.trim() || '(empty message)')
+    .split('\n')
+    .map(line => `  ${line}`)
+    .join('\n');
+  return [
+    chalk.yellow('  A previous message was interrupted — its text was:'),
+    chalk.dim(quoted),
+    chalk.dim('  Re-send it by submitting that text again.'),
+  ].join('\n');
+}
+
 const MODE_COLOR: Record<AgentMode, (s: string) => string> = {
   chat: chalk.blue,
   cowork: chalk.magenta,

--- a/tests/server/wsHandler.test.ts
+++ b/tests/server/wsHandler.test.ts
@@ -93,13 +93,14 @@ describe('wsHandler messageId idempotency', () => {
       }),
     );
 
-    const { done } = await waitForDone(ws);
+    const { all, done } = await waitForDone(ws);
     expect(runAgentTurnMock).toHaveBeenCalledTimes(1);
     expect(runAgentTurnMock.mock.calls[0]?.[0]).toMatchObject({
       content: 'hello',
       messageId: 'client-msg-1',
     });
     expect(done.replayed).toBeUndefined();
+    expect(all.some((m) => m.type === 'recovered_turn')).toBe(false);
     ws.close();
   });
 
@@ -160,6 +161,47 @@ describe('wsHandler messageId idempotency', () => {
     });
     expect(second.all.some((m) => m.type === 'run_report')).toBe(false);
 
+    ws.close();
+  });
+
+  it('emits recovered interrupted turns before finishing the new response', async () => {
+    runAgentTurnMock.mockResolvedValueOnce({
+      sessionId: 'dc_test_recovered',
+      result: {
+        messages: [
+          { role: 'user', content: 'resume now' },
+          { role: 'assistant', content: 'ready' },
+        ] satisfies ChatMessage[],
+        output: 'ready',
+        iterationsUsed: 1,
+      },
+      providerId: 'mock',
+      model: 'mock-model',
+      recovered: [{ messageId: 'lost-msg-1', content: 'build the dashboard' }],
+    });
+
+    const ws = await connect();
+    ws.send(
+      JSON.stringify({
+        type: 'send',
+        content: 'resume now',
+        sessionId: 'dc_test_recovered',
+        cwd: process.cwd(),
+        mode: 'chat',
+      }),
+    );
+
+    const { all } = await waitForDone(ws);
+    const recovered = all.find((m) => m.type === 'recovered_turn');
+    const responseIndex = all.findIndex((m) => m.type === 'response');
+    const recoveredIndex = all.findIndex((m) => m.type === 'recovered_turn');
+
+    expect(recovered).toMatchObject({
+      messageId: 'lost-msg-1',
+      content: 'build the dashboard',
+    });
+    expect(recoveredIndex).toBeGreaterThanOrEqual(0);
+    expect(responseIndex).toBeGreaterThan(recoveredIndex);
     ws.close();
   });
 

--- a/tests/tui/render.test.ts
+++ b/tests/tui/render.test.ts
@@ -6,6 +6,7 @@ import {
   formatToolError,
   colorizeDiff,
   formatToolResult,
+  formatRecoveredTurnNotice,
   statusLine,
   approvalLine,
 } from '../../src/tui/render.js';
@@ -63,6 +64,16 @@ describe('formatToolResult', () => {
   it('indents output and shows a fallback for empty results', () => {
     expect(formatToolResult('hello')).toBe('  hello');
     expect(formatToolResult('   ')).toContain('done');
+  });
+});
+
+describe('formatRecoveredTurnNotice', () => {
+  it('shows the interrupted message text and resend instruction', () => {
+    const notice = formatRecoveredTurnNotice('first line\nsecond line');
+    expect(notice).toContain('A previous message was interrupted');
+    expect(notice).toContain('first line');
+    expect(notice).toContain('second line');
+    expect(notice).toContain('Re-send it');
   });
 });
 

--- a/web/src/components/MessageBubble.tsx
+++ b/web/src/components/MessageBubble.tsx
@@ -1,6 +1,7 @@
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import rehypeHighlight from 'rehype-highlight';
+import { RotateCcw } from 'lucide-react';
 import { AgentActivity } from './AgentActivity.tsx';
 import { PlanCard, extractPlanSteps } from './PlanCard.tsx';
 import { ThemeLogo } from './ThemeLogo.tsx';
@@ -29,6 +30,31 @@ export function MessageBubble({ message, mode, onProceed }: Props) {
       <div className="flex justify-end mb-4 animate-fade-in">
         <div className="max-w-[75%] bg-surface-2 border border-border rounded-2xl rounded-tr-sm px-4 py-2.5 text-fg text-sm leading-relaxed whitespace-pre-wrap">
           {message.content}
+        </div>
+      </div>
+    );
+  }
+
+  if (message.role === 'recovered') {
+    return (
+      <div className="mb-4 ml-7 animate-fade-in">
+        <div className="rounded-lg border border-yellow-500/25 bg-yellow-500/10 px-3 py-2.5 text-sm text-fg">
+          <div className="text-yellow-300 font-medium">A previous message was interrupted.</div>
+          <div className="mt-1 text-muted-fg">Its text was:</div>
+          <blockquote className="mt-2 border-l-2 border-yellow-500/35 pl-3 text-fg whitespace-pre-wrap">
+            {message.content}
+          </blockquote>
+          {onProceed && (
+            <button
+              type="button"
+              onClick={() => onProceed(message.content)}
+              className="mt-3 inline-flex items-center gap-1.5 rounded-md border border-yellow-500/30 bg-yellow-500/10 px-2.5 py-1.5 text-xs font-medium text-yellow-200 hover:bg-yellow-500/20"
+              title="Re-send recovered message"
+            >
+              <RotateCcw size={12} />
+              Re-send
+            </button>
+          )}
         </div>
       </div>
     );

--- a/web/src/hooks/useChat.ts
+++ b/web/src/hooks/useChat.ts
@@ -30,6 +30,16 @@ function updateLastPendingAssistant(
   return messages;
 }
 
+function insertBeforePendingAssistant(messages: ChatMessage[], message: ChatMessage): ChatMessage[] {
+  for (let i = messages.length - 1; i >= 0; i -= 1) {
+    const current = messages[i];
+    if (current?.role === 'assistant' && current.pending) {
+      return [...messages.slice(0, i), message, ...messages.slice(i)];
+    }
+  }
+  return [...messages, message];
+}
+
 /** Convert saved backend messages into UI chat messages for session restore */
 function mapBackendMessages(raw: BackendChatMessage[]): ChatMessage[] {
   const result: ChatMessage[] = [];
@@ -120,6 +130,16 @@ export function useChat(opts: UseChatOptions = {}) {
           case 'session_id':
             setCurrentSessionId(event.sessionId);
             setRunningSessionId(event.sessionId);
+            break;
+
+          case 'recovered_turn':
+            setMessages((prev) =>
+              insertBeforePendingAssistant(prev, {
+                role: 'recovered',
+                messageId: event.messageId,
+                content: event.content,
+              }),
+            );
             break;
 
           case 'token_delta':

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -88,6 +88,7 @@ export type ToolCallEvent = {
 
 export type ChatMessage =
   | { role: 'user'; content: string; messageId?: string }
+  | { role: 'recovered'; content: string; messageId: string }
   | {
       role: 'assistant';
       content: string;
@@ -210,6 +211,7 @@ export type PendingApproval = {
 
 export type ServerEvent =
   | { type: 'session_id'; sessionId: string }
+  | { type: 'recovered_turn'; messageId: string; content: string }
   | { type: 'token_delta'; content: string }
   | { type: 'tool_call'; name: string; id: string; input: unknown }
   | { type: 'tool_result'; name: string; id: string; output: string; metadata?: Record<string, unknown> }


### PR DESCRIPTION
## Summary

- Emit recovered interrupted turns from the WebSocket transport when `runAgentTurn` reports them.
- Show a web chat notice with the recovered message text and a one-click Re-send action.
- Print an equivalent TUI notice before the new turn response.

Fixes #47

## Testing

- `npm install`
- `cd web && npm install`
- `npx vitest run tests/server/wsHandler.test.ts tests/tui/render.test.ts`
- `npm run check` (47 files / 296 tests passed)
- `npm run build`
- `npm run web:build`

## Security and AI Governance

- [x] This change does not expand file, shell, network, model, or approval permissions.
- [x] No prompt, policy, provider, audit logging, or release/build security behavior is changed; no governance evidence update is required.
- [x] No new model/provider/tool is introduced, and no external data flow is added. The recovered text is already session-journal state and is sent back only to the active UI session.

AI assistance disclosure: this PR was prepared with OpenAI Codex.
