### PR TITLE
build(deps): bump codeql-action init+analyze to v4.37.1 together

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -25,13 +25,13 @@ jobs:
           persist-credentials: false
 
       - name: Initialize CodeQL
-        # github/codeql-action/init v4.36.2
-        uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9
+        # github/codeql-action/init v4.37.1
+        uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a
         with:
           languages: javascript-typescript
 
       - name: Perform CodeQL analysis
-        # github/codeql-action/analyze v4.37.0
-        uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9
+        # github/codeql-action/analyze v4.37.1
+        uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a
         with:
           category: '/language:javascript-typescript'


### PR DESCRIPTION
## Summary

Supersedes #126 and #127. Dependabot split the `codeql-action/init` and `codeql-action/analyze` bumps into separate PRs, but both steps in `codeql.yml` are pinned to the **same** SHA and must run at the **same** version. Bumping one line alone de-syncs the pair and fails the required *Analyze JavaScript and TypeScript* check with:

```
##[error]Loaded a configuration file for version '4.37.1', but running version '4.37.0'
```

This PR bumps **both** `init` (line 29) and `analyze` (line 35) to `7188fc363630916deb702c7fdcf4e481b751f97a` (v4.37.1) in one commit, so the versions stay aligned and CI passes. It also corrects the version comments, which previously read `v4.36.2` / `v4.37.0` while both lines actually pointed at the same SHA.

`upload-sarif` (in `scorecard.yml`) was already bumped to the same v4.37.1 SHA via #124.

## Testing

CI on this PR (the CodeQL analysis job runs the action itself — a green *Analyze JavaScript and TypeScript* check is the proof the init/analyze pairing is consistent).

## Security and AI Governance

- [x] This change does not expand file, shell, network, model, or approval permissions.
- [x] Release/build security surface: this is a pinned-SHA bump of the CodeQL scanning action to an upstream patch release; no governance evidence change required.
- [x] No new model/provider/tool or data flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)