### PR TITLE
fix: support native Windows shell execution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,3 +23,25 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm run check
+
+  shell-cross-platform:
+    name: Native shell (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      # actions/checkout v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          persist-credentials: false
+      # actions/setup-node v6.4.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npm run typecheck
+      - name: Test native command execution and cancellation
+        run: npx vitest run tests/shellSeatbeltExec.test.ts tests/subprocessAbort.test.ts tests/shellSandbox.test.ts

--- a/README.md
+++ b/README.md
@@ -666,7 +666,13 @@ They represent different outcomes and safety defaults. <b>Home</b> groups read-o
 <details>
 <summary><b>Is the shell tool sandboxed?</b></summary>
 <br>
-On macOS, yes — every <code>shell</code> tool invocation is wrapped in <code>sandbox-exec</code> with a profile that <i>denies network access</i> and allows file writes only inside <code>cwd</code>, <code>/tmp</code>, and <code>/var</code>. Linux and Windows sandboxing is planned.
+On macOS, commands use <code>sandbox-exec</code>; on Linux, restrictive network policies use Bubblewrap when installed. Windows has no supported subprocess network sandbox yet, so restrictive policies fail closed instead of silently running unrestricted. The native command runner itself works on all three platforms.
+</details>
+
+<details>
+<summary><b>Which operating-system shells are supported?</b></summary>
+<br>
+Linux and macOS commands run through <code>/bin/sh</code>; Windows commands run through the system <code>ComSpec</code> (<code>cmd.exe</code> by default). Full native command lines support pipes, redirects, and conditional operators. The split <code>command</code> + <code>args</code> form quotes executable paths and arguments for the host shell.
 </details>
 
 <details>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -596,7 +596,13 @@ DvalinCode 顶栏实时显示本 session 的费用 —— 在 **LLM Configuratio
 <details>
 <summary><b>Shell 工具有沙箱吗？</b></summary>
 <br>
-macOS 上有 —— 每次 <code>shell</code> 调用都包在 <code>sandbox-exec</code> 里，profile <i>拒绝网络访问</i>，仅允许写入 <code>cwd</code>、<code>/tmp</code>、<code>/var</code>。Linux 和 Windows 沙箱已规划中。
+macOS 使用 <code>sandbox-exec</code>；Linux 在限制性网络策略下会在已安装 Bubblewrap 时启用它。Windows 暂无受支持的子进程网络沙箱，因此限制性策略会安全关闭执行，不会静默降级为无限制运行。原生命令运行器本身支持这三个平台。
+</details>
+
+<details>
+<summary><b>支持哪些操作系统终端？</b></summary>
+<br>
+Linux 与 macOS 命令通过 <code>/bin/sh</code> 执行；Windows 命令通过系统 <code>ComSpec</code>（默认为 <code>cmd.exe</code>）执行。完整原生命令行支持管道、重定向与条件操作符；拆分的 <code>command</code> + <code>args</code> 形式会按宿主 shell 规则引用可执行文件路径及参数。
 </details>
 
 <details>

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -14,19 +14,46 @@ The project does not intentionally vendor third-party source code into this repo
 
 | License | Packages |
 |---|---:|
-| 0BSD | 1 |
-| Apache-2.0 | 9 |
-| BSD-3-Clause | 3 |
+| 0BSD | 2 |
+| Apache-2.0 | 27 |
+| BSD-2-Clause | 1 |
+| BSD-3-Clause | 4 |
 | CC-BY-4.0 | 1 |
-| ISC | 19 |
-| MIT | 358 |
+| CC0-1.0 | 1 |
+| ISC | 17 |
+| MIT | 484 |
 | MPL-2.0 | 12 |
 
 ## Packages
 
 | Package | Version | License | Used by | Repository |
 |---|---:|---|---|---|
+| `@algolia/abtesting` | 1.21.1 | MIT | CLI package |  |
+| `@algolia/autocomplete-core` | 1.17.7 | MIT | CLI package |  |
+| `@algolia/autocomplete-plugin-algolia-insights` | 1.17.7 | MIT | CLI package |  |
+| `@algolia/autocomplete-preset-algolia` | 1.17.7 | MIT | CLI package |  |
+| `@algolia/autocomplete-shared` | 1.17.7 | MIT | CLI package |  |
+| `@algolia/client-abtesting` | 5.55.1 | MIT | CLI package |  |
+| `@algolia/client-analytics` | 5.55.1 | MIT | CLI package |  |
+| `@algolia/client-common` | 5.55.1 | MIT | CLI package |  |
+| `@algolia/client-insights` | 5.55.1 | MIT | CLI package |  |
+| `@algolia/client-personalization` | 5.55.1 | MIT | CLI package |  |
+| `@algolia/client-query-suggestions` | 5.55.1 | MIT | CLI package |  |
+| `@algolia/client-search` | 5.55.1 | MIT | CLI package |  |
+| `@algolia/ingestion` | 1.55.1 | MIT | CLI package |  |
+| `@algolia/monitoring` | 1.55.1 | MIT | CLI package |  |
+| `@algolia/recommend` | 5.55.1 | MIT | CLI package |  |
+| `@algolia/requester-browser-xhr` | 5.55.1 | MIT | CLI package |  |
+| `@algolia/requester-fetch` | 5.55.1 | MIT | CLI package |  |
+| `@algolia/requester-node-http` | 5.55.1 | MIT | CLI package |  |
 | `@alloc/quick-lru` | 5.2.0 | MIT | Web package |  |
+| `@babel/helper-string-parser` | 7.29.7 | MIT | CLI package |  |
+| `@babel/helper-validator-identifier` | 7.29.7 | MIT | CLI package |  |
+| `@babel/parser` | 7.29.7 | MIT | CLI package |  |
+| `@babel/types` | 7.29.7 | MIT | CLI package |  |
+| `@docsearch/css` | 3.8.2 | MIT | CLI package |  |
+| `@docsearch/js` | 3.8.2 | MIT | CLI package |  |
+| `@docsearch/react` | 3.8.2 | MIT | CLI package |  |
 | `@emnapi/core` | 1.11.1 | MIT | CLI package, Web package |  |
 | `@emnapi/runtime` | 1.11.1 | MIT | CLI package, Web package |  |
 | `@emnapi/wasi-threads` | 1.2.2 | MIT | CLI package, Web package |  |
@@ -56,32 +83,89 @@ The project does not intentionally vendor third-party source code into this repo
 | `@esbuild/win32-arm64` | 0.28.1 | MIT | CLI package |  |
 | `@esbuild/win32-ia32` | 0.28.1 | MIT | CLI package |  |
 | `@esbuild/win32-x64` | 0.28.1 | MIT | CLI package |  |
+| `@iconify-json/simple-icons` | 1.2.89 | CC0-1.0 | CLI package |  |
+| `@iconify/types` | 2.0.0 | MIT | CLI package |  |
 | `@jridgewell/gen-mapping` | 0.3.13 | MIT | Web package |  |
+| `@jridgewell/remapping` | 2.3.5 | MIT | Web package |  |
 | `@jridgewell/resolve-uri` | 3.1.2 | MIT | Web package |  |
 | `@jridgewell/sourcemap-codec` | 1.5.5 | MIT | CLI package, Web package |  |
 | `@jridgewell/trace-mapping` | 0.3.31 | MIT | Web package |  |
 | `@napi-rs/wasm-runtime` | 1.1.6 | MIT | CLI package, Web package |  |
-| `@nodelib/fs.scandir` | 2.1.5 | MIT | CLI package, Web package |  |
-| `@nodelib/fs.stat` | 2.0.5 | MIT | CLI package, Web package |  |
-| `@nodelib/fs.walk` | 1.2.8 | MIT | CLI package, Web package |  |
-| `@oxc-project/types` | 0.137.0 | MIT | CLI package, Web package |  |
-| `@rolldown/binding-android-arm64` | 1.1.3 | MIT | CLI package, Web package |  |
-| `@rolldown/binding-darwin-arm64` | 1.1.3 | MIT | CLI package, Web package |  |
-| `@rolldown/binding-darwin-x64` | 1.1.3 | MIT | CLI package, Web package |  |
-| `@rolldown/binding-freebsd-x64` | 1.1.3 | MIT | CLI package, Web package |  |
-| `@rolldown/binding-linux-arm-gnueabihf` | 1.1.3 | MIT | CLI package, Web package |  |
-| `@rolldown/binding-linux-arm64-gnu` | 1.1.3 | MIT | CLI package, Web package |  |
-| `@rolldown/binding-linux-arm64-musl` | 1.1.3 | MIT | CLI package, Web package |  |
-| `@rolldown/binding-linux-ppc64-gnu` | 1.1.3 | MIT | CLI package, Web package |  |
-| `@rolldown/binding-linux-s390x-gnu` | 1.1.3 | MIT | CLI package, Web package |  |
-| `@rolldown/binding-linux-x64-gnu` | 1.1.3 | MIT | CLI package, Web package |  |
-| `@rolldown/binding-linux-x64-musl` | 1.1.3 | MIT | CLI package, Web package |  |
-| `@rolldown/binding-openharmony-arm64` | 1.1.3 | MIT | CLI package, Web package |  |
-| `@rolldown/binding-wasm32-wasi` | 1.1.3 | MIT | CLI package, Web package |  |
-| `@rolldown/binding-win32-arm64-msvc` | 1.1.3 | MIT | CLI package, Web package |  |
-| `@rolldown/binding-win32-x64-msvc` | 1.1.3 | MIT | CLI package, Web package |  |
+| `@nodelib/fs.scandir` | 2.1.5 | MIT | CLI package |  |
+| `@nodelib/fs.stat` | 2.0.5 | MIT | CLI package |  |
+| `@nodelib/fs.walk` | 1.2.8 | MIT | CLI package |  |
+| `@oxc-project/types` | 0.139.0 | MIT | CLI package, Web package |  |
+| `@rolldown/binding-android-arm64` | 1.1.5 | MIT | CLI package, Web package |  |
+| `@rolldown/binding-darwin-arm64` | 1.1.5 | MIT | CLI package, Web package |  |
+| `@rolldown/binding-darwin-x64` | 1.1.5 | MIT | CLI package, Web package |  |
+| `@rolldown/binding-freebsd-x64` | 1.1.5 | MIT | CLI package, Web package |  |
+| `@rolldown/binding-linux-arm-gnueabihf` | 1.1.5 | MIT | CLI package, Web package |  |
+| `@rolldown/binding-linux-arm64-gnu` | 1.1.5 | MIT | CLI package, Web package |  |
+| `@rolldown/binding-linux-arm64-musl` | 1.1.5 | MIT | CLI package, Web package |  |
+| `@rolldown/binding-linux-ppc64-gnu` | 1.1.5 | MIT | CLI package, Web package |  |
+| `@rolldown/binding-linux-s390x-gnu` | 1.1.5 | MIT | CLI package, Web package |  |
+| `@rolldown/binding-linux-x64-gnu` | 1.1.5 | MIT | CLI package, Web package |  |
+| `@rolldown/binding-linux-x64-musl` | 1.1.5 | MIT | CLI package, Web package |  |
+| `@rolldown/binding-openharmony-arm64` | 1.1.5 | MIT | CLI package, Web package |  |
+| `@rolldown/binding-wasm32-wasi` | 1.1.5 | MIT | CLI package, Web package |  |
+| `@rolldown/binding-win32-arm64-msvc` | 1.1.5 | MIT | CLI package, Web package |  |
+| `@rolldown/binding-win32-x64-msvc` | 1.1.5 | MIT | CLI package, Web package |  |
 | `@rolldown/pluginutils` | 1.0.1 | MIT | CLI package, Web package |  |
+| `@rollup/rollup-android-arm-eabi` | 4.62.2 | MIT | CLI package |  |
+| `@rollup/rollup-android-arm64` | 4.62.2 | MIT | CLI package |  |
+| `@rollup/rollup-darwin-arm64` | 4.62.2 | MIT | CLI package |  |
+| `@rollup/rollup-darwin-x64` | 4.62.2 | MIT | CLI package |  |
+| `@rollup/rollup-freebsd-arm64` | 4.62.2 | MIT | CLI package |  |
+| `@rollup/rollup-freebsd-x64` | 4.62.2 | MIT | CLI package |  |
+| `@rollup/rollup-linux-arm-gnueabihf` | 4.62.2 | MIT | CLI package |  |
+| `@rollup/rollup-linux-arm-musleabihf` | 4.62.2 | MIT | CLI package |  |
+| `@rollup/rollup-linux-arm64-gnu` | 4.62.2 | MIT | CLI package |  |
+| `@rollup/rollup-linux-arm64-musl` | 4.62.2 | MIT | CLI package |  |
+| `@rollup/rollup-linux-loong64-gnu` | 4.62.2 | MIT | CLI package |  |
+| `@rollup/rollup-linux-loong64-musl` | 4.62.2 | MIT | CLI package |  |
+| `@rollup/rollup-linux-ppc64-gnu` | 4.62.2 | MIT | CLI package |  |
+| `@rollup/rollup-linux-ppc64-musl` | 4.62.2 | MIT | CLI package |  |
+| `@rollup/rollup-linux-riscv64-gnu` | 4.62.2 | MIT | CLI package |  |
+| `@rollup/rollup-linux-riscv64-musl` | 4.62.2 | MIT | CLI package |  |
+| `@rollup/rollup-linux-s390x-gnu` | 4.62.2 | MIT | CLI package |  |
+| `@rollup/rollup-linux-x64-gnu` | 4.62.2 | MIT | CLI package |  |
+| `@rollup/rollup-linux-x64-musl` | 4.62.2 | MIT | CLI package |  |
+| `@rollup/rollup-openbsd-x64` | 4.62.2 | MIT | CLI package |  |
+| `@rollup/rollup-openharmony-arm64` | 4.62.2 | MIT | CLI package |  |
+| `@rollup/rollup-win32-arm64-msvc` | 4.62.2 | MIT | CLI package |  |
+| `@rollup/rollup-win32-ia32-msvc` | 4.62.2 | MIT | CLI package |  |
+| `@rollup/rollup-win32-x64-gnu` | 4.62.2 | MIT | CLI package |  |
+| `@rollup/rollup-win32-x64-msvc` | 4.62.2 | MIT | CLI package |  |
+| `@shikijs/core` | 2.5.0 | MIT | CLI package |  |
+| `@shikijs/engine-javascript` | 2.5.0 | MIT | CLI package |  |
+| `@shikijs/engine-oniguruma` | 2.5.0 | MIT | CLI package |  |
+| `@shikijs/langs` | 2.5.0 | MIT | CLI package |  |
+| `@shikijs/themes` | 2.5.0 | MIT | CLI package |  |
+| `@shikijs/transformers` | 2.5.0 | MIT | CLI package |  |
+| `@shikijs/types` | 2.5.0 | MIT | CLI package |  |
+| `@shikijs/vscode-textmate` | 10.0.2 | MIT | CLI package |  |
 | `@standard-schema/spec` | 1.1.0 | MIT | CLI package |  |
+| `@tailwindcss/node` | 4.3.3 | MIT | Web package |  |
+| `@tailwindcss/oxide` | 4.3.3 | MIT | Web package |  |
+| `@tailwindcss/oxide-android-arm64` | 4.3.3 | MIT | Web package |  |
+| `@tailwindcss/oxide-darwin-arm64` | 4.3.3 | MIT | Web package |  |
+| `@tailwindcss/oxide-darwin-x64` | 4.3.3 | MIT | Web package |  |
+| `@tailwindcss/oxide-freebsd-x64` | 4.3.3 | MIT | Web package |  |
+| `@tailwindcss/oxide-linux-arm-gnueabihf` | 4.3.3 | MIT | Web package |  |
+| `@tailwindcss/oxide-linux-arm64-gnu` | 4.3.3 | MIT | Web package |  |
+| `@tailwindcss/oxide-linux-arm64-musl` | 4.3.3 | MIT | Web package |  |
+| `@tailwindcss/oxide-linux-x64-gnu` | 4.3.3 | MIT | Web package |  |
+| `@tailwindcss/oxide-linux-x64-musl` | 4.3.3 | MIT | Web package |  |
+| `@tailwindcss/oxide-wasm32-wasi` | 4.3.3 | MIT | Web package |  |
+| `@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core` | 1.11.1 | MIT | Web package |  |
+| `@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime` | 1.11.1 | MIT | Web package |  |
+| `@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads` | 1.2.2 | MIT | Web package |  |
+| `@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime` | 1.1.4 | MIT | Web package |  |
+| `@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util` | 0.10.2 | MIT | Web package |  |
+| `@tailwindcss/oxide-wasm32-wasi/node_modules/tslib` | 2.8.1 | 0BSD | Web package |  |
+| `@tailwindcss/oxide-win32-arm64-msvc` | 4.3.3 | MIT | Web package |  |
+| `@tailwindcss/oxide-win32-x64-msvc` | 4.3.3 | MIT | Web package |  |
+| `@tailwindcss/postcss` | 4.3.3 | MIT | Web package |  |
 | `@tybys/wasm-util` | 0.10.3 | MIT | CLI package, Web package |  |
 | `@types/body-parser` | 1.19.6 | MIT | CLI package |  |
 | `@types/chai` | 5.2.3 | MIT | CLI package |  |
@@ -93,86 +177,124 @@ The project does not intentionally vendor third-party source code into this repo
 | `@types/estree-jsx` | 1.0.5 | MIT | Web package |  |
 | `@types/express` | 5.0.6 | MIT | CLI package |  |
 | `@types/express-serve-static-core` | 5.1.1 | MIT | CLI package |  |
-| `@types/hast` | 3.0.4 | MIT | Web package |  |
+| `@types/hast` | 3.0.4 | MIT | CLI package, Web package |  |
 | `@types/http-errors` | 2.0.5 | MIT | CLI package |  |
-| `@types/mdast` | 4.0.4 | MIT | Web package |  |
+| `@types/linkify-it` | 5.0.0 | MIT | CLI package |  |
+| `@types/markdown-it` | 14.1.2 | MIT | CLI package |  |
+| `@types/mdast` | 4.0.4 | MIT | CLI package, Web package |  |
+| `@types/mdurl` | 2.0.0 | MIT | CLI package |  |
 | `@types/ms` | 2.1.0 | MIT | Web package |  |
-| `@types/node` | 26.0.1 | MIT | CLI package |  |
+| `@types/node` | 26.1.1 | MIT | CLI package |  |
 | `@types/qs` | 6.15.1 | MIT | CLI package |  |
 | `@types/range-parser` | 1.2.7 | MIT | CLI package |  |
 | `@types/react` | 19.2.17 | MIT | Web package |  |
 | `@types/react-dom` | 19.2.3 | MIT | Web package |  |
 | `@types/send` | 1.2.1 | MIT | CLI package |  |
 | `@types/serve-static` | 2.2.0 | MIT | CLI package |  |
-| `@types/unist` | 3.0.3 | MIT | Web package |  |
+| `@types/unist` | 3.0.3 | MIT | CLI package, Web package |  |
+| `@types/web-bluetooth` | 0.0.21 | MIT | CLI package |  |
 | `@types/ws` | 8.18.1 | MIT | CLI package |  |
+| `@typescript/typescript-aix-ppc64` | 7.0.2 | Apache-2.0 | CLI package, Web package |  |
+| `@typescript/typescript-darwin-arm64` | 7.0.2 | Apache-2.0 | CLI package, Web package |  |
+| `@typescript/typescript-darwin-x64` | 7.0.2 | Apache-2.0 | CLI package, Web package |  |
+| `@typescript/typescript-freebsd-arm64` | 7.0.2 | Apache-2.0 | CLI package, Web package |  |
+| `@typescript/typescript-freebsd-x64` | 7.0.2 | Apache-2.0 | CLI package, Web package |  |
+| `@typescript/typescript-linux-arm` | 7.0.2 | Apache-2.0 | CLI package, Web package |  |
+| `@typescript/typescript-linux-arm64` | 7.0.2 | Apache-2.0 | CLI package, Web package |  |
+| `@typescript/typescript-linux-loong64` | 7.0.2 | Apache-2.0 | CLI package, Web package |  |
+| `@typescript/typescript-linux-mips64el` | 7.0.2 | Apache-2.0 | CLI package, Web package |  |
+| `@typescript/typescript-linux-ppc64` | 7.0.2 | Apache-2.0 | CLI package, Web package |  |
+| `@typescript/typescript-linux-riscv64` | 7.0.2 | Apache-2.0 | CLI package, Web package |  |
+| `@typescript/typescript-linux-s390x` | 7.0.2 | Apache-2.0 | CLI package, Web package |  |
+| `@typescript/typescript-linux-x64` | 7.0.2 | Apache-2.0 | CLI package, Web package |  |
+| `@typescript/typescript-netbsd-arm64` | 7.0.2 | Apache-2.0 | CLI package, Web package |  |
+| `@typescript/typescript-netbsd-x64` | 7.0.2 | Apache-2.0 | CLI package, Web package |  |
+| `@typescript/typescript-openbsd-arm64` | 7.0.2 | Apache-2.0 | CLI package, Web package |  |
+| `@typescript/typescript-openbsd-x64` | 7.0.2 | Apache-2.0 | CLI package, Web package |  |
+| `@typescript/typescript-sunos-x64` | 7.0.2 | Apache-2.0 | CLI package, Web package |  |
+| `@typescript/typescript-win32-arm64` | 7.0.2 | Apache-2.0 | CLI package, Web package |  |
+| `@typescript/typescript-win32-x64` | 7.0.2 | Apache-2.0 | CLI package, Web package |  |
 | `@ungap/structured-clone` | 1.3.1 | ISC | Web package |  |
-| `@vitejs/plugin-react` | 6.0.3 | MIT | Web package |  |
-| `@vitest/expect` | 4.1.9 | MIT | CLI package |  |
-| `@vitest/mocker` | 4.1.9 | MIT | CLI package |  |
-| `@vitest/pretty-format` | 4.1.9 | MIT | CLI package |  |
-| `@vitest/runner` | 4.1.9 | MIT | CLI package |  |
-| `@vitest/snapshot` | 4.1.9 | MIT | CLI package |  |
-| `@vitest/spy` | 4.1.9 | MIT | CLI package |  |
-| `@vitest/utils` | 4.1.9 | MIT | CLI package |  |
+| `@ungap/structured-clone` | 1.3.2 | ISC | CLI package |  |
+| `@vitejs/plugin-react` | 6.0.4 | MIT | Web package |  |
+| `@vitest/expect` | 4.1.10 | MIT | CLI package |  |
+| `@vitest/mocker` | 4.1.10 | MIT | CLI package |  |
+| `@vitest/pretty-format` | 4.1.10 | MIT | CLI package |  |
+| `@vitest/runner` | 4.1.10 | MIT | CLI package |  |
+| `@vitest/snapshot` | 4.1.10 | MIT | CLI package |  |
+| `@vitest/spy` | 4.1.10 | MIT | CLI package |  |
+| `@vitest/utils` | 4.1.10 | MIT | CLI package |  |
+| `@vue/compiler-core` | 3.5.39 | MIT | CLI package |  |
+| `@vue/compiler-core/node_modules/estree-walker` | 2.0.2 | MIT | CLI package |  |
+| `@vue/compiler-dom` | 3.5.39 | MIT | CLI package |  |
+| `@vue/compiler-sfc` | 3.5.39 | MIT | CLI package |  |
+| `@vue/compiler-sfc/node_modules/estree-walker` | 2.0.2 | MIT | CLI package |  |
+| `@vue/compiler-ssr` | 3.5.39 | MIT | CLI package |  |
+| `@vue/devtools-api` | 7.7.10 | MIT | CLI package |  |
+| `@vue/devtools-kit` | 7.7.10 | MIT | CLI package |  |
+| `@vue/devtools-shared` | 7.7.10 | MIT | CLI package |  |
+| `@vue/reactivity` | 3.5.39 | MIT | CLI package |  |
+| `@vue/runtime-core` | 3.5.39 | MIT | CLI package |  |
+| `@vue/runtime-dom` | 3.5.39 | MIT | CLI package |  |
+| `@vue/server-renderer` | 3.5.39 | MIT | CLI package |  |
+| `@vue/shared` | 3.5.39 | MIT | CLI package |  |
+| `@vueuse/core` | 12.8.2 | MIT | CLI package |  |
+| `@vueuse/integrations` | 12.8.2 | MIT | CLI package |  |
+| `@vueuse/metadata` | 12.8.2 | MIT | CLI package |  |
+| `@vueuse/shared` | 12.8.2 | MIT | CLI package |  |
 | `accepts` | 2.0.0 | MIT | CLI package |  |
+| `algoliasearch` | 5.55.1 | MIT | CLI package |  |
 | `ansi-regex` | 6.2.2 | MIT | CLI package |  |
 | `ansi-styles` | 6.2.3 | MIT | CLI package |  |
-| `any-promise` | 1.3.0 | MIT | Web package |  |
-| `anymatch` | 3.1.3 | ISC | Web package |  |
-| `anymatch/node_modules/picomatch` | 2.3.2 | MIT | Web package |  |
-| `arg` | 5.0.2 | MIT | Web package |  |
 | `assertion-error` | 2.0.1 | MIT | CLI package |  |
-| `autoprefixer` | 10.5.2 | MIT | Web package |  |
+| `autoprefixer` | 10.5.4 | MIT | Web package |  |
 | `bail` | 2.0.2 | MIT | Web package |  |
-| `baseline-browser-mapping` | 2.10.40 | Apache-2.0 | Web package |  |
-| `binary-extensions` | 2.3.0 | MIT | Web package |  |
+| `baseline-browser-mapping` | 2.10.43 | Apache-2.0 | Web package |  |
+| `birpc` | 2.9.0 | MIT | CLI package |  |
 | `body-parser` | 2.3.0 | MIT | CLI package |  |
 | `body-parser/node_modules/content-type` | 2.0.0 | MIT | CLI package |  |
-| `braces` | 3.0.3 | MIT | CLI package, Web package |  |
-| `browserslist` | 4.28.4 | MIT | Web package |  |
+| `braces` | 3.0.3 | MIT | CLI package |  |
+| `browserslist` | 4.28.6 | MIT | Web package |  |
 | `bytes` | 3.1.2 | MIT | CLI package |  |
 | `call-bind-apply-helpers` | 1.0.2 | MIT | CLI package |  |
 | `call-bound` | 1.0.4 | MIT | CLI package |  |
-| `camelcase-css` | 2.0.1 | MIT | Web package |  |
-| `caniuse-lite` | 1.0.30001799 | CC-BY-4.0 | Web package |  |
-| `ccount` | 2.0.1 | MIT | Web package |  |
+| `caniuse-lite` | 1.0.30001806 | CC-BY-4.0 | Web package |  |
+| `ccount` | 2.0.1 | MIT | CLI package, Web package |  |
 | `chai` | 6.2.2 | MIT | CLI package |  |
-| `chalk` | 5.6.2 | MIT | CLI package |  |
+| `chalk` | 6.0.0 | MIT | CLI package |  |
 | `character-entities` | 2.0.2 | MIT | Web package |  |
-| `character-entities-html4` | 2.1.0 | MIT | Web package |  |
-| `character-entities-legacy` | 3.0.0 | MIT | Web package |  |
+| `character-entities-html4` | 2.1.0 | MIT | CLI package, Web package |  |
+| `character-entities-legacy` | 3.0.0 | MIT | CLI package, Web package |  |
 | `character-reference-invalid` | 2.0.1 | MIT | Web package |  |
-| `chokidar` | 3.6.0 | MIT | Web package |  |
-| `chokidar/node_modules/glob-parent` | 5.1.2 | ISC | Web package |  |
 | `cliui` | 9.0.1 | ISC | CLI package |  |
-| `comma-separated-tokens` | 2.0.3 | MIT | Web package |  |
+| `comma-separated-tokens` | 2.0.3 | MIT | CLI package, Web package |  |
 | `commander` | 15.0.0 | MIT | CLI package |  |
-| `commander` | 4.1.1 | MIT | Web package |  |
-| `concurrently` | 10.0.3 | MIT | CLI package |  |
+| `concurrently` | 10.0.4 | MIT | CLI package |  |
+| `concurrently/node_modules/chalk` | 5.6.2 | MIT | CLI package |  |
 | `content-disposition` | 1.1.0 | MIT | CLI package |  |
 | `content-type` | 1.0.5 | MIT | CLI package |  |
 | `convert-source-map` | 2.0.0 | MIT | CLI package |  |
 | `cookie` | 0.7.2 | MIT | CLI package |  |
 | `cookie-signature` | 1.2.2 | MIT | CLI package |  |
+| `copy-anything` | 4.0.5 | MIT | CLI package |  |
 | `cors` | 2.8.6 | MIT | CLI package |  |
-| `cssesc` | 3.0.0 | MIT | Web package |  |
-| `csstype` | 3.2.3 | MIT | Web package |  |
+| `csstype` | 3.2.3 | MIT | CLI package, Web package |  |
 | `debug` | 4.4.3 | MIT | CLI package, Web package |  |
 | `decode-named-character-reference` | 1.3.0 | MIT | Web package |  |
 | `depd` | 2.0.0 | MIT | CLI package |  |
-| `dequal` | 2.0.3 | MIT | Web package |  |
+| `dequal` | 2.0.3 | MIT | CLI package, Web package |  |
 | `detect-libc` | 2.1.2 | Apache-2.0 | CLI package, Web package |  |
-| `devlop` | 1.1.0 | MIT | Web package |  |
-| `didyoumean` | 1.2.2 | Apache-2.0 | Web package |  |
-| `dlv` | 1.1.3 | MIT | Web package |  |
+| `devlop` | 1.1.0 | MIT | CLI package, Web package |  |
 | `dunder-proto` | 1.0.1 | MIT | CLI package |  |
 | `ee-first` | 1.1.1 | MIT | CLI package |  |
-| `electron-to-chromium` | 1.5.381 | ISC | Web package |  |
+| `electron-to-chromium` | 1.5.393 | ISC | Web package |  |
 | `emoji-regex` | 10.6.0 | MIT | CLI package |  |
+| `emoji-regex-xs` | 1.0.0 | MIT | CLI package |  |
 | `encodeurl` | 2.0.0 | MIT | CLI package |  |
+| `enhanced-resolve` | 5.24.2 | MIT | Web package |  |
+| `entities` | 7.0.1 | BSD-2-Clause | CLI package |  |
 | `es-define-property` | 1.0.1 | MIT | CLI package |  |
-| `es-errors` | 1.3.0 | MIT | CLI package, Web package |  |
+| `es-errors` | 1.3.0 | MIT | CLI package |  |
 | `es-module-lexer` | 2.1.0 | MIT | CLI package |  |
 | `es-object-atoms` | 1.1.2 | MIT | CLI package |  |
 | `esbuild` | 0.28.1 | MIT | CLI package |  |
@@ -184,34 +306,37 @@ The project does not intentionally vendor third-party source code into this repo
 | `etag` | 1.8.1 | MIT | CLI package |  |
 | `expect-type` | 1.3.0 | Apache-2.0 | CLI package |  |
 | `express` | 5.2.1 | MIT | CLI package |  |
-| `express-rate-limit` | 8.5.2 | MIT | CLI package |  |
+| `express-rate-limit` | 8.6.1 | MIT | CLI package |  |
 | `extend` | 3.0.2 | MIT | Web package |  |
-| `fast-glob` | 3.3.3 | MIT | CLI package, Web package |  |
-| `fast-glob/node_modules/glob-parent` | 5.1.2 | ISC | Web package |  |
-| `fastq` | 1.20.1 | ISC | CLI package, Web package |  |
+| `fast-glob` | 3.3.3 | MIT | CLI package |  |
+| `fastq` | 1.20.1 | ISC | CLI package |  |
 | `fdir` | 6.5.0 | MIT | Web package |  |
-| `fill-range` | 7.1.1 | MIT | CLI package, Web package |  |
+| `fill-range` | 7.1.1 | MIT | CLI package |  |
 | `finalhandler` | 2.1.1 | MIT | CLI package |  |
+| `focus-trap` | 7.8.0 | MIT | CLI package |  |
 | `forwarded` | 0.2.0 | MIT | CLI package |  |
 | `fraction.js` | 5.3.4 | MIT | Web package |  |
 | `fresh` | 2.0.0 | MIT | CLI package |  |
 | `fsevents` | 2.3.3 | MIT | CLI package, Web package |  |
-| `function-bind` | 1.1.2 | MIT | CLI package, Web package |  |
+| `function-bind` | 1.1.2 | MIT | CLI package |  |
 | `get-caller-file` | 2.0.5 | ISC | CLI package |  |
 | `get-east-asian-width` | 1.6.0 | MIT | CLI package |  |
 | `get-intrinsic` | 1.3.0 | MIT | CLI package |  |
 | `get-proto` | 1.0.1 | MIT | CLI package |  |
 | `glob-parent` | 5.1.2 | ISC | CLI package |  |
-| `glob-parent` | 6.0.2 | ISC | Web package |  |
 | `gopd` | 1.2.0 | MIT | CLI package |  |
+| `graceful-fs` | 4.2.11 | ISC | Web package |  |
 | `has-symbols` | 1.1.0 | MIT | CLI package |  |
-| `hasown` | 2.0.4 | MIT | CLI package, Web package |  |
+| `hasown` | 2.0.4 | MIT | CLI package |  |
 | `hast-util-is-element` | 3.0.0 | MIT | Web package |  |
+| `hast-util-to-html` | 9.0.5 | MIT | CLI package |  |
 | `hast-util-to-jsx-runtime` | 2.3.6 | MIT | Web package |  |
 | `hast-util-to-text` | 4.0.2 | MIT | Web package |  |
-| `hast-util-whitespace` | 3.0.0 | MIT | Web package |  |
+| `hast-util-whitespace` | 3.0.0 | MIT | CLI package, Web package |  |
 | `highlight.js` | 11.11.1 | BSD-3-Clause | Web package |  |
+| `hookable` | 5.5.3 | MIT | CLI package |  |
 | `html-url-attributes` | 3.0.1 | MIT | Web package |  |
+| `html-void-elements` | 3.0.0 | MIT | CLI package |  |
 | `http-errors` | 2.0.1 | MIT | CLI package |  |
 | `iconv-lite` | 0.7.2 | MIT | CLI package |  |
 | `inherits` | 2.0.4 | ISC | CLI package |  |
@@ -220,15 +345,15 @@ The project does not intentionally vendor third-party source code into this repo
 | `ipaddr.js` | 1.9.1 | MIT | CLI package |  |
 | `is-alphabetical` | 2.0.1 | MIT | Web package |  |
 | `is-alphanumerical` | 2.0.1 | MIT | Web package |  |
-| `is-binary-path` | 2.1.0 | MIT | Web package |  |
-| `is-core-module` | 2.16.2 | MIT | Web package |  |
 | `is-decimal` | 2.0.1 | MIT | Web package |  |
-| `is-extglob` | 2.1.1 | MIT | CLI package, Web package |  |
-| `is-glob` | 4.0.3 | MIT | CLI package, Web package |  |
+| `is-extglob` | 2.1.1 | MIT | CLI package |  |
+| `is-glob` | 4.0.3 | MIT | CLI package |  |
 | `is-hexadecimal` | 2.0.1 | MIT | Web package |  |
-| `is-number` | 7.0.0 | MIT | CLI package, Web package |  |
+| `is-number` | 7.0.0 | MIT | CLI package |  |
 | `is-plain-obj` | 4.1.0 | MIT | Web package |  |
 | `is-promise` | 4.0.0 | MIT | CLI package |  |
+| `is-what` | 5.5.0 | MIT | CLI package |  |
+| `jiti` | 2.7.0 | MIT | Web package |  |
 | `lightningcss` | 1.32.0 | MPL-2.0 | CLI package, Web package |  |
 | `lightningcss-android-arm64` | 1.32.0 | MPL-2.0 | CLI package, Web package |  |
 | `lightningcss-darwin-arm64` | 1.32.0 | MPL-2.0 | CLI package, Web package |  |
@@ -241,12 +366,11 @@ The project does not intentionally vendor third-party source code into this repo
 | `lightningcss-linux-x64-musl` | 1.32.0 | MPL-2.0 | CLI package, Web package |  |
 | `lightningcss-win32-arm64-msvc` | 1.32.0 | MPL-2.0 | CLI package, Web package |  |
 | `lightningcss-win32-x64-msvc` | 1.32.0 | MPL-2.0 | CLI package, Web package |  |
-| `lilconfig` | 3.1.3 | MIT | Web package |  |
-| `lines-and-columns` | 1.2.4 | MIT | Web package |  |
 | `longest-streak` | 3.1.0 | MIT | Web package |  |
 | `lowlight` | 3.3.0 | MIT | Web package |  |
-| `lucide-react` | 1.22.0 | ISC | Web package |  |
-| `magic-string` | 0.30.21 | MIT | CLI package |  |
+| `lucide-react` | 1.27.0 | ISC | Web package |  |
+| `magic-string` | 0.30.21 | MIT | CLI package, Web package |  |
+| `mark.js` | 8.11.1 | MIT | CLI package |  |
 | `markdown-table` | 3.0.4 | MIT | Web package |  |
 | `math-intrinsics` | 1.1.0 | MIT | CLI package |  |
 | `mdast-util-find-and-replace` | 3.0.2 | MIT | Web package |  |
@@ -261,12 +385,12 @@ The project does not intentionally vendor third-party source code into this repo
 | `mdast-util-mdx-jsx` | 3.2.0 | MIT | Web package |  |
 | `mdast-util-mdxjs-esm` | 2.0.1 | MIT | Web package |  |
 | `mdast-util-phrasing` | 4.1.0 | MIT | Web package |  |
-| `mdast-util-to-hast` | 13.2.1 | MIT | Web package |  |
+| `mdast-util-to-hast` | 13.2.1 | MIT | CLI package, Web package |  |
 | `mdast-util-to-markdown` | 2.1.2 | MIT | Web package |  |
 | `mdast-util-to-string` | 4.0.0 | MIT | Web package |  |
 | `media-typer` | 1.1.0 | MIT | CLI package |  |
 | `merge-descriptors` | 2.0.0 | MIT | CLI package |  |
-| `merge2` | 1.4.1 | MIT | CLI package, Web package |  |
+| `merge2` | 1.4.1 | MIT | CLI package |  |
 | `micromark` | 4.0.2 | MIT | Web package |  |
 | `micromark-core-commonmark` | 2.0.3 | MIT | Web package |  |
 | `micromark-extension-gfm` | 3.0.0 | MIT | Web package |  |
@@ -281,152 +405,176 @@ The project does not intentionally vendor third-party source code into this repo
 | `micromark-factory-space` | 2.0.1 | MIT | Web package |  |
 | `micromark-factory-title` | 2.0.1 | MIT | Web package |  |
 | `micromark-factory-whitespace` | 2.0.1 | MIT | Web package |  |
-| `micromark-util-character` | 2.1.1 | MIT | Web package |  |
+| `micromark-util-character` | 2.1.1 | MIT | CLI package, Web package |  |
 | `micromark-util-chunked` | 2.0.1 | MIT | Web package |  |
 | `micromark-util-classify-character` | 2.0.1 | MIT | Web package |  |
 | `micromark-util-combine-extensions` | 2.0.1 | MIT | Web package |  |
 | `micromark-util-decode-numeric-character-reference` | 2.0.2 | MIT | Web package |  |
 | `micromark-util-decode-string` | 2.0.1 | MIT | Web package |  |
-| `micromark-util-encode` | 2.0.1 | MIT | Web package |  |
+| `micromark-util-encode` | 2.0.1 | MIT | CLI package, Web package |  |
 | `micromark-util-html-tag-name` | 2.0.1 | MIT | Web package |  |
 | `micromark-util-normalize-identifier` | 2.0.1 | MIT | Web package |  |
 | `micromark-util-resolve-all` | 2.0.1 | MIT | Web package |  |
-| `micromark-util-sanitize-uri` | 2.0.1 | MIT | Web package |  |
+| `micromark-util-sanitize-uri` | 2.0.1 | MIT | CLI package, Web package |  |
 | `micromark-util-subtokenize` | 2.1.0 | MIT | Web package |  |
-| `micromark-util-symbol` | 2.0.1 | MIT | Web package |  |
-| `micromark-util-types` | 2.0.2 | MIT | Web package |  |
-| `micromatch` | 4.0.8 | MIT | CLI package, Web package |  |
-| `micromatch/node_modules/picomatch` | 2.3.2 | MIT | Web package |  |
+| `micromark-util-symbol` | 2.0.1 | MIT | CLI package, Web package |  |
+| `micromark-util-types` | 2.0.2 | MIT | CLI package, Web package |  |
+| `micromatch` | 4.0.8 | MIT | CLI package |  |
 | `mime-db` | 1.54.0 | MIT | CLI package |  |
 | `mime-types` | 3.0.2 | MIT | CLI package |  |
+| `minisearch` | 7.2.0 | MIT | CLI package |  |
+| `mitt` | 3.0.1 | MIT | CLI package |  |
 | `ms` | 2.1.3 | MIT | CLI package, Web package |  |
-| `mz` | 2.7.0 | MIT | Web package |  |
-| `nanoid` | 3.3.12 | MIT | Web package |  |
 | `nanoid` | 3.3.15 | MIT | CLI package |  |
+| `nanoid` | 3.3.16 | MIT | Web package |  |
 | `negotiator` | 1.0.0 | MIT | CLI package |  |
-| `node-releases` | 2.0.50 | MIT | Web package |  |
-| `normalize-path` | 3.0.0 | MIT | Web package |  |
-| `object-assign` | 4.1.1 | MIT | CLI package, Web package |  |
-| `object-hash` | 3.0.0 | MIT | Web package |  |
+| `node-releases` | 2.0.51 | MIT | Web package |  |
+| `object-assign` | 4.1.1 | MIT | CLI package |  |
 | `object-inspect` | 1.13.4 | MIT | CLI package |  |
 | `obug` | 2.1.1 | MIT | CLI package |  |
 | `on-finished` | 2.4.1 | MIT | CLI package |  |
 | `once` | 1.4.0 | ISC | CLI package |  |
+| `oniguruma-to-es` | 3.1.1 | MIT | CLI package |  |
 | `parse-entities` | 4.0.2 | MIT | Web package |  |
 | `parse-entities/node_modules/@types/unist` | 2.0.11 | MIT | Web package |  |
 | `parseurl` | 1.3.3 | MIT | CLI package |  |
-| `path-parse` | 1.0.7 | MIT | Web package |  |
 | `path-to-regexp` | 8.4.2 | MIT | CLI package |  |
 | `pathe` | 2.0.3 | MIT | CLI package |  |
+| `perfect-debounce` | 1.0.0 | MIT | CLI package |  |
 | `picocolors` | 1.1.1 | ISC | CLI package, Web package |  |
 | `picomatch` | 2.3.2 | MIT | CLI package |  |
-| `picomatch` | 4.0.4 | MIT | Web package |  |
-| `pify` | 2.3.0 | MIT | Web package |  |
-| `pirates` | 4.0.7 | MIT | Web package |  |
-| `playwright` | 1.61.1 | Apache-2.0 | CLI package |  |
-| `playwright-core` | 1.61.1 | Apache-2.0 | CLI package |  |
+| `picomatch` | 4.0.5 | MIT | Web package |  |
+| `playwright` | 1.62.0 | Apache-2.0 | CLI package |  |
+| `playwright-core` | 1.62.0 | Apache-2.0 | CLI package |  |
 | `playwright/node_modules/fsevents` | 2.3.2 | MIT | CLI package |  |
-| `postcss` | 8.5.16 | MIT | CLI package, Web package |  |
-| `postcss-import` | 15.1.0 | MIT | Web package |  |
-| `postcss-js` | 4.1.0 | MIT | Web package |  |
-| `postcss-load-config` | 6.0.1 | MIT | Web package |  |
-| `postcss-nested` | 6.2.0 | MIT | Web package |  |
-| `postcss-selector-parser` | 6.1.4 | MIT | Web package |  |
+| `postcss` | 8.5.16 | MIT | CLI package |  |
+| `postcss` | 8.5.23 | MIT | Web package |  |
 | `postcss-value-parser` | 4.2.0 | MIT | Web package |  |
+| `preact` | 10.29.4 | MIT | CLI package |  |
 | `property-information` | 7.1.0 | MIT | Web package |  |
+| `property-information` | 7.2.0 | MIT | CLI package |  |
 | `proxy-addr` | 2.0.7 | MIT | CLI package |  |
 | `qs` | 6.15.3 | BSD-3-Clause | CLI package |  |
-| `queue-microtask` | 1.2.3 | MIT | CLI package, Web package |  |
+| `queue-microtask` | 1.2.3 | MIT | CLI package |  |
 | `range-parser` | 1.3.0 | MIT | CLI package |  |
 | `raw-body` | 3.0.2 | MIT | CLI package |  |
-| `react` | 19.2.7 | MIT | Web package |  |
-| `react-dom` | 19.2.7 | MIT | Web package |  |
+| `react` | 19.2.8 | MIT | Web package |  |
+| `react-dom` | 19.2.8 | MIT | Web package |  |
 | `react-markdown` | 10.1.0 | MIT | Web package |  |
-| `read-cache` | 1.0.0 | MIT | Web package |  |
-| `readdirp` | 3.6.0 | MIT | Web package |  |
-| `readdirp/node_modules/picomatch` | 2.3.2 | MIT | Web package |  |
+| `regex` | 6.1.0 | MIT | CLI package |  |
+| `regex-recursion` | 6.0.2 | MIT | CLI package |  |
+| `regex-utilities` | 2.3.0 | MIT | CLI package |  |
 | `rehype-highlight` | 7.0.2 | MIT | Web package |  |
 | `remark-gfm` | 4.0.1 | MIT | Web package |  |
 | `remark-parse` | 11.0.0 | MIT | Web package |  |
 | `remark-rehype` | 11.1.2 | MIT | Web package |  |
 | `remark-stringify` | 11.0.0 | MIT | Web package |  |
-| `resolve` | 1.22.12 | MIT | Web package |  |
-| `reusify` | 1.1.0 | MIT | CLI package, Web package |  |
-| `rolldown` | 1.1.3 | MIT | CLI package, Web package |  |
+| `reusify` | 1.1.0 | MIT | CLI package |  |
+| `rfdc` | 1.4.1 | MIT | CLI package |  |
+| `rolldown` | 1.1.5 | MIT | CLI package, Web package |  |
+| `rollup` | 4.62.2 | MIT | CLI package |  |
 | `router` | 2.2.0 | MIT | CLI package |  |
-| `run-parallel` | 1.2.0 | MIT | CLI package, Web package |  |
+| `run-parallel` | 1.2.0 | MIT | CLI package |  |
 | `rxjs` | 7.8.2 | Apache-2.0 | CLI package |  |
 | `safer-buffer` | 2.1.2 | MIT | CLI package |  |
 | `scheduler` | 0.27.0 | MIT | Web package |  |
+| `search-insights` | 2.17.3 | MIT | CLI package |  |
 | `send` | 1.2.1 | MIT | CLI package |  |
 | `serve-static` | 2.2.1 | MIT | CLI package |  |
 | `setprototypeof` | 1.2.0 | ISC | CLI package |  |
-| `shell-quote` | 1.8.4 | MIT | CLI package |  |
+| `shell-quote` | 1.9.0 | MIT | CLI package |  |
+| `shiki` | 2.5.0 | MIT | CLI package |  |
 | `side-channel` | 1.1.1 | MIT | CLI package |  |
 | `side-channel-list` | 1.0.1 | MIT | CLI package |  |
 | `side-channel-map` | 1.0.1 | MIT | CLI package |  |
 | `side-channel-weakmap` | 1.0.2 | MIT | CLI package |  |
 | `siginfo` | 2.0.0 | ISC | CLI package |  |
 | `source-map-js` | 1.2.1 | BSD-3-Clause | CLI package, Web package |  |
-| `space-separated-tokens` | 2.0.2 | MIT | Web package |  |
+| `space-separated-tokens` | 2.0.2 | MIT | CLI package, Web package |  |
+| `speakingurl` | 14.0.1 | BSD-3-Clause | CLI package |  |
 | `stackback` | 0.0.2 | MIT | CLI package |  |
 | `statuses` | 2.0.2 | MIT | CLI package |  |
 | `std-env` | 4.1.0 | MIT | CLI package |  |
 | `string-width` | 7.2.0 | MIT | CLI package |  |
-| `stringify-entities` | 4.0.4 | MIT | Web package |  |
+| `stringify-entities` | 4.0.4 | MIT | CLI package, Web package |  |
 | `strip-ansi` | 7.2.0 | MIT | CLI package |  |
 | `style-to-js` | 1.1.21 | MIT | Web package |  |
 | `style-to-object` | 1.0.14 | MIT | Web package |  |
-| `sucrase` | 3.35.1 | MIT | Web package |  |
+| `superjson` | 2.2.6 | MIT | CLI package |  |
 | `supports-color` | 10.2.2 | MIT | CLI package |  |
-| `supports-preserve-symlinks-flag` | 1.0.0 | MIT | Web package |  |
-| `tailwindcss` | 3.4.19 | MIT | Web package |  |
-| `tailwindcss/node_modules/jiti` | 1.21.7 | MIT | Web package |  |
-| `thenify` | 3.3.1 | MIT | Web package |  |
-| `thenify-all` | 1.6.0 | MIT | Web package |  |
+| `tabbable` | 6.5.0 | MIT | CLI package |  |
+| `tailwindcss` | 4.3.3 | MIT | Web package |  |
+| `tapable` | 2.3.3 | MIT | Web package |  |
 | `tinybench` | 2.9.0 | MIT | CLI package |  |
 | `tinyexec` | 1.1.2 | MIT | CLI package |  |
 | `tinyglobby` | 0.2.17 | MIT | CLI package, Web package |  |
 | `tinyglobby/node_modules/fdir` | 6.5.0 | MIT | CLI package |  |
-| `tinyglobby/node_modules/picomatch` | 4.0.4 | MIT | CLI package |  |
+| `tinyglobby/node_modules/picomatch` | 4.0.5 | MIT | CLI package |  |
 | `tinyrainbow` | 3.1.0 | MIT | CLI package |  |
-| `to-regex-range` | 5.0.1 | MIT | CLI package, Web package |  |
+| `to-regex-range` | 5.0.1 | MIT | CLI package |  |
 | `toidentifier` | 1.0.1 | MIT | CLI package |  |
 | `tree-kill` | 1.2.2 | MIT | CLI package |  |
-| `trim-lines` | 3.0.1 | MIT | Web package |  |
+| `trim-lines` | 3.0.1 | MIT | CLI package, Web package |  |
 | `trough` | 2.2.0 | MIT | Web package |  |
-| `ts-interface-checker` | 0.1.13 | Apache-2.0 | Web package |  |
 | `tslib` | 2.8.1 | 0BSD | CLI package, Web package |  |
-| `tsx` | 4.22.4 | MIT | CLI package |  |
+| `tsx` | 4.23.1 | MIT | CLI package |  |
 | `type-is` | 2.1.0 | MIT | CLI package |  |
 | `type-is/node_modules/content-type` | 2.0.0 | MIT | CLI package |  |
-| `typescript` | 6.0.3 | Apache-2.0 | CLI package, Web package |  |
+| `typescript` | 7.0.2 | Apache-2.0 | CLI package, Web package |  |
 | `undici-types` | 8.3.0 | MIT | CLI package |  |
 | `unified` | 11.0.5 | MIT | Web package |  |
 | `unist-util-find-after` | 5.0.0 | MIT | Web package |  |
-| `unist-util-is` | 6.0.1 | MIT | Web package |  |
-| `unist-util-position` | 5.0.0 | MIT | Web package |  |
-| `unist-util-stringify-position` | 4.0.0 | MIT | Web package |  |
-| `unist-util-visit` | 5.1.0 | MIT | Web package |  |
-| `unist-util-visit-parents` | 6.0.2 | MIT | Web package |  |
+| `unist-util-is` | 6.0.1 | MIT | CLI package, Web package |  |
+| `unist-util-position` | 5.0.0 | MIT | CLI package, Web package |  |
+| `unist-util-stringify-position` | 4.0.0 | MIT | CLI package, Web package |  |
+| `unist-util-visit` | 5.1.0 | MIT | CLI package, Web package |  |
+| `unist-util-visit-parents` | 6.0.2 | MIT | CLI package, Web package |  |
 | `unpipe` | 1.0.0 | MIT | CLI package |  |
 | `update-browserslist-db` | 1.2.3 | MIT | Web package |  |
-| `util-deprecate` | 1.0.2 | MIT | Web package |  |
 | `vary` | 1.1.2 | MIT | CLI package |  |
-| `vfile` | 6.0.3 | MIT | Web package |  |
-| `vfile-message` | 4.0.3 | MIT | Web package |  |
-| `vite` | 8.1.0 | MIT | CLI package, Web package |  |
-| `vite/node_modules/picomatch` | 4.0.4 | MIT | CLI package |  |
-| `vitest` | 4.1.9 | MIT | CLI package |  |
+| `vfile` | 6.0.3 | MIT | CLI package, Web package |  |
+| `vfile-message` | 4.0.3 | MIT | CLI package, Web package |  |
+| `vite` | 8.1.4 | MIT | CLI package |  |
+| `vite` | 8.1.5 | MIT | Web package |  |
+| `vite/node_modules/picomatch` | 4.0.5 | MIT | CLI package |  |
+| `vitepress` | 1.6.4 | MIT | CLI package |  |
+| `vitepress/node_modules/@esbuild/aix-ppc64` | 0.21.5 | MIT | CLI package |  |
+| `vitepress/node_modules/@esbuild/android-arm` | 0.21.5 | MIT | CLI package |  |
+| `vitepress/node_modules/@esbuild/android-arm64` | 0.21.5 | MIT | CLI package |  |
+| `vitepress/node_modules/@esbuild/android-x64` | 0.21.5 | MIT | CLI package |  |
+| `vitepress/node_modules/@esbuild/darwin-arm64` | 0.21.5 | MIT | CLI package |  |
+| `vitepress/node_modules/@esbuild/darwin-x64` | 0.21.5 | MIT | CLI package |  |
+| `vitepress/node_modules/@esbuild/freebsd-arm64` | 0.21.5 | MIT | CLI package |  |
+| `vitepress/node_modules/@esbuild/freebsd-x64` | 0.21.5 | MIT | CLI package |  |
+| `vitepress/node_modules/@esbuild/linux-arm` | 0.21.5 | MIT | CLI package |  |
+| `vitepress/node_modules/@esbuild/linux-arm64` | 0.21.5 | MIT | CLI package |  |
+| `vitepress/node_modules/@esbuild/linux-ia32` | 0.21.5 | MIT | CLI package |  |
+| `vitepress/node_modules/@esbuild/linux-loong64` | 0.21.5 | MIT | CLI package |  |
+| `vitepress/node_modules/@esbuild/linux-mips64el` | 0.21.5 | MIT | CLI package |  |
+| `vitepress/node_modules/@esbuild/linux-ppc64` | 0.21.5 | MIT | CLI package |  |
+| `vitepress/node_modules/@esbuild/linux-riscv64` | 0.21.5 | MIT | CLI package |  |
+| `vitepress/node_modules/@esbuild/linux-s390x` | 0.21.5 | MIT | CLI package |  |
+| `vitepress/node_modules/@esbuild/linux-x64` | 0.21.5 | MIT | CLI package |  |
+| `vitepress/node_modules/@esbuild/netbsd-x64` | 0.21.5 | MIT | CLI package |  |
+| `vitepress/node_modules/@esbuild/openbsd-x64` | 0.21.5 | MIT | CLI package |  |
+| `vitepress/node_modules/@esbuild/sunos-x64` | 0.21.5 | MIT | CLI package |  |
+| `vitepress/node_modules/@esbuild/win32-arm64` | 0.21.5 | MIT | CLI package |  |
+| `vitepress/node_modules/@esbuild/win32-ia32` | 0.21.5 | MIT | CLI package |  |
+| `vitepress/node_modules/@esbuild/win32-x64` | 0.21.5 | MIT | CLI package |  |
+| `vitepress/node_modules/@vitejs/plugin-vue` | 5.2.4 | MIT | CLI package |  |
+| `vitepress/node_modules/esbuild` | 0.21.5 | MIT | CLI package |  |
+| `vitepress/node_modules/vite` | 5.4.21 | MIT | CLI package |  |
+| `vitest` | 4.1.10 | MIT | CLI package |  |
 | `vitest/node_modules/picomatch` | 4.0.4 | MIT | CLI package |  |
+| `vue` | 3.5.39 | MIT | CLI package |  |
 | `webview-bun` | 2.4.0 | MIT | CLI package |  |
 | `why-is-node-running` | 2.3.0 | MIT | CLI package |  |
 | `wrap-ansi` | 9.0.2 | MIT | CLI package |  |
 | `wrappy` | 1.0.2 | ISC | CLI package |  |
-| `ws` | 8.21.0 | MIT | CLI package |  |
+| `ws` | 8.21.1 | MIT | CLI package |  |
 | `y18n` | 5.0.8 | ISC | CLI package |  |
 | `yargs` | 18.0.0 | MIT | CLI package |  |
 | `yargs-parser` | 22.0.0 | ISC | CLI package |  |
 | `zod` | 4.4.3 | MIT | CLI package |  |
-| `zwitch` | 2.0.4 | MIT | Web package |  |
+| `zwitch` | 2.0.4 | MIT | CLI package, Web package |  |
 

--- a/docs/bugs.md
+++ b/docs/bugs.md
@@ -149,3 +149,35 @@ Chrome MCP 的元素引用是基于当前 DOM 快照生成的，页面重载后 
 
 ### 处理方式
 每次页面变化后重新调用 `find` 获取新引用。这是正常行为，无需在产品层面修复。
+
+---
+
+## BUG-007: Windows 进程运行器硬编码 `/bin/sh`，OS 命令无法启动
+
+**发现日期**: 2026-07-30
+**状态**: ✅ 已修复
+**文件**: `src/core/subprocessSandbox.ts`
+
+### 问题定义
+
+受治理的 `shell` 与 `run_check` 共用进程运行器。此前运行器在所有平台上都生成
+`/bin/sh -c <command>`，这隐含了 POSIX 宿主假设。在 Windows 上 `/bin/sh` 通常不存在，
+所以 `cmd`、`dir`、`npm.cmd` 等命令会在执行前以 `ENOENT` 失败。
+
+跨平台执行契约为：
+
+- Linux、macOS：通过 `/bin/sh -c` 执行 shell 命令行。
+- Windows：通过系统 `ComSpec`（缺省为 `cmd.exe`）执行 `cmd.exe /d /s /c` 命令行。
+- `command` 单独使用时表示原生 shell 命令行，可包含管道、重定向和条件操作符。
+- 同时传入 `args` 时，`command` 表示可执行文件名或路径；命令与每个参数按宿主 shell
+  规则分别转义。
+- 中断或超时时必须终止整个子进程树：POSIX 使用独立进程组，Windows 使用
+  `taskkill.exe /T /F`。
+- OS 网络沙箱能力保持原有安全边界：Seatbelt（macOS）、Bubblewrap（Linux）；
+  Windows 在限制性网络策略下仍然 fail closed，不以“跨平台执行”为由绕过组织策略。
+
+### 验收
+
+CI 在 Ubuntu、Windows 和 macOS 上运行同一组原生命令执行、参数转义、取消与沙箱选择
+回归测试。Windows 启动参数中不得出现 `/bin/sh`，路径位于 `Program Files` 下的可执行
+文件必须被正确引用。

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dvalincode",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dvalincode",
-      "version": "0.14.0",
+      "version": "0.14.1",
       "license": "MIT",
       "dependencies": {
         "chalk": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dvalincode",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "A local-first, provider-neutral CLI foundation for agentic coding workflows.",
   "type": "module",
   "license": "MIT",

--- a/src/core/subprocessSandbox.ts
+++ b/src/core/subprocessSandbox.ts
@@ -1,4 +1,4 @@
-import { execFile, spawn } from 'node:child_process';
+import { spawn, type ChildProcess } from 'node:child_process';
 import { existsSync } from 'node:fs';
 import type { AuditSink } from '../audit/log.js';
 import { checkEgress, PolicyViolationError, type ResolvedPolicy } from './policy.js';
@@ -60,7 +60,7 @@ export async function runGovernedProcess(options: GovernedProcessOptions): Promi
     throw new PolicyViolationError(options.toolName, rule, 'subprocess network isolation');
   }
 
-  const launch = buildLaunch(options.command, options.args, options.cwd, plan);
+  const launch = buildProcessLaunch(options.command, options.args, options.cwd, plan);
   const result = await spawnProcess(launch.command, launch.args, options.cwd, options.timeoutMs, options.signal);
   return { ...result, sandbox: plan.sandbox };
 }
