### PR TITLE
feat: validate local MCP server config

### DIFF
--- a/src/mcp/config.ts
+++ b/src/mcp/config.ts
@@ -1,4 +1,36 @@
-import type { McpServerConfig } from '../server/configStore.js';
+import { z } from 'zod';
+
+export const remoteMcpServerConfigSchema = z
+  .object({
+    id: z.string().trim().min(1, 'MCP server id must not be empty'),
+    url: z.url('MCP server url must be a valid URL'),
+    headers: z.record(z.string(), z.string()).optional(),
+    enabled: z.boolean().optional(),
+  })
+  .strict();
+
+export const localMcpServerConfigSchema = z
+  .object({
+    id: z.string().trim().min(1, 'MCP server id must not be empty'),
+    command: z.string().trim().min(1, 'MCP server command must not be empty'),
+    args: z.array(z.string()),
+    enabled: z.boolean().optional(),
+  })
+  .strict();
+
+export const mcpServerConfigSchema = z.union([
+  remoteMcpServerConfigSchema,
+  localMcpServerConfigSchema,
+]);
+
+export type RemoteMcpServerConfig = z.infer<typeof remoteMcpServerConfigSchema>;
+export type LocalMcpServerConfig = z.infer<typeof localMcpServerConfigSchema>;
+export type McpServerConfig = z.infer<typeof mcpServerConfigSchema>;
+
+/** Parse one remote or local MCP config entry at the configuration boundary. */
+export function parseMcpServerConfig(input: unknown): McpServerConfig {
+  return mcpServerConfigSchema.parse(input);
+}
 
 /**
  * Resolve `${ENV}` placeholders in header values from the process environment.
@@ -15,6 +47,8 @@ export function resolveHeaders(headers: Record<string, string> | undefined): Rec
 }
 
 /** Servers that are explicitly enabled. Disabled/omitted servers are never connected. */
-export function enabledServers(servers: McpServerConfig[] | undefined): McpServerConfig[] {
-  return (servers ?? []).filter(s => s.enabled);
+export function enabledServers(servers: McpServerConfig[] | undefined): RemoteMcpServerConfig[] {
+  return (servers ?? []).filter(
+    (server): server is RemoteMcpServerConfig => server.enabled === true && 'url' in server,
+  );
 }

--- a/src/mcp/register.ts
+++ b/src/mcp/register.ts
@@ -3,7 +3,7 @@ import { checkMcpServer, PolicyViolationError, type ResolvedPolicy } from '../co
 import type { AuditSink } from '../audit/log.js';
 import type { Tool, ToolAccess } from '../tools/types.js';
 import type { ToolRegistry } from '../tools/registry.js';
-import type { McpServerConfig } from '../server/configStore.js';
+import type { McpServerConfig } from './config.js';
 import { McpClient, type McpToolDef, type McpCallResult } from './client.js';
 import { resolveHeaders, enabledServers } from './config.js';
 

--- a/src/server/configStore.ts
+++ b/src/server/configStore.ts
@@ -2,6 +2,8 @@ import { readFile, writeFile, mkdir } from 'node:fs/promises';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
 import type { ProviderKeySource } from '../providers/secrets.js';
+import type { McpServerConfig } from '../mcp/config.js';
+export type { McpServerConfig } from '../mcp/config.js';
 
 export type LLMConfig = {
   provider: string;
@@ -39,15 +41,6 @@ export type ProviderPoolConfig = {
   enabled: boolean;
   policy: RotationPolicy;
   entries: PoolEntry[];
-};
-
-/** A remote MCP server DvalinCode may connect to. Header values may contain
- * `${ENV}` placeholders resolved from the environment at connect time. */
-export type McpServerConfig = {
-  id: string;
-  url: string;
-  headers?: Record<string, string>;
-  enabled?: boolean;
 };
 
 export type McpConfig = { servers: McpServerConfig[] };
@@ -115,12 +108,16 @@ export function maskConfig(config: AppConfig): AppConfig & { llm: { apiKeySet: b
 
   const maskedMcp: McpConfig | undefined = config.mcp
     ? {
-        servers: config.mcp.servers.map(s => ({
-          ...s,
-          headers: s.headers
-            ? Object.fromEntries(Object.keys(s.headers).map(k => [k, '••••••••']))
-            : undefined,
-        })),
+        servers: config.mcp.servers.map(s =>
+          'headers' in s
+            ? {
+                ...s,
+                headers: s.headers
+                  ? Object.fromEntries(Object.keys(s.headers).map(k => [k, '••••••••']))
+                  : undefined,
+              }
+            : s,
+        ),
       }
     : undefined;
 

--- a/tests/mcp/mcp.test.ts
+++ b/tests/mcp/mcp.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { McpClient } from '../../src/mcp/client.js';
 import { mcpToolToTool, registerMcpServers } from '../../src/mcp/register.js';
-import { resolveHeaders } from '../../src/mcp/config.js';
+import { parseMcpServerConfig, resolveHeaders } from '../../src/mcp/config.js';
 import { governedMcpFetch } from '../../src/mcp/governedFetch.js';
 import { permissivePolicy, resolvePolicy, PolicyViolationError } from '../../src/core/policy.js';
 import { ToolRegistry } from '../../src/tools/registry.js';
@@ -64,6 +64,33 @@ describe('mcp config', () => {
     process.env.TEST_MCP_KEY = 'secret-123';
     expect(resolveHeaders({ Authorization: 'Bearer ${TEST_MCP_KEY}' })).toEqual({ Authorization: 'Bearer secret-123' });
     delete process.env.TEST_MCP_KEY;
+  });
+
+  it('parses a local stdio server entry', () => {
+    expect(
+      parseMcpServerConfig({
+        id: 'filesystem',
+        command: 'npx',
+        args: ['-y', '@modelcontextprotocol/server-filesystem', '.'],
+        enabled: true,
+      }),
+    ).toEqual({
+      id: 'filesystem',
+      command: 'npx',
+      args: ['-y', '@modelcontextprotocol/server-filesystem', '.'],
+      enabled: true,
+    });
+  });
+
+  it('rejects a local stdio entry with a malformed command', () => {
+    expect(() =>
+      parseMcpServerConfig({
+        id: 'filesystem',
+        command: '',
+        args: ['-y', '@modelcontextprotocol/server-filesystem'],
+        enabled: true,
+      }),
+    ).toThrow(/command must not be empty/);
   });
 });
 


### PR DESCRIPTION
## Summary
- add strict Zod schemas for existing remote MCP entries and new local stdio entries
- expose a parser for `{ id, command, args, enabled }` local configurations with clear validation errors
- keep current connection registration limited to remote servers until governed stdio transport lands
- cover valid local parsing and malformed commands

## Validation
- `npm run typecheck`
- `npx vitest run tests/mcp/mcp.test.ts` ? 13 passed
- `npm run check` ? typecheck passes and 289 tests pass; 9 unrelated platform-dependent tests fail on Windows because they expect `/bin/sh`, macOS bundle paths, or installed Semgrep/OSV tooling

Closes #137

AI-assisted contribution prepared with Codex.
