### PR TITLE
docs: refresh roadmap and add issue templates for contributors

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,64 @@
+name: Bug report
+description: Something behaves incorrectly. (For a security vulnerability, do NOT file here — see SECURITY.md for private reporting.)
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the report. **Security vulnerabilities must not be filed as public issues** — see [SECURITY.md](../blob/main/SECURITY.md) for private disclosure.
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened
+      description: What did you do, what did you expect, and what happened instead?
+      placeholder: |
+        1. Ran `dvalincode …`
+        2. Expected …
+        3. Got …
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: Output of `dvalincode --version` (or the commit SHA / release tag).
+      placeholder: "0.14.0"
+    validations:
+      required: true
+  - type: dropdown
+    id: surface
+    attributes:
+      label: Surface
+      description: Where did it happen?
+      options:
+        - CLI / TUI
+        - Web UI
+        - Desktop GUI
+        - Harness / headless / MCP server
+        - Dvalin security scan / remediation
+        - Other / not sure
+    validations:
+      required: true
+  - type: input
+    id: platform
+    attributes:
+      label: OS & platform
+      placeholder: "macOS 15 arm64 / Ubuntu 24.04 x64 / Windows 11"
+    validations:
+      required: true
+  - type: textarea
+    id: governance
+    attributes:
+      label: Governance impact (if any)
+      description: Does this involve policy, approvals, audit logging, egress, or the sandbox? If a control failed **open** (allowed something it should have blocked), say so clearly — that is treated as high priority.
+      placeholder: "e.g. a tool ran despite a policy deny; an audit event was missing; egress reached an un-allow-listed host."
+    validations:
+      required: false
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs / output
+      description: Relevant terminal output or an audit `report`. **Redact secrets, tokens, and private paths first.**
+      render: shell
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: 🔒 Report a security vulnerability (private)
+    url: https://github.com/arthurpanhku/dvalincode/blob/main/SECURITY.md
+    about: Do NOT open a public issue for vulnerabilities. Follow the private disclosure process in SECURITY.md.
+  - name: 🙌 Good first issues & how to contribute
+    url: https://github.com/arthurpanhku/dvalincode/blob/main/CONTRIBUTING.md
+    about: New here? Start with CONTRIBUTING.md and the "good first issue" / "mentored" labels.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,45 @@
+name: Feature request
+description: Propose a capability or improvement.
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Before filing, skim [ROADMAP.md](../blob/main/ROADMAP.md) and open issues — the thing you want may already be tracked.
+        Every capability in DvalinCode must pass through the policy + audit chokepoints (see [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) → "governance rules").
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / motivation
+      description: What are you trying to do, and why is it hard or impossible today?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What should happen? A rough sketch is fine — design docs with acceptance matrices land in `docs/` before large implementations.
+    validations:
+      required: true
+  - type: checkboxes
+    id: governance-surface
+    attributes:
+      label: Governance surface
+      description: Check any this proposal would touch. (Not a blocker — it helps triage, and these areas need a threat-model note in the eventual PR.)
+      options:
+        - label: Adds or changes a side effect, subprocess, or network egress
+        - label: Introduces a new model, provider, tool, or external data flow
+        - label: Changes policy, approvals, audit logging, or the sandbox
+        - label: None of the above (pure UX, docs, or internal refactor)
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+    validations:
+      required: false
+  - type: checkboxes
+    id: contribute
+    attributes:
+      label: Contribution
+      options:
+        - label: I'd be willing to work on this (a maintainer can help scope it)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,20 +6,26 @@ Every item below is governed by one architectural rule: *no capability may bypas
 
 Issues are the source of truth for status; this file is the map. Want one of these? Comment on its issue — most have a `help wanted` or `good first issue` label.
 