@@ -92,7 +92,7 @@ export async function runGovernedExecutable(options: GovernedExecutableOptions):
   }
 
   const launch = buildExecutableLaunch(options.command, options.args, options.cwd, plan);
-  const result = await execFileProcess(launch.command, launch.args, options.cwd, options.timeoutMs, options.signal);
+  const result = await spawnExecutableProcess(launch.command, launch.args, options.cwd, options.timeoutMs, options.signal);
   return { ...result, sandbox: plan.sandbox };
 }
 
@@ -137,31 +137,107 @@ export function detectSubprocessSandboxCapabilities(): SubprocessSandboxCapabili
 
 const POSIX_SHELL = '/bin/sh';
 
+export type HostShell = {
+  executable: string;
+  argsBeforeScript: string[];
+  kind: 'cmd' | 'posix';
+};
+
 /**
- * The `command` field is treated as a shell command line — models routinely
- * put a full line there (`cd X && python …`, `echo "hi"`, pipes, redirection),
- * so it is passed to `/bin/sh -c` verbatim. Any `args` are appended as literal,
- * shell-quoted arguments. Spawning the inner command directly (`shell: false`)
- * made `sandbox-exec` execvp() the whole line as one path → ENOENT → exit 71.
+ * Resolve the native command interpreter for the host OS.
+ *
+ * `/bin/sh` is available on Linux and macOS. Windows must use `ComSpec`
+ * (normally `C:\Windows\System32\cmd.exe`); falling back to `cmd.exe` lets
+ * Windows resolve it from the system search path when ComSpec is absent.
  */
