### PR TITLE
build(deps): group GitHub Actions bumps into one PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -43,3 +43,11 @@ updates:
     labels:
       - dependencies
       - security
+    # Bump all GitHub Actions in a single PR. Coupled actions such as
+    # codeql-action/init + analyze + upload-sarif must move to the same
+    # version together; a per-action PR bumps one and fails CI with a
+    # version mismatch (see #126/#127, resolved by #130).
+    groups:
+      github-actions:
+        patterns:
+          - '*'


### PR DESCRIPTION
## Summary

The `github-actions` ecosystem in `.github/dependabot.yml` had no `groups` block, so Dependabot opened one PR per action (#123–#127). That splits **coupled** actions across PRs — most importantly `codeql-action/init` + `analyze` + `upload-sarif`, which must run at the same version. A per-action PR bumps only one, de-syncing the pair and failing the required *Analyze JavaScript and TypeScript* check with:

```
Loaded a configuration file for version '4.37.1', but running version '4.37.0'
```

That's what blocked #126 and #127 this week (resolved by hand in #130).

This adds a `github-actions` group with `patterns: ['*']`, mirroring the existing `node-runtime` and `web-runtime` groups. From now on all action bumps arrive in a **single** PR, so coupled actions stay in lockstep and CI passes.

## Testing

Config-only change (validated as well-formed YAML locally). No runtime surface — takes effect on Dependabot's next weekly run (Monday).

## Security and AI Governance

- [x] This change does not expand file, shell, network, model, or approval permissions.
- [x] Release/build security: only changes how dependency-update PRs are batched; the pinned-SHA + CI-gate model is unchanged. No governance evidence update required.
- [x] No new model/provider/tool or data flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)