### PR TITLE
fix: start the embedded server under gui:dev (bun run), not just compiled

### DIFF
--- a/src/gui/index.ts
+++ b/src/gui/index.ts
@@ -10,6 +10,8 @@
 // re-spawns itself with DVALINCODE_GUI_ROLE=server to run the HTTP server as a
 // child process, and the parent keeps the webview on its own main thread.
 
+import { basename } from 'node:path';
+
 if (process.env.DVALINCODE_GUI_ROLE === 'server') {
   const { startServer } = await import('../server/index.js');
   await startServer({ host: '127.0.0.1', port: 0, open: false });
@@ -19,7 +21,16 @@ if (process.env.DVALINCODE_GUI_ROLE === 'server') {
 
   const { Webview } = await import('webview-bun');
 
-  const child = Bun.spawn([process.execPath], {
+  // Re-spawn ourselves as the server child. In a `bun build --compile` binary
+  // `process.execPath` is the compiled app, and relaunching it re-runs this
+  // embedded entry (which then takes the server branch above). Under
+  // `bun run src/gui/index.ts` (dev), `process.execPath` is the Bun runtime, so
+  // spawning it with no script just prints Bun's help and exits — the server
+  // never starts. Pass this module's path in that case so Bun executes it.
+  const underBunRuntime = /^bun/i.test(basename(process.execPath));
+  const serverCmd = underBunRuntime ? [process.execPath, import.meta.path] : [process.execPath];
+
+  const child = Bun.spawn(serverCmd, {
     env: { ...process.env, DVALINCODE_GUI_ROLE: 'server' },
     stdout: 'pipe',
     stderr: 'inherit',


### PR DESCRIPTION
## Summary

Fixes #138. `npm run gui:dev` never opened the desktop window — the embedded server child never started, so the parent timed out after 30s (`embedded server did not start within 30s`) and exited 1.

**Root cause:** the parent re-spawns itself as the server role with `Bun.spawn([process.execPath])` ([src/gui/index.ts](src/gui/index.ts)). That assumes relaunching `process.execPath` re-runs *this* embedded entry — true for a `bun build --compile` standalone binary, but under `bun run src/gui/index.ts` (the `gui:dev` script) `process.execPath` is the **Bun runtime**. `Bun.spawn([bun])` with no script argument just prints Bun's top-level help and exits, so the `DVALINCODE_GUI_ROLE=server` branch never runs.

**Fix:** when running under the Bun runtime (dev), pass `import.meta.path` so Bun executes this module; the compiled binary keeps the bare `[process.execPath]` self-respawn. One added `node:path` import.

## Testing

- `npm run check` — typecheck clean, **296/296 tests pass**. (`src/gui` is excluded from tsc, so the Bun-only `import.meta.path` is fine.)
- Manual: `npm run gui:dev` now boots the embedded server — it prints `http://localhost:<port>` and that port returns **HTTP 200**. Before the fix it printed Bun's help and timed out.
- Compiled-binary launch path is unchanged (still a single bare self-respawn).

## How it was found

Surfaced during an end-to-end manual test of the Dvalin scan→fix→verify flow. The scan/fix engine itself works correctly (verified separately, 100/100 health with all findings remediated in an isolated worktree); this fix is purely the GUI dev-launch wrapper.

## Security and AI Governance

- [x] This change does not expand file, shell, network, model, or approval permissions. It changes which arguments a self-respawn passes to its own process; the child still runs the same entry with the same `DVALINCODE_GUI_ROLE=server` env.
- [x] No prompt, policy, provider, audit logging, or release/build security behavior changes.
- [x] No new model/provider/tool or data flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)