-## Now (in progress / next up)
+## Recently shipped ✅
+
+- **Evidence Pack v1** ([#51](https://github.com/arthurpanhku/dvalincode/issues/51)) — offline-verifiable governance bundle (resolved policy + hash, audit chains, enforcement posture) mapped to OpenSSF / ISO-42001 clauses.
+- **`run-tool` policy bypass fixed** ([#45](https://github.com/arthurpanhku/dvalincode/issues/45)) — the CLI entrypoint now resolves org policy like every other surface.
+- **Durable-session transport wiring** ([#46](https://github.com/arthurpanhku/dvalincode/issues/46) · [#47](https://github.com/arthurpanhku/dvalincode/issues/47)) — stable `messageId` for idempotent replay, plus recovered-turn notices in the TUI and web UI.
+- **Governed harness mode** ([#115](https://github.com/arthurpanhku/dvalincode/pull/115)) — headless runs, an MCP server surface, and the unattended permission tier.
+
+## Now / next up
 
 | Item | Why it matters | Ref |
 |---|---|---|
-| **Evidence Pack v1** | Turn governance claims into an offline-verifiable bundle (resolved policy + hash, audit chains, enforcement posture, run summaries) mapped to OpenSSF / ISO-42001 clauses. Evidence > claims — the highest-leverage step toward the North Star. | [#51](https://github.com/arthurpanhku/dvalincode/issues/51) |
-| **Fix `run-tool` policy bypass** | The `run-tool` CLI entrypoint builds its context without `loadPolicy`, sidestepping org policy — a real governance gap. | [#45](https://github.com/arthurpanhku/dvalincode/issues/45) |
-| **Durable-session transport wiring** | Engine-level crash recovery + idempotent replay exist; transports don't pass a stable `messageId` or surface recovered turns yet. | [#46](https://github.com/arthurpanhku/dvalincode/issues/46) · [#47](https://github.com/arthurpanhku/dvalincode/issues/47) |
+| **Provider adapter conformance suite** | A shared contract every provider must pass (egress allow-listing, redaction, audit) — turns "should we trust a new provider?" into an objective gate. Highest-leverage onboarding for external model vendors. | [#118](https://github.com/arthurpanhku/dvalincode/issues/118) |
+| **stdio / local MCP servers** | Local MCP without network egress — completes the MCP story beyond remote gateways. Same governed mapping as [GOVERNED-MCP.md](docs/GOVERNED-MCP.md). | [#52](https://github.com/arthurpanhku/dvalincode/issues/52) |
+| **Structured approval engine** | Upgrade boolean approvals to scoped grants ("allow `npm test` for this run") — subject, scope, expiry, recorded in audit. | [#53](https://github.com/arthurpanhku/dvalincode/issues/53) |
+| **Harness-mode + unattended-tier test coverage** | Pin the most governance-sensitive path (no human in the loop) with bypass-proof tests. | [#119](https://github.com/arthurpanhku/dvalincode/issues/119) |
 
 ## Next
 
 | Item | Why it matters | Ref |
 |---|---|---|
-| **stdio / local MCP servers** | Local MCP without network egress — completes the MCP story beyond remote gateways. Same governed mapping as [GOVERNED-MCP.md](docs/GOVERNED-MCP.md). | [#52](https://github.com/arthurpanhku/dvalincode/issues/52) |
-| **Structured approval engine** | Upgrade boolean approvals to scoped grants ("allow `npm test` for this run") — subject, scope, expiry, recorded in audit. | [#53](https://github.com/arthurpanhku/dvalincode/issues/53) |
 | **Read-only Explore subagent** | Parallel read-only exploration that inherits the parent policy and gets its own audit chain linked to the parent run. | [#54](https://github.com/arthurpanhku/dvalincode/issues/54) |
 | **Remediation worktree under the sandbox profile** | Close the documented exemption for the two local git calls (needs sandbox write access to the remediation dir first). | [#55](https://github.com/arthurpanhku/dvalincode/issues/55) |
 | **MCP discovery audit anchoring** | Tool *calls* are audited per run; anchor the pre-run discovery connection into the chain as well. | [#56](https://github.com/arthurpanhku/dvalincode/issues/56) |


### PR DESCRIPTION
## Summary

Two contributor-onboarding fixes.

**ROADMAP.md** — the entire "Now (in progress / next up)" section was stale: all four items (#45, #46, #47, #51) had shipped and were closed, so a newcomer's first read of the roadmap was a list of *done* work.
- New **"Recently shipped ✅"** block records those, plus governed harness mode (#115).
- **"Now / next up"** repopulated with genuinely-open, high-leverage items: provider conformance suite (#118), stdio MCP (#52), structured approval (#53), harness-mode tests (#119).
- "Next" keeps #54/#55/#56.

**Issue templates** — the repo had none (`.github/ISSUE_TEMPLATE/` did not exist). Added GitHub-Forms templates:
- `bug_report.yml` and `feature_request.yml`, both with **governance-aware fields** matching the PR template — "does this touch policy/audit/egress?", and an explicit prompt that a control failing **open** is high priority.
- `config.yml` routes security vulnerabilities to the private `SECURITY.md` flow (not public issues) and links newcomers to `CONTRIBUTING.md`.

## Testing

Docs/config only — no runtime surface. All three template YAMLs validated as well-formed locally. GitHub renders the forms on the "New issue" screen after merge.

## Security and AI Governance

- [x] This change does not expand file, shell, network, model, or approval permissions.
- [x] No prompt, policy, provider, audit logging, or release/build behavior changes; no governance evidence update required. (The bug template actively steers vuln reports to private disclosure.)
- [x] No new model/provider/tool or data flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)