-export function buildShellScript(command: string, args: string[]): string {
-  if (args.length === 0) return command;
-  return `${command} ${args.map(shellQuote).join(' ')}`;
+export function resolveHostShell(
+  platform: NodeJS.Platform = process.platform,
+  env: NodeJS.ProcessEnv = process.env,
+): HostShell {
+  if (platform === 'win32') {
+    const configured = Object.entries(env)
+      .find(([key, value]) => key.toLowerCase() === 'comspec' && value?.trim())?.[1]
+      ?.trim();
+    return {
+      executable: configured || 'cmd.exe',
+      // /d disables registry AutoRun hooks, making governed launches deterministic.
+      // /s gives /c consistent quote handling for a command supplied as one argv item.
+      argsBeforeScript: ['/d', '/s', '/c'],
+      kind: 'cmd',
+    };
+  }
+  return { executable: POSIX_SHELL, argsBeforeScript: ['-c'], kind: 'posix' };
 }
 
-function shellQuote(value: string): string {
+/**
+ * With no `args`, the `command` field is treated as a native shell command line
+ * because models routinely put a full line there (`cd X && python …`, pipes,
+ * redirection). Linux/macOS route it through `/bin/sh -c`; Windows routes it
+ * through `cmd.exe /d /s /c`. With `args`, command is an executable reference
+ * and every token is quoted for the host shell.
+ *
+ * Spawning a full command line directly (`shell: false`) previously made
+ * sandbox-exec execvp() the whole line as one path → ENOENT → exit 71.
+ */
+export function buildShellScript(
+  command: string,
+  args: string[],
+  platform: NodeJS.Platform = process.platform,
+): string {
+  if (args.length === 0) return command;
+  const quote = platform === 'win32' ? cmdQuote : posixShellQuote;
+  // With explicit args, `command` is an executable name/path rather than a
+  // complete shell line. Quote it too so installations under paths such as
+  // C:\Program Files\... work correctly.
+  return `${quote(command)} ${args.map(quote).join(' ')}`;
+}
+
+function posixShellQuote(value: string): string {
   if (value === '') return "''";
   if (/^[A-Za-z0-9_@%+=:,./-]+$/.test(value)) return value;
   return `'${value.replace(/'/g, `'\\''`)}'`;
 }
 
-function buildLaunch(
+/**
+ * Quote one argument in a command line parsed by cmd.exe and then by the
+ * launched program's Windows argv parser. Shell metacharacters remain inert
+ * inside the quotes, while backslashes before quotes follow the Windows CRT
+ * escaping convention.
+ */
+function cmdQuote(value: string): string {
+  if (value === '') return '""';
+  if (/^[A-Za-z0-9_@+=:,./\\-]+$/.test(value)) return value;
+
+  let quoted = '"';
+  let backslashes = 0;
+  for (const char of value) {
+    if (char === '\\') {
+      backslashes++;
+      continue;
+    }
+    if (char === '"') {
+      quoted += '\\'.repeat(backslashes * 2 + 1);
+      quoted += '"';
+      backslashes = 0;
+      continue;
+    }
+    quoted += '\\'.repeat(backslashes);
+    quoted += char;
+    backslashes = 0;
+  }
+  quoted += '\\'.repeat(backslashes * 2);
+  return `${quoted}"`;
+}
+
+export function buildProcessLaunch(
   command: string,
   args: string[],
   cwd: string,
   plan: Extract<SubprocessSandboxPlan, { allowed: true }>,
+  platform: NodeJS.Platform = process.platform,
+  env: NodeJS.ProcessEnv = process.env,
 ): { command: string; args: string[] } {
-  const script = buildShellScript(command, args);
+  const script = buildShellScript(command, args, platform);
 
   if (plan.sandbox === 'seatbelt') {
     const profile = [
@@ -192,7 +268,11 @@ function buildLaunch(
     };
   }
 
-  return { command: POSIX_SHELL, args: ['-c', script] };
+  const shell = resolveHostShell(platform, env);
+  return {
+    command: shell.executable,
+    args: [...shell.argsBeforeScript, script],
+  };
 }
 
 function buildExecutableLaunch(
@@ -224,47 +304,14 @@ function buildExecutableLaunch(
   return { command, args };
 }
 
-function execFileProcess(
+function spawnExecutableProcess(
   command: string,
   args: string[],
   cwd: string,
   timeoutMs: number,
   signal?: AbortSignal,
 ): Promise<Omit<GovernedProcessResult, 'sandbox'>> {
-  return new Promise((resolve, reject) => {
-    if (signal?.aborted) {
-      reject(new Error('interrupted'));
-      return;
-    }
-
-    let timedOut = false;
-    let interrupted = false;
-    const child = execFile(command, args, {
-      cwd,
-      encoding: 'utf8',
-      maxBuffer: 32_000,
-      shell: false,
-    }, (error, stdout, stderr) => {
-      clearTimeout(timer);
-      signal?.removeEventListener('abort', onAbort);
-      if (interrupted) {
-        reject(new Error('interrupted'));
-        return;
-      }
-      const output = `${stdout ?? ''}${stderr ?? ''}`.trimEnd();
-      const exitCode = error ? (typeof error.code === 'number' ? error.code : 1) : 0;
-      resolve({ output, exitCode, timedOut });
-    });
-    const timer = setTimeout(() => {
-      timedOut = true;
-      child.kill('SIGTERM');
-    }, timeoutMs);
-    const onAbort = () => {
-      interrupted = true;
-      child.kill('SIGTERM');
-    };
-    signal?.addEventListener('abort', onAbort, { once: true });
-  });
+  return spawnProcess(command, args, cwd, timeoutMs, signal);
 }
 
 function spawnProcess(
@@ -280,16 +327,16 @@ function spawnProcess(
       return;
     }
 
-    // A governed command is normally launched through `/bin/sh -c`. On POSIX,
-    // killing only that shell can leave its actual command running with the
-    // stdout/stderr pipes open forever. Give every launch its own process group
-    // so abort and timeout signals reach the complete subprocess tree.
+    // Governed commands may launch a shell and then further descendants.
+    // Give POSIX launches their own process group so abort and timeout signals
+    // reach the complete subprocess tree.
     const usesProcessGroup = process.platform !== 'win32';
     const child = spawn(command, args, {
       cwd,
       detached: usesProcessGroup,
       shell: false,
       stdio: ['ignore', 'pipe', 'pipe'],
+      windowsHide: true,
     });
 
     let output = '';
@@ -304,15 +351,7 @@ function spawnProcess(
     };
 
     const signalTree = (signal: NodeJS.Signals) => {
-      if (usesProcessGroup && child.pid) {
-        try {
-          process.kill(-child.pid, signal);
-          return;
-        } catch {
-          // The group may already be gone; fall back to the direct child.
-        }
-      }
-      child.kill(signal);
+      signalProcessTree(child, signal, usesProcessGroup);
     };
 
     const scheduleForceKill = () => {
@@ -359,6 +398,41 @@ function spawnProcess(
       resolve({ output: output.trimEnd(), exitCode: code, timedOut });
     });
   });
+}
+
+/**
+ * POSIX launches get their own process group. Windows has no equivalent signal
+ * API in Node, so taskkill /T is required to avoid leaving grandchildren (for
+ * example npm -> node) running after an interrupted or timed-out tool call.
+ */
+function signalProcessTree(
+  child: ChildProcess,
+  signal: NodeJS.Signals,
+  usesProcessGroup: boolean,
+): void {
+  if (process.platform === 'win32' && child.pid) {
+    try {
+      const killer = spawn('taskkill.exe', ['/pid', String(child.pid), '/t', '/f'], {
+        stdio: 'ignore',
+        windowsHide: true,
+      });
+      killer.on('error', () => child.kill());
+      return;
+    } catch {
+      child.kill();
+      return;
+    }
+  }
+
+  if (usesProcessGroup && child.pid) {
+    try {
+      process.kill(-child.pid, signal);
+      return;
+    } catch {
+      // The group may already be gone; fall back to the direct child.
+    }
+  }
+  child.kill(signal);
 }
 
 function escapeSeatbeltPath(value: string): string {

--- a/src/core/subprocessSandbox.ts
+++ b/src/core/subprocessSandbox.ts
@@ -61,7 +61,14 @@ export async function runGovernedProcess(options: GovernedProcessOptions): Promi
   }
 
   const launch = buildProcessLaunch(options.command, options.args, options.cwd, plan);
-  const result = await spawnProcess(launch.command, launch.args, options.cwd, options.timeoutMs, options.signal);
+  const result = await spawnProcess(
+    launch.command,
+    launch.args,
+    options.cwd,
+    options.timeoutMs,
+    options.signal,
+    launch.windowsVerbatimArguments,
+  );
   return { ...result, sandbox: plan.sandbox };
 }
 
@@ -141,6 +148,12 @@ export type HostShell = {
   executable: string;
   argsBeforeScript: string[];
   kind: 'cmd' | 'posix';
+};
+
+type ProcessLaunch = {
+  command: string;
+  args: string[];
+  windowsVerbatimArguments?: boolean;
 };
 
 /**
@@ -236,7 +249,7 @@ export function buildProcessLaunch(
   plan: Extract<SubprocessSandboxPlan, { allowed: true }>,
   platform: NodeJS.Platform = process.platform,
   env: NodeJS.ProcessEnv = process.env,
-): { command: string; args: string[] } {
+): ProcessLaunch {
   const script = buildShellScript(command, args, platform);
 
   if (plan.sandbox === 'seatbelt') {
@@ -269,6 +282,16 @@ export function buildProcessLaunch(
   }
 
   const shell = resolveHostShell(platform, env);
+  if (shell.kind === 'cmd') {
+    // Match Node's own shell:true launch contract. cmd.exe requires the entire
+    // /c payload to be surrounded by one verbatim quote pair; letting libuv
+    // quote this argv item again can silently drop nested quoted arguments.
+    return {
+      command: shell.executable,
+      args: [...shell.argsBeforeScript, `"${script}"`],
+      windowsVerbatimArguments: true,
+    };
+  }
   return {
     command: shell.executable,
     args: [...shell.argsBeforeScript, script],
@@ -320,6 +343,7 @@ function spawnProcess(
   cwd: string,
   timeoutMs: number,
   signal?: AbortSignal,
+  windowsVerbatimArguments = false,
 ): Promise<Omit<GovernedProcessResult, 'sandbox'>> {
   return new Promise((resolve, reject) => {
     if (signal?.aborted) {
@@ -337,6 +361,7 @@ function spawnProcess(
       shell: false,
       stdio: ['ignore', 'pipe', 'pipe'],
       windowsHide: true,
+      windowsVerbatimArguments,
     });
 
     let output = '';

--- a/src/tools/shell.ts
+++ b/src/tools/shell.ts
@@ -21,7 +21,7 @@ type Input = z.infer<typeof inputSchema>;
 
 export const shellTool: Tool<Input> = {
   name: 'shell',
-  description: 'Run a process in the workspace. Git pull/push/fetch/clone and GitHub CLI (gh) operations automatically request outbound network access.',
+  description: 'Run a command in the workspace using the native host shell (cmd.exe on Windows, /bin/sh on Linux and macOS). Git pull/push/fetch/clone and GitHub CLI (gh) operations automatically request outbound network access.',
   access: 'execute',
   inputSchema,
   isConcurrencySafe: () => false,

--- a/src/version.ts
+++ b/src/version.ts
@@ -5,4 +5,4 @@
  * Everything that reports a version — the CLI `--version`, the trust report, and
  * the self-update check — imports from here so the copies can never drift.
  */
-export const VERSION = '0.14.0';
+export const VERSION = '0.14.1';

--- a/tests/shellSeatbeltExec.test.ts
+++ b/tests/shellSeatbeltExec.test.ts
@@ -64,7 +64,8 @@ describe('native host shell selection', () => {
       { COMSPEC: 'C:\\Windows\\System32\\cmd.exe' },
     )).toEqual({
       command: 'C:\\Windows\\System32\\cmd.exe',
-      args: ['/d', '/s', '/c', 'echo hello & ver'],
+      args: ['/d', '/s', '/c', '"echo hello & ver"'],
+      windowsVerbatimArguments: true,
     });
   });
 

