### PR TITLE
docs: thank project contributors

### DIFF
--- a/README.md
+++ b/README.md
@@ -774,3 +774,21 @@ Full source references: [docs/REFERENCES.md](docs/REFERENCES.md)
     </picture>
   </a>
 </p>
+
+---
+
+## 💛 Thanks to Our Contributors
+
+<p align="center">
+  Every issue, idea, documentation improvement, test, and code contribution helps make DvalinCode better.
+</p>
+
+<p align="center">
+  <a href="https://github.com/arthurpanhku/dvalincode/graphs/contributors">
+    <img src="https://contrib.rocks/image?repo=arthurpanhku/dvalincode" alt="DvalinCode contributors">
+  </a>
+</p>
+
+<p align="center">
+  <sub>Want to join them? Read the <a href="CONTRIBUTING.md">contribution guide</a> and send your first pull request.</sub>
+</p>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -702,3 +702,21 @@ prompt、UI 文案、工具 schema、模块布局和产品实现均为原创；�
     </picture>
   </a>
 </p>
+
+---
+
+## 💛 感谢每一位贡献者
+
+<p align="center">
+  每一个 Issue、想法、文档改进、测试和代码贡献，都在帮助 DvalinCode 变得更好。
+</p>
+
+<p align="center">
+  <a href="https://github.com/arthurpanhku/dvalincode/graphs/contributors">
+    <img src="https://contrib.rocks/image?repo=arthurpanhku/dvalincode" alt="DvalinCode 贡献者">
+  </a>
+</p>
+
+<p align="center">
+  <sub>也想加入？阅读<a href="CONTRIBUTING.md">贡献指南</a>，提交你的第一个 Pull Request。</sub>
+</p>


### PR DESCRIPTION
## What changed

- Add a contributor thank-you section at the bottom of the English README.
- Add the matching section to the Chinese README.
- Show a dynamic contributor avatar wall linked to GitHub contributor graph.
- Link prospective contributors to the contribution guide.

## Why

Contributors should have a visible, automatically maintained place of recognition on the project landing page.

## User impact

New contributors appear without manually editing the README, and visitors have a clear path to make their first contribution.

## Validation

- `git diff --check`
- Verified the contributor image endpoint returns HTTP 200.