### PR TITLE
feat: persist recovered-turn notices across reload

### DIFF
--- a/src/server/routes/sessions.ts
+++ b/src/server/routes/sessions.ts
@@ -1,5 +1,6 @@
 import { Router } from 'express';
 import { listSessions, loadSession, deleteSession, deleteAllSessions } from '../../sessions/store.js';
+import { readJournal, recoveredTurnNotices } from '../../sessions/journal.js';
 import { renderSessionMarkdown } from '../../sessions/markdown.js';
 import { allowWorkspaceRoot } from '../security.js';
 
@@ -32,7 +33,10 @@ sessionsRouter.get('/:id', async (req, res) => {
     return;
   }
   await allowWorkspaceRoot(session.cwd).catch(() => {});
-  res.json(session);
+  res.json({
+    ...session,
+    recoveredTurns: recoveredTurnNotices(readJournal(session.id)),
+  });
 });
 
 // Download the conversation as a Markdown transcript.

--- a/src/sessions/journal.ts
+++ b/src/sessions/journal.ts
@@ -44,6 +44,11 @@ export type JournalEvent = JournalTurnStart | JournalTurnEnd | JournalTurnInterr
 /** A persisted journal record: an event plus ordering metadata. */
 export type JournalRecord = JournalEvent & { seq: number; ts: string };
 
+export type RecoveredTurnNotice = {
+  messageId: string;
+  content: string;
+};
+
 /** Status derived from the journal tail. `running` is in-memory only and never persisted. */
 export type SessionStatus = 'idle' | 'interrupted';
 
@@ -89,15 +94,6 @@ export function appendJournal(sessionId: string, event: JournalEvent, dir: strin
   }
 }
 