--- a/tests/shellSeatbeltExec.test.ts
+++ b/tests/shellSeatbeltExec.test.ts
@@ -2,26 +2,90 @@ import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
-import { buildShellScript, runGovernedExecutable, runGovernedProcess } from '../src/core/subprocessSandbox.js';
+import {
+  buildProcessLaunch,
+  buildShellScript,
+  resolveHostShell,
+  runGovernedExecutable,
+  runGovernedProcess,
+} from '../src/core/subprocessSandbox.js';
 import { resolvePolicy } from '../src/core/policy.js';
 
 describe('buildShellScript', () => {
   it('passes a full command line through unchanged when there are no args', () => {
-    expect(buildShellScript('cd repo && python -m pytest', [])).toBe('cd repo && python -m pytest');
-    expect(buildShellScript('echo "hello"', [])).toBe('echo "hello"');
-    expect(buildShellScript('/bin/echo hello', [])).toBe('/bin/echo hello');
+    expect(buildShellScript('cd repo && python -m pytest', [], 'linux')).toBe('cd repo && python -m pytest');
+    expect(buildShellScript('echo "hello"', [], 'darwin')).toBe('echo "hello"');
   });
 
   it('appends args as shell-quoted literals', () => {
-    expect(buildShellScript('python', ['-c', "print('hi')"])).toBe(`python -c 'print('\\''hi'\\'')'`);
-    expect(buildShellScript('grep', ['-r', 'a b', '.'])).toBe("grep -r 'a b' .");
-    expect(buildShellScript('echo', [''])).toBe("echo ''");
+    expect(buildShellScript('python', ['-c', "print('hi')"], 'linux')).toBe(`python -c 'print('\\''hi'\\'')'`);
+    expect(buildShellScript('grep', ['-r', 'a b', '.'], 'darwin')).toBe("grep -r 'a b' .");
+    expect(buildShellScript('echo', [''], 'linux')).toBe("echo ''");
+  });
+
+  it('uses Windows command-line quoting for cmd.exe', () => {
+    expect(buildShellScript('node', ['script.js', 'a b', 'a&b', ''], 'win32'))
+      .toBe('node script.js "a b" "a&b" ""');
+    expect(buildShellScript('C:\\Program Files\\nodejs\\node.exe', ['--version'], 'win32'))
+      .toBe('"C:\\Program Files\\nodejs\\node.exe" --version');
+    expect(buildShellScript('echo hello & ver', [], 'win32')).toBe('echo hello & ver');
+  });
+});
+
+describe('native host shell selection', () => {
+  it.each(['linux', 'darwin'] as const)('uses /bin/sh on %s', platform => {
+    expect(resolveHostShell(platform)).toEqual({
+      executable: '/bin/sh',
+      argsBeforeScript: ['-c'],
+      kind: 'posix',
+    });
+  });
+
+  it('uses ComSpec and disables AutoRun hooks on Windows', () => {
+    const env = { ComSpec: 'C:\\Windows\\System32\\cmd.exe' };
+    expect(resolveHostShell('win32', env)).toEqual({
+      executable: env.ComSpec,
+      argsBeforeScript: ['/d', '/s', '/c'],
+      kind: 'cmd',
+    });
+  });
+
+  it('falls back to cmd.exe when Windows ComSpec is unavailable', () => {
+    expect(resolveHostShell('win32', {})).toMatchObject({ executable: 'cmd.exe', kind: 'cmd' });
+  });
+
+  it('builds a Windows launch without referencing /bin/sh', () => {
+    expect(buildProcessLaunch(
+      'echo hello & ver',
+      [],
+      'C:\\workspace',
+      { allowed: true, sandbox: 'none' },
+      'win32',
+      { COMSPEC: 'C:\\Windows\\System32\\cmd.exe' },
+    )).toEqual({
+      command: 'C:\\Windows\\System32\\cmd.exe',
+      args: ['/d', '/s', '/c', 'echo hello & ver'],
+    });
+  });
+
+  it.each(['linux', 'darwin'] as const)('builds a POSIX launch on %s', platform => {
+    expect(buildProcessLaunch(
+      'printf',
+      ['%s', 'hello world'],
+      '/workspace',
+      { allowed: true, sandbox: 'none' },
+      platform,
+      {},
+    )).toEqual({
+      command: '/bin/sh',
+      args: ['-c', "printf %s 'hello world'"],
+    });
   });
 });
 
 // Regression for the exit-71 bug: a shell command line placed in `command`
 // used to be execvp()'d as a single path under sandbox-exec and fail with
-// EX_OSERR. Routing through `/bin/sh -c` must let it run.
+// EX_OSERR. Routing through the native host shell must let it run.
 describe('runGovernedProcess (real subprocess)', () => {
   let cwd: string;
   const policy = resolvePolicy([]);
@@ -51,14 +115,17 @@ describe('runGovernedProcess (real subprocess)', () => {
     expect(res.output).toContain('world');
   });
 
-  it('runs an absolute-path command with an inline argument', async () => {
+  it.skipIf(process.platform === 'win32')('runs an absolute-path command with an inline argument', async () => {
     const res = await run('/bin/echo hello');
     expect(res.exitCode).toBe(0);
     expect(res.output.trim()).toBe('hello');
   });
 
   it('runs the split command + args form and quotes args literally', async () => {
-    const res = await run('printf', ['%s\n', 'a b']);
+    const res = await run(
+      process.execPath,
+      ['-e', 'process.stdout.write(process.argv[1])', 'a b'],
+    );
     expect(res.exitCode).toBe(0);
     expect(res.output.trim()).toBe('a b');
   });


### PR DESCRIPTION
## What changed

- Select `cmd.exe` through `ComSpec` on Windows and `/bin/sh` on Linux/macOS.
- Quote split executable and argument input for the host shell, including Windows paths under `Program Files`.
- Preserve nested quoted arguments with the verbatim `cmd.exe /d /s /c` launch contract.
- Terminate Windows subprocess trees with `taskkill /T /F` on timeout or interruption.
- Add Ubuntu, Windows, and macOS shell regression CI.
- Bump the release version to `0.14.1` and refresh third-party notices.

## Why

The governed process runner always launched `/bin/sh -c`, even on Windows. Standard Windows installations do not provide `/bin/sh`, so commands such as `cmd`, `dir`, and `npm.cmd` failed with `ENOENT` before the requested command could run.

The first Windows CI run also found that normal argv quoting could silently drop nested quoted arguments passed through `cmd.exe`. The launch now matches the Node.js native shell contract by wrapping the `/c` payload once and enabling verbatim Windows arguments.

## User impact

DvalinCode can now execute native OS-level commands on Windows, Linux, and macOS while preserving governed-network behavior. Windows still fails closed when policy requires an unavailable subprocess network sandbox.

## Validation

- `npm run check`: 130 test files, 798 tests passed
- `npm run build`
- `npm run build:release:windows`
- Windows ZIP structure and checksum smoke tests passed
- SHA-256: `91cb031d9679624a28570aa5e30dd794454bc5aeb785641bcb88ddc6a6e5d2ec`