-/** Message ids that have reached a terminal record (turn_end or turn_interrupted). */
-function closedMessageIds(records: JournalRecord[]): Set<string> {
-  const closed = new Set<string>();
-  for (const r of records) {
-    if (r.type === 'turn_end' || r.type === 'turn_interrupted') closed.add(r.messageId);
-  }
-  return closed;
-}
-
 /** The successful `turn_end` for a message id, if the turn already completed. */
 export function completedTurn(records: JournalRecord[], messageId: string): JournalTurnEnd | undefined {
   return records.find(
@@ -113,16 +109,57 @@ export function completedTurnResponse(records: JournalRecord[], messageId: strin
 
 /** Turn starts that never reached a terminal record — i.e. crashed mid-turn. */
 export function danglingTurns(records: JournalRecord[]): JournalTurnStart[] {
-  const closed = closedMessageIds(records);
-  const seen = new Set<string>();
-  const dangling: JournalTurnStart[] = [];
+  const open = new Map<string, JournalTurnStart>();
   for (const r of records) {
-    if (r.type !== 'turn_start') continue;
-    if (closed.has(r.messageId) || seen.has(r.messageId)) continue;
-    seen.add(r.messageId);
-    dangling.push(r);
+    if (r.type === 'turn_start') {
+      open.set(r.messageId, r);
+      continue;
+    }
+    if (r.type === 'turn_end' || r.type === 'turn_interrupted') {
+      open.delete(r.messageId);
+    }
   }
-  return dangling;
+  return [...open.values()];
+}
+
+/**
+ * Recovered notices that should still be shown on session restore. The raw
+ * recovered text lives in the matching turn_start record; turn_interrupted only
+ * marks that the process died before turn_end. A later successful re-send with
+ * the same messageId resolves the notice.
+ */
+export function recoveredTurnNotices(records: JournalRecord[]): RecoveredTurnNotice[] {
+  const open = new Map<string, JournalTurnStart>();
+  const notices = new Map<string, RecoveredTurnNotice & { seq: number }>();
+
+  for (const r of records) {
+    if (r.type === 'turn_start') {
+      open.set(r.messageId, r);
+      continue;
+    }
+
+    if (r.type === 'turn_interrupted') {
+      const start = open.get(r.messageId);
+      if (start) {
+        notices.set(r.messageId, {
+          messageId: r.messageId,
+          content: start.content,
+          seq: r.seq,
+        });
+      }
+      open.delete(r.messageId);
+      continue;
+    }
+
+    if (r.type === 'turn_end') {
+      open.delete(r.messageId);
+      if (r.status === 'done') notices.delete(r.messageId);
+    }
+  }
+
+  return [...notices.values()]
+    .sort((a, b) => a.seq - b.seq)
+    .map(({ messageId, content }) => ({ messageId, content }));
 }
 
 /** Derive session status from its journal. */

--- a/tests/sessions/journal.test.ts
+++ b/tests/sessions/journal.test.ts
@@ -9,6 +9,7 @@ import {
   danglingTurns,
   projectStatus,
   readJournal,
+  recoveredTurnNotices,
   recoverSession,
 } from '../../src/sessions/journal.js';
 
@@ -59,6 +60,29 @@ describe('session journal', () => {
     expect(projectStatus(after)).toBe('idle');
     expect(after.at(-1)?.type).toBe('turn_interrupted');
     expect(recoverSession(sid, dir)).toEqual([]);
+  });
+
+  it('projects unresolved recovered turn notices from interrupted journal records', () => {
+    appendJournal(sid, { type: 'turn_start', messageId: 'm1', content: 'lost work', cwd: '/w', mode: 'chat' }, dir);
+    recoverSession(sid, dir);
+    expect(recoveredTurnNotices(readJournal(sid, dir))).toEqual([
+      { messageId: 'm1', content: 'lost work' },
+    ]);
+  });
+
+  it('clears a recovered notice after the same messageId is successfully re-sent', () => {
+    appendJournal(sid, { type: 'turn_start', messageId: 'm1', content: 'lost work', cwd: '/w', mode: 'chat' }, dir);
+    recoverSession(sid, dir);
+    appendJournal(sid, { type: 'turn_start', messageId: 'm1', content: 'lost work', cwd: '/w', mode: 'chat' }, dir);
+    appendJournal(sid, { type: 'turn_end', messageId: 'm1', status: 'done', output: 'done' }, dir);
+    expect(danglingTurns(readJournal(sid, dir))).toEqual([]);
+    expect(recoveredTurnNotices(readJournal(sid, dir))).toEqual([]);
+  });
+
+  it('does not report completed or clean sessions as recovered notices', () => {
+    appendJournal(sid, { type: 'turn_start', messageId: 'm1', content: 'ordinary work', cwd: '/w', mode: 'chat' }, dir);
+    appendJournal(sid, { type: 'turn_end', messageId: 'm1', status: 'done', output: 'ok' }, dir);
+    expect(recoveredTurnNotices(readJournal(sid, dir))).toEqual([]);
   });
 
   it('completedTurn enables idempotent replay only for finished turns', () => {

--- a/tests/webActivity.test.ts
+++ b/tests/webActivity.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { formatElapsed } from '../web/src/lib/duration.js';
 
 describe('agent activity duration', () => {
@@ -6,5 +6,38 @@ describe('agent activity duration', () => {
     expect(formatElapsed(0)).toBe('0 Min 0 S');
     expect(formatElapsed(65_900)).toBe('1 Min 5 S');
     expect(formatElapsed(-100)).toBe('0 Min 0 S');
+  });
+});
+
+describe('mapBackendMessages recovered turns', () => {
+  it('restores recovered notices from session detail projection', async () => {
+    vi.stubGlobal('location', { protocol: 'http:', host: '127.0.0.1:3000' });
+    const { mapBackendMessages } = await import('../web/src/hooks/useChat.js');
+
+    const messages = mapBackendMessages(
+      [
+        { role: 'user', content: 'resume now' },
+        { role: 'assistant', content: 'ready' },
+      ],
+      [{ messageId: 'lost-msg-1', content: 'build the dashboard' }],
+    );
+
+    expect(messages.at(-1)).toEqual({
+      role: 'recovered',
+      messageId: 'lost-msg-1',
+      content: 'build the dashboard',
+    });
+  });
+
+  it('does not synthesize a recovered notice when none is projected', async () => {
+    vi.stubGlobal('location', { protocol: 'http:', host: '127.0.0.1:3000' });
+    const { mapBackendMessages } = await import('../web/src/hooks/useChat.js');
+
+    const messages = mapBackendMessages([
+      { role: 'user', content: 'hello' },
+      { role: 'assistant', content: 'hi' },
+    ]);
+
+    expect(messages.some((message) => message.role === 'recovered')).toBe(false);
   });
 });

--- a/tests/webActivity.test.ts
+++ b/tests/webActivity.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { formatElapsed } from '../web/src/lib/duration.js';
+import { mapBackendMessages } from '../web/src/lib/messages.js';
 
 describe('agent activity duration', () => {
   it('formats elapsed time for the Worked for disclosure', () => {
@@ -10,10 +11,7 @@ describe('agent activity duration', () => {
 });
 
 describe('mapBackendMessages recovered turns', () => {
-  it('restores recovered notices from session detail projection', async () => {
-    vi.stubGlobal('location', { protocol: 'http:', host: '127.0.0.1:3000' });
-    const { mapBackendMessages } = await import('../web/src/hooks/useChat.js');
-
+  it('restores recovered notices from session detail projection', () => {
     const messages = mapBackendMessages(
       [
         { role: 'user', content: 'resume now' },
@@ -29,10 +27,7 @@ describe('mapBackendMessages recovered turns', () => {
     });
   });
 
-  it('does not synthesize a recovered notice when none is projected', async () => {
-    vi.stubGlobal('location', { protocol: 'http:', host: '127.0.0.1:3000' });
-    const { mapBackendMessages } = await import('../web/src/hooks/useChat.js');
-
+  it('does not synthesize a recovered notice when none is projected', () => {
     const messages = mapBackendMessages([
       { role: 'user', content: 'hello' },
       { role: 'assistant', content: 'hi' },

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -121,16 +121,16 @@ export default function App() {
   }, [chat]);
 
   const handleSend = useCallback(
-    (text: string) => {
+    (text: string, messageId?: string) => {
       if (text.trim() === '/compact') {
         chat.compact();
         return;
       }
       if (!chat.connected) {
         chat.connect();
-        setTimeout(() => chat.send(text), 300);
+        setTimeout(() => chat.send(text, messageId), 300);
       } else {
-        chat.send(text);
+        chat.send(text, messageId);
       }
       setTimeout(() => setSidebarRefresh((n) => n + 1), 2000);
     },

--- a/web/src/components/ChatThread.tsx
+++ b/web/src/components/ChatThread.tsx
@@ -8,7 +8,7 @@ type Props = {
   messages: ChatMessage[];
   connected: boolean;
   mode?: AgentMode;
-  onProceed?: (text: string) => void;
+  onProceed?: (text: string, messageId?: string) => void;
 };
 
 export function ChatThread({ messages, connected, mode, onProceed }: Props) {

--- a/web/src/components/MessageBubble.tsx
+++ b/web/src/components/MessageBubble.tsx
@@ -21,7 +21,7 @@ function ThinkingDots() {
 type Props = {
   message: ChatMessage;
   mode?: AgentMode;
-  onProceed?: (text: string) => void;
+  onProceed?: (text: string, messageId?: string) => void;
 };
 
 export function MessageBubble({ message, mode, onProceed }: Props) {
@@ -47,7 +47,7 @@ export function MessageBubble({ message, mode, onProceed }: Props) {
           {onProceed && (
             <button
               type="button"
-              onClick={() => onProceed(message.content)}
+              onClick={() => onProceed(message.content, message.messageId)}
               className="mt-3 inline-flex items-center gap-1.5 rounded-md border border-yellow-500/30 bg-yellow-500/10 px-2.5 py-1.5 text-xs font-medium text-yellow-200 hover:bg-yellow-500/20"
               title="Re-send recovered message"
             >

--- a/web/src/hooks/useChat.ts
+++ b/web/src/hooks/useChat.ts
@@ -1,6 +1,7 @@
 import { useState, useCallback, useRef } from 'react';
 import { client, fetchSessionDetail } from '../lib/client.ts';
-import type { ChatMessage, ToolCallEvent, ServerEvent, BackendChatMessage, RecoveredTurn, ApprovalMode, AgentMode, PendingApproval, CodePermissionMode } from '../types.ts';
+import { mapBackendMessages } from '../lib/messages.ts';
+import type { ChatMessage, ToolCallEvent, ServerEvent, ApprovalMode, AgentMode, PendingApproval, CodePermissionMode } from '../types.ts';
 
 export type UseChatOptions = {
   sessionId?: string;
@@ -38,80 +39,6 @@ function insertBeforePendingAssistant(messages: ChatMessage[], message: ChatMess
     }
   }
   return [...messages, message];
-}
-
-/** Convert saved backend messages into UI chat messages for session restore */
-export function mapBackendMessages(raw: BackendChatMessage[], recoveredTurns: RecoveredTurn[] = []): ChatMessage[] {
-  const result: ChatMessage[] = [];
-  let assistantBuf: { content: string; toolCalls: ToolCallEvent[] } | null = null;
-  // Map from tool_call_id → index in assistantBuf.toolCalls
-  const tcIndex = new Map<string, number>();
-
-  const flushAssistant = () => {
-    if (assistantBuf) {
-      result.push({ role: 'assistant', content: assistantBuf.content, toolCalls: assistantBuf.toolCalls, pending: false });
-      assistantBuf = null;
-      tcIndex.clear();
-    }
-  };
-
-  for (const msg of raw) {
-    if (msg.role === 'system') continue;
-
-    if (msg.role === 'user') {
-      flushAssistant();
-      result.push({ role: 'user', content: msg.content });
-      continue;
-    }
-
-    if (msg.role === 'assistant') {
-      flushAssistant();
-      // Build tool calls from native tool_calls array
-      const toolCalls: ToolCallEvent[] = (msg.tool_calls ?? []).map((tc) => ({
-        id: tc.id,
-        name: tc.name,
-        input: (() => { try { return JSON.parse(tc.arguments); } catch { return tc.arguments; } })(),
-        status: 'done' as const,
-      }));
-      assistantBuf = { content: msg.content, toolCalls };
-      // Register id→index for matching tool results
-      toolCalls.forEach((tc, i) => tcIndex.set(tc.id, i));
-      continue;
-    }
-
-    if (msg.role === 'tool' && assistantBuf) {
-      const id = msg.tool_call_id ?? '';
-      const name = msg.name ?? 'unknown';
-      const output = msg.content.replace(/^\[Tool \w+ result\]:\n/, '').replace(/^\[Tool \w+ error\]: /, '');
-      const isError = msg.content.startsWith(`[Tool ${name} error]:`);
-
-      const idx = id ? tcIndex.get(id) : undefined;
-      if (idx !== undefined) {
-        // Update existing tool call with its result
-        const tc = assistantBuf.toolCalls[idx]!;
-        if (isError) {
-          assistantBuf.toolCalls[idx] = { ...tc, error: output, status: 'error' };
-        } else {
-          assistantBuf.toolCalls[idx] = { ...tc, output, status: 'done' };
-        }
-      } else {
-        // Orphan tool result — create an entry
-        assistantBuf.toolCalls.push({
-          id: id || `tc_${assistantBuf.toolCalls.length}`,
-          name,
-          input: {},
-          output: isError ? undefined : output,
-          error: isError ? output : undefined,
-          status: isError ? 'error' : 'done',
-        });
-      }
-    }
-  }
-  flushAssistant();
-  for (const recovered of recoveredTurns) {
-    result.push({ role: 'recovered', ...recovered });
-  }
-  return result;
 }
 
 export function useChat(opts: UseChatOptions = {}) {

--- a/web/src/hooks/useChat.ts
+++ b/web/src/hooks/useChat.ts
@@ -1,6 +1,6 @@
 import { useState, useCallback, useRef } from 'react';
 import { client, fetchSessionDetail } from '../lib/client.ts';
-import type { ChatMessage, ToolCallEvent, ServerEvent, BackendChatMessage, ApprovalMode, AgentMode, PendingApproval, CodePermissionMode } from '../types.ts';
+import type { ChatMessage, ToolCallEvent, ServerEvent, BackendChatMessage, RecoveredTurn, ApprovalMode, AgentMode, PendingApproval, CodePermissionMode } from '../types.ts';
 
 export type UseChatOptions = {
   sessionId?: string;
@@ -41,7 +41,7 @@ function insertBeforePendingAssistant(messages: ChatMessage[], message: ChatMess
 }
 
 /** Convert saved backend messages into UI chat messages for session restore */
-function mapBackendMessages(raw: BackendChatMessage[]): ChatMessage[] {
+export function mapBackendMessages(raw: BackendChatMessage[], recoveredTurns: RecoveredTurn[] = []): ChatMessage[] {
   const result: ChatMessage[] = [];
   let assistantBuf: { content: string; toolCalls: ToolCallEvent[] } | null = null;
   // Map from tool_call_id → index in assistantBuf.toolCalls
@@ -108,6 +108,9 @@ function mapBackendMessages(raw: BackendChatMessage[]): ChatMessage[] {
     }
   }
   flushAssistant();
+  for (const recovered of recoveredTurns) {
+    result.push({ role: 'recovered', ...recovered });
+  }
   return result;
 }
 
@@ -232,7 +235,7 @@ export function useChat(opts: UseChatOptions = {}) {
             if (event.replayed && event.sessionId) {
               void fetchSessionDetail(event.sessionId)
                 .then((detail) => {
-                  const uiMessages = mapBackendMessages(detail.messages);
+                  const uiMessages = mapBackendMessages(detail.messages, detail.recoveredTurns);
                   for (let i = uiMessages.length - 1; i >= 0; i--) {
                     const msg = uiMessages[i];
                     if (msg?.role === 'assistant') {
@@ -305,9 +308,9 @@ export function useChat(opts: UseChatOptions = {}) {
   }, []);
 
   const send = useCallback(
-    (content: string) => {
+    (content: string, recoveredMessageId?: string) => {
       if (sending) return;
-      const messageId = crypto.randomUUID();
+      const messageId = recoveredMessageId ?? crypto.randomUUID();
       setSending(true);
       setRunningSessionId(currentSessionId);
       pendingToolCallsRef.current.clear();
@@ -358,7 +361,7 @@ export function useChat(opts: UseChatOptions = {}) {
   const loadSession = useCallback(async (id: string) => {
     try {
       const detail = await fetchSessionDetail(id);
-      const uiMessages = mapBackendMessages(detail.messages);
+      const uiMessages = mapBackendMessages(detail.messages, detail.recoveredTurns);
       setMessages(uiMessages);
       setCurrentSessionId(id);
       return detail;

--- a/web/src/lib/client.ts
+++ b/web/src/lib/client.ts
@@ -1,4 +1,4 @@
-import type { ServerEvent, SessionMeta, AppConfig, BackendChatMessage, ApprovalMode, AgentMode, ProviderPoolConfig, CodePermissionMode, SarifImportResult, RemediationFinding, RemediationWorktreeResult, RemediationCase, RemediationCaseStatus, SkillSummary, LLMConfig, Profile, DvalinScanner, DvalinScannerId, DvalinScanResult } from '../types.ts';
+import type { ServerEvent, SessionMeta, AppConfig, BackendChatMessage, RecoveredTurn, ApprovalMode, AgentMode, ProviderPoolConfig, CodePermissionMode, SarifImportResult, RemediationFinding, RemediationWorktreeResult, RemediationCase, RemediationCaseStatus, SkillSummary, LLMConfig, Profile, DvalinScanner, DvalinScannerId, DvalinScanResult } from '../types.ts';
 
 const WS_URL = `${location.protocol === 'https:' ? 'wss' : 'ws'}://${location.host}/ws`;
 
@@ -233,6 +233,7 @@ export type SessionDetail = {
   id: string;
   cwd: string;
   messages: BackendChatMessage[];
+  recoveredTurns?: RecoveredTurn[];
   summary?: string;
 };
 

--- a/web/src/lib/messages.ts
+++ b/web/src/lib/messages.ts
@@ -1,0 +1,71 @@
+import type { BackendChatMessage, ChatMessage, RecoveredTurn, ToolCallEvent } from '../types.ts';
+
+/** Convert saved backend messages into UI chat messages for session restore. */
+export function mapBackendMessages(raw: BackendChatMessage[], recoveredTurns: RecoveredTurn[] = []): ChatMessage[] {
+  const result: ChatMessage[] = [];
+  let assistantBuf: { content: string; toolCalls: ToolCallEvent[] } | null = null;
+  // Map from tool_call_id to index in assistantBuf.toolCalls.
+  const tcIndex = new Map<string, number>();
+
+  const flushAssistant = () => {
+    if (assistantBuf) {
+      result.push({ role: 'assistant', content: assistantBuf.content, toolCalls: assistantBuf.toolCalls, pending: false });
+      assistantBuf = null;
+      tcIndex.clear();
+    }
+  };
+
+  for (const msg of raw) {
+    if (msg.role === 'system') continue;
+
+    if (msg.role === 'user') {
+      flushAssistant();
+      result.push({ role: 'user', content: msg.content });
+      continue;
+    }
+
+    if (msg.role === 'assistant') {
+      flushAssistant();
+      const toolCalls: ToolCallEvent[] = (msg.tool_calls ?? []).map((tc) => ({
+        id: tc.id,
+        name: tc.name,
+        input: (() => { try { return JSON.parse(tc.arguments); } catch { return tc.arguments; } })(),
+        status: 'done' as const,
+      }));
+      assistantBuf = { content: msg.content, toolCalls };
+      toolCalls.forEach((tc, i) => tcIndex.set(tc.id, i));
+      continue;
+    }
+
+    if (msg.role === 'tool' && assistantBuf) {
+      const id = msg.tool_call_id ?? '';
+      const name = msg.name ?? 'unknown';
+      const output = msg.content.replace(/^\[Tool \w+ result\]:\n/, '').replace(/^\[Tool \w+ error\]: /, '');
+      const isError = msg.content.startsWith(`[Tool ${name} error]:`);
+
+      const idx = id ? tcIndex.get(id) : undefined;
+      if (idx !== undefined) {
+        const tc = assistantBuf.toolCalls[idx]!;
+        if (isError) {
+          assistantBuf.toolCalls[idx] = { ...tc, error: output, status: 'error' };
+        } else {
+          assistantBuf.toolCalls[idx] = { ...tc, output, status: 'done' };
+        }
+      } else {
+        assistantBuf.toolCalls.push({
+          id: id || `tc_${assistantBuf.toolCalls.length}`,
+          name,
+          input: {},
+          output: isError ? undefined : output,
+          error: isError ? output : undefined,
+          status: isError ? 'error' : 'done',
+        });
+      }
+    }
+  }
+  flushAssistant();
+  for (const recovered of recoveredTurns) {
+    result.push({ role: 'recovered', ...recovered });
+  }
+  return result;
+}

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -74,6 +74,11 @@ export type BackendChatMessage = {
   tool_calls?: Array<{ id: string; name: string; arguments: string }>;
 };
 
+export type RecoveredTurn = {
+  messageId: string;
+  content: string;
+};
+
 export type ToolCallEvent = {
   id: string;
   name: string;
@@ -88,7 +93,7 @@ export type ToolCallEvent = {
 
 export type ChatMessage =
   | { role: 'user'; content: string; messageId?: string }
-  | { role: 'recovered'; content: string; messageId: string }
+  | ({ role: 'recovered' } & RecoveredTurn)
   | {
       role: 'assistant';
       content: string;


### PR DESCRIPTION
## Summary

- expose unresolved recovered-turn notices from the existing session journal in session detail responses
- restore recovered notices when the web UI reloads or re-opens a session
- preserve the original recovered messageId when Re-send is clicked so a successful resend resolves the notice

Fixes #120

## Testing

- [x] npm install
- [x] cd web && npm install
- [x] npx vitest run tests/sessions/journal.test.ts tests/webActivity.test.ts tests/server/wsHandler.test.ts
- [x] npm run check
- [x] npm run build
- [x] npm run web:build

## Security and AI Governance

- [x] This change does not expand file, shell, network, model, or approval permissions.
- [x] No governance evidence update required: this replays existing session-journal recovery state in the local session restore UI and does not change prompts, policy, providers, audit logging, or release/build security.
- [x] No new model/provider/tool or external data flow is introduced.

## Notes

AI assistance disclosure: implemented with OpenAI Codex.
