### PR TITLE
feat: ship a per-release Evidence Pack and publish PCP-1 as an open spec

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,6 +109,25 @@ jobs:
       - name: Verify checksums
         run: cd release && shasum -a 256 -c SHA256SUMS.txt
 
+      # Every release ships an Evidence Pack produced BY the shipped binary:
+      # real governed runs (one allowed, one blocked by policy) on this build
+      # machine, exported and re-verified offline. The script appends the pack's
+      # checksum to SHA256SUMS.txt, so the provenance attestation below covers
+      # it too. See docs/RELEASE-EVIDENCE.md.
+      - name: Build release Evidence Pack
+        run: |
+          set -euo pipefail
+          ARCH=x64
+          if [ "$(uname -m)" = "arm64" ]; then ARCH=arm64; fi
+          mkdir -p release/evidence-bin
+          tar xzf release/dvalincode-v*-macos-"$ARCH".tar.gz -C release/evidence-bin
+          BIN="$(find release/evidence-bin -maxdepth 2 -type f -name "dvalincode-macos-$ARCH" | head -1)"
+          [ -n "$BIN" ] || { echo "evidence: shipped binary not found" >&2; exit 1; }
+          node scripts/release-evidence.mjs --bin "$BIN"
+          rm -rf release/evidence-bin
+          # Re-verify including the appended Evidence Pack line.
+          cd release && shasum -a 256 -c SHA256SUMS.txt
+
       # Notarize the macOS archives so Gatekeeper clears them on download.
       # Skipped without the Apple credentials (→ ad-hoc builds ship as-is).
       # NOTE: a bare CLI binary inside a .tar.gz cannot be stapled, so this
@@ -187,4 +206,5 @@ jobs:
             release/dvalincode-v*-linux-arm64.tar.gz
             release/dvalincode-v*-linux-x64.tar.gz
             release/dvalincode-v*-windows-x64.zip
+            release/dvalincode-v*-evidence.json
             release/SHA256SUMS.txt

--- a/README.md
+++ b/README.md
@@ -109,7 +109,8 @@ dvalincode report verify    # re-derive the hash chain of the last run's audit l
 <tr><td><b>📚 Skills</b></td><td>Upload, download, and inspect local skill bundles. DvalinCode ships built-in secure-code-scan and secure-code-remediation skills, plus agent tools for listing skills, reading skill instructions, scanning, listing cases, and preparing remediation worktrees. <a href="docs/SKILLS.md">Format →</a></td></tr>
 <tr><td><b>🛡️ Audit trail</b></td><td>Every run emits a tamper-evident, hash-chained JSONL log — every file read/written, every command, every approval. A Run Report renders it as Markdown; <code>dvalincode report verify</code> proves the chain is intact. <a href="docs/AUDIT-TRAIL.md">Threat model →</a></td></tr>
 <tr><td><b>🔒 Org policy &amp; <code>trust</code></b></td><td>A company — not the developer — bounds the agent. A <code>dvalin.policy.json</code> constrains modes, shell commands, file paths, tools, and models; a repo policy can only ever <i>narrow</i> the machine-level one, never widen it. Each run records the governing policy's hash. <code>dvalincode trust</code> prints the install's live security posture — active policy + hashes, audit status, runtime — so a reviewer can verify it directly. <a href="docs/POLICY-REFERENCE.md">Policy reference →</a> · <a href="docs/APPROVABILITY-PLAN.md">Approvability plan →</a></td></tr>
-<tr><td><b>🏛️ Governance evidence</b></td><td>OpenSSF Scorecard, CodeQL, Dependabot, pinned GitHub Actions, CODEOWNERS, and ISO/IEC 42001 AIMS alignment docs are maintained as reviewable project evidence. <a href="docs/security/OPENSSF-SCORECARD.md">Scorecard map →</a> · <a href="docs/governance/ISO-42001-AIMS.md">ISO 42001 alignment →</a></td></tr>
+<tr><td><b>🏛️ Governance evidence</b></td><td>OpenSSF Scorecard, CodeQL, Dependabot, pinned GitHub Actions, CODEOWNERS, and ISO/IEC 42001 AIMS alignment docs are maintained as reviewable project evidence, and every release ships an Evidence Pack the binary produced of itself. <a href="docs/security/OPENSSF-SCORECARD.md">Scorecard map →</a> · <a href="docs/governance/ISO-42001-AIMS.md">ISO 42001 alignment →</a> · <a href="docs/RELEASE-EVIDENCE.md">Release evidence →</a></td></tr>
+<tr><td><b>📐 Open specs</b></td><td><b>PCP-1</b> — the provider-boundary contract (egress containment, credential containment, audit, policy binding) written as a vendor-neutral profile with test procedures, so any agent runtime can run it against its own adapters and publish the result. Not a DvalinCode test file; a checklist anyone can hold us to as well. <a href="docs/spec/PROVIDER-CONFORMANCE.md">Provider Conformance Profile →</a></td></tr>
 <tr><td><b>🖥️ First-class GUI</b></td><td>Modern web UI with code highlighting, file <code>@</code>-references, <code>/</code> slash commands, Git branch indicator, live token + cost counter, multi-profile LLM config, and a dark / light / system theme switcher.</td></tr>
 <tr><td><b>🖥️ Terminal or web — one binary</b></td><td>Run it bare for an interactive <b>terminal agent</b> with streaming output, inline approvals, and red/green diffs, or <code>dvalincode serve</code> to host the <b>web GUI</b> for browser/remote use. Both frontends drive the same agent core.</td></tr>
 <tr><td><b>🖥️ Native desktop app</b></td><td><code>DvalinCode.app</code> — a real dock application (OS-native webview, no Electron) over the same engine. On macOS the one-line installer puts it in <code>/Applications</code> automatically; launch it straight from Launchpad.</td></tr>
@@ -443,6 +444,18 @@ Grab the archive for your platform from the [Releases page](https://github.com/a
 | Linux x64 | `dvalincode-v*-linux-x64.tar.gz` |
 
 Verify against `SHA256SUMS.txt` (included in each release).
+
+Each release also ships **`dvalincode-v*-evidence.json`** — an Evidence Pack the
+shipped binary produced of itself on the build machine: two real governed runs,
+one allowed and one blocked by policy, with their hash chains. You can check the
+claims on this page before installing anything:
+
+```sh
+dvalincode evidence verify dvalincode-v0.14.0-evidence.json   # offline, reads only the file
+```
+
+The pack's checksum is inside `SHA256SUMS.txt`, which is the subject of the
+release's build-provenance attestation. [How it is produced →](docs/RELEASE-EVIDENCE.md)
 
 > **macOS Gatekeeper:** binaries are unsigned. On first run, either clear the quarantine flag with `xattr -dr com.apple.quarantine ~/.dvalincode`, or right-click the binary in Finder → Open → confirm.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -100,7 +100,8 @@ dvalincode report verify    # 重新推导上次运行审计日志的哈希链
 <tr><td><b>📚 Skills</b></td><td>上传、下载和查看本地 skill bundle。DvalinCode 内置 secure-code-scan 与 secure-code-remediation skills，并提供列出 skill、读取 skill 说明、扫描、列出 case、准备 remediation worktree 的 agent tools。<a href="docs/SKILLS.md">格式 →</a></td></tr>
 <tr><td><b>🛡️ 审计日志</b></td><td>每次运行都生成防篡改、哈希链式的 JSONL 日志 —— 每次文件读写、每条命令、每次审批都被记录。Run Report 将其渲染为 Markdown；<code>dvalincode report verify</code> 可验证链条完好。<a href="docs/AUDIT-TRAIL.md">威胁模型 →</a></td></tr>
 <tr><td><b>🔒 组织级策略 &amp; <code>trust</code></b></td><td>由公司、而非开发者来约束 Agent。一个 <code>dvalin.policy.json</code> 限定模式、shell 命令、文件路径、工具与模型；仓库级策略只能让机器级策略<i>更严</i>、永不放宽。每次运行都记录所遵循策略的哈希。<code>dvalincode trust</code> 直接打印本机的实时安全态势 —— 生效策略 + 哈希、审计状态、运行时 —— 让审批人自行核验。<a href="docs/POLICY-REFERENCE.md">策略参考 →</a> · <a href="docs/APPROVABILITY-PLAN.md">可审批性方案 →</a></td></tr>
-<tr><td><b>🏛️ 治理证据</b></td><td>仓库维护 OpenSSF Scorecard、CodeQL、Dependabot、固定 SHA 的 GitHub Actions、CODEOWNERS，以及 ISO/IEC 42001 AIMS 对齐文档，作为可审查的项目治理证据。<a href="docs/security/OPENSSF-SCORECARD.md">Scorecard 映射 →</a> · <a href="docs/governance/ISO-42001-AIMS.md">ISO 42001 对齐 →</a></td></tr>
+<tr><td><b>🏛️ 治理证据</b></td><td>仓库维护 OpenSSF Scorecard、CodeQL、Dependabot、固定 SHA 的 GitHub Actions、CODEOWNERS，以及 ISO/IEC 42001 AIMS 对齐文档，作为可审查的项目治理证据；每个 release 还附带一份由该二进制给自己生成的 Evidence Pack。<a href="docs/security/OPENSSF-SCORECARD.md">Scorecard 映射 →</a> · <a href="docs/governance/ISO-42001-AIMS.md">ISO 42001 对齐 →</a> · <a href="docs/RELEASE-EVIDENCE.md">发布证据 →</a></td></tr>
+<tr><td><b>📐 开放规范</b></td><td><b>PCP-1</b> —— 把模型提供方边界的约束（出网收敛、凭据收敛、审计、策略绑定）写成与厂商无关、带测试步骤的开放规范，任何 agent 运行时都可以拿它跑自己的 adapter 并公开结果。它不是 DvalinCode 的一个测试文件，而是别人同样可以用来衡量我们的清单。<a href="docs/spec/PROVIDER-CONFORMANCE.md">Provider Conformance Profile →</a></td></tr>
 <tr><td><b>🖥️ 一流的 GUI</b></td><td>现代化 Web UI，包含代码语法高亮、<code>@</code> 文件引用、<code>/</code> 斜杠命令、Git 分支显示、实时 Token 与费用统计、多 LLM Profile，以及暗色 / 浅色 / 跟随系统的主题切换。</td></tr>
 <tr><td><b>🖥️ 终端或 Web，同一个二进制</b></td><td>直接运行进入交互式<b>终端代理</b>，支持流式输出、行内审批和红绿 diff；或 <code>dvalincode serve</code> 启动 <b>Web GUI</b> 供浏览器/远程使用。两个前端共用同一套 agent 内核。</td></tr>
 <tr><td><b>🖥️ 原生桌面应用</b></td><td><code>DvalinCode.app</code> —— 真正的 Dock 应用（系统原生 webview，非 Electron），驱动同一套引擎。macOS 上一行安装命令会自动装进 <code>/Applications</code>，从启动台直接打开。</td></tr>
@@ -381,6 +382,16 @@ dvalincode mcp-serve             # 供外部 Agent 调用的任务级 stdio MCP 
 | Linux x64 | `dvalincode-v*-linux-x64.tar.gz` |
 
 每个 release 都附带 `SHA256SUMS.txt` 用于校验。
+
+每个 release 还附带 **`dvalincode-v*-evidence.json`** —— 由发布出去的那个二进制在构建机上给自己生成的
+Evidence Pack：两次真实的受治理运行（一次放行、一次被策略拦截）及其哈希链。安装之前就可以自己核验本页的说法：
+
+```sh
+dvalincode evidence verify dvalincode-v0.14.0-evidence.json   # 离线，只读这一个文件
+```
+
+该文件的校验和写在 `SHA256SUMS.txt` 里，而 `SHA256SUMS.txt` 正是 release 构建溯源签名（build provenance
+attestation）的签署对象。[生成方式 →](docs/RELEASE-EVIDENCE.md)
 
 > **macOS Gatekeeper：** 二进制未签名。首次运行可执行 `xattr -dr com.apple.quarantine ~/.dvalincode`，或在 Finder 中右键 → 打开一次。
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -8,6 +8,8 @@ Issues are the source of truth for status; this file is the map. Want one of the
 
 ## Recently shipped ✅
 
+- **Release Evidence Pack** — every release now ships `dvalincode-v<version>-evidence.json`, produced by the shipped binary from two real governed runs (one allowed, one blocked by policy) and re-verifiable offline before you install anything. [Design →](docs/RELEASE-EVIDENCE.md)
+- **PCP-1, an open profile** — the provider-boundary contract ([egress, credentials, audit, policy binding](docs/spec/PROVIDER-CONFORMANCE.md)) published as a vendor-neutral spec any agent runtime can implement and report against, not just a DvalinCode test file.
 - **Evidence Pack v1** ([#51](https://github.com/arthurpanhku/dvalincode/issues/51)) — offline-verifiable governance bundle (resolved policy + hash, audit chains, enforcement posture) mapped to OpenSSF / ISO-42001 clauses.
 - **`run-tool` policy bypass fixed** ([#45](https://github.com/arthurpanhku/dvalincode/issues/45)) — the CLI entrypoint now resolves org policy like every other surface.
 - **Durable-session transport wiring** ([#46](https://github.com/arthurpanhku/dvalincode/issues/46) · [#47](https://github.com/arthurpanhku/dvalincode/issues/47)) — stable `messageId` for idempotent replay, plus recovered-turn notices in the TUI and web UI.
@@ -17,7 +19,7 @@ Issues are the source of truth for status; this file is the map. Want one of the
 
 | Item | Why it matters | Ref |
 |---|---|---|
-| **Provider adapter conformance suite** | A shared contract every provider must pass (egress allow-listing, redaction, audit) — turns "should we trust a new provider?" into an objective gate. Highest-leverage onboarding for external model vendors. | [#118](https://github.com/arthurpanhku/dvalincode/issues/118) |
+| **Provider adapter conformance suite** | The executable half of [PCP-1](docs/spec/PROVIDER-CONFORMANCE.md) — the shared contract every provider must pass (egress containment, credential containment, audit, policy binding). Turns "should we trust a new provider?" into an objective gate. | [#118](https://github.com/arthurpanhku/dvalincode/issues/118) |
 | **stdio / local MCP servers** | Local MCP without network egress — completes the MCP story beyond remote gateways. Same governed mapping as [GOVERNED-MCP.md](docs/GOVERNED-MCP.md). | [#52](https://github.com/arthurpanhku/dvalincode/issues/52) |
 | **Structured approval engine** | Upgrade boolean approvals to scoped grants ("allow `npm test` for this run") — subject, scope, expiry, recorded in audit. | [#53](https://github.com/arthurpanhku/dvalincode/issues/53) |
 | **Harness-mode + unattended-tier test coverage** | Pin the most governance-sensitive path (no human in the loop) with bypass-proof tests. | [#119](https://github.com/arthurpanhku/dvalincode/issues/119) |

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -107,8 +107,15 @@ export default defineConfig({
         items: [
           { text: 'Approvability Plan', link: '/APPROVABILITY-PLAN' },
           { text: 'Evidence Pack', link: '/EVIDENCE-PACK' },
+          { text: 'Release Evidence Pack', link: '/RELEASE-EVIDENCE' },
           { text: 'ISO/IEC 42001 AIMS', link: '/governance/ISO-42001-AIMS' },
           { text: 'AI Change Impact Assessment', link: '/governance/AI-CHANGE-IMPACT-ASSESSMENT' },
+        ],
+      },
+      {
+        text: 'Open specs',
+        items: [
+          { text: 'Provider Conformance (PCP-1)', link: '/spec/PROVIDER-CONFORMANCE' },
         ],
       },
       {

--- a/docs/RELEASE-EVIDENCE.md
+++ b/docs/RELEASE-EVIDENCE.md
@@ -1,0 +1,110 @@
+# Release Evidence Pack
+
+## Why
+
+[`docs/EVIDENCE-PACK.md`](EVIDENCE-PACK.md) makes a *running install* provable:
+its policy, its posture, its audit chains. But a reviewer meets the project
+before they install anything — at the release page — and there the only thing on
+offer is prose. "Tamper-evident audit trail" is a claim like any other until
+someone runs the binary.
+
+Every release therefore ships **`dvalincode-v<version>-evidence.json`**: an
+Evidence Pack produced *by the shipped binary*, from real governed runs on the
+build machine, downloadable and re-verifiable offline before a single line of
+DvalinCode is installed.
+
+This is the project's habit stated as an artifact: **claims ship with the
+evidence that backs them.** Ordinary release notes say what changed; this says
+what the build actually did, in a form the reader can re-derive.
+
+## What is in it
+
+The format is unchanged — Evidence Pack v1, verified by the same
+`dvalincode evidence verify`. What the release adds is *which runs are inside*.
+Two, on purpose:
+
+| Run | Setup | Proves |
+|---|---|---|
+| **allowed** | Plan mode (read-only) over the release tree | the normal path is fully audited — including a `file_read` record whose `sha256` is the released `README.md` itself |
+| **denied** | Auto mode in a fixture workspace whose `dvalin.policy.json` sets `commands.defaultDeny` | enforcement is real: the agent asks for a shell command, the policy blocks it, and `policy_violation` — naming the rule — lands in the chain |
+
+A pack with only the happy path shows a tool that logs. A pack containing a
+recorded denial shows a tool that *stops*, and lets the reader check the stop is
+in the same hash chain as everything else.
+
+## The model is a deterministic local stub
+
+The runs are driven by a small OpenAI-compatible endpoint on `127.0.0.1` that
+replays a fixed script (`scripts/release-evidence.mjs`). No API key, no egress,
+no model vendor in the release path — a release build must be reproducible and
+offline.
+
+This is recorded, not hidden: the audit records carry
+`provider: evidence-stub`, `model: deterministic-stub-v1`, and a
+`provider_request` to a loopback origin. The pack never implies a real model
+ran. It is evidence about **governance** — policy resolution, egress
+chokepoint, audit integrity, enforcement — which is exactly the part that must
+behave identically whichever model a user later brings.
+
+## How it is produced
+
+```sh
+npm run evidence:release            # uses the built binary for this host
+node scripts/release-evidence.mjs --bin <path-to-binary> --out <file>
+```
+
+In CI (`.github/workflows/release.yml`, after checksum verification):
+
+1. The **shipped** macOS archive is extracted and its binary is used — the
+   evidence comes from the artifact users download, not from a source checkout.
+2. Both runs execute under a throwaway `HOME`, so the pack contains those runs
+   and nothing else from the build machine.
+3. `evidence export` → `evidence verify` → structural assertions (below).
+4. The pack's SHA-256 is appended to `SHA256SUMS.txt`, which is then re-verified
+   and is the subject of the existing build-provenance attestation — so the pack
+   inherits the release's supply-chain signature without a new trust surface.
+5. The pack is attached to the GitHub Release next to the archives.
+
+## Acceptance matrix
+
+The script fails the release build — it does not warn — when any of these fail:
+
+| Case | Expected |
+|---|---|
+| Either run fails to record a run id | build fails; no pack is published |
+| Fewer than 2 runs in the pack | build fails |
+| Any embedded chain fails `verifyRecords` | build fails |
+| No `policy_violation` record present | build fails — the denial run did not prove enforcement |
+| `pack.tool.version` ≠ `package.json` version | build fails |
+| `evidence verify` on the written file | exits 0, all section hashes match |
+| Credential-shaped key with a value anywhere in the pack | `verify` reports a minimization issue → build fails |
+| Appended checksum line | `shasum -c SHA256SUMS.txt` passes with the pack included |
+
+## What a reviewer can do with it
+
+Download the pack from the release page, then, with no DvalinCode installed and
+no network:
+
+```sh
+dvalincode evidence verify dvalincode-v0.14.0-evidence.json
+```
+
+(or re-derive the hashes with any SHA-256 implementation — the format is
+documented in [EVIDENCE-PACK.md](EVIDENCE-PACK.md) and the canonicalization rule
+is plain sorted-key JSON). They can read the resolved policy, see the enforcement
+posture the build self-reports, and follow both runs record by record.
+
+## Non-goals
+
+- **Not a security certification.** The pack proves what these two runs did and
+  that the records are intact. It does not prove the absence of vulnerabilities,
+  and nothing in it should be read as a pass mark.
+- **Not a substitute for the per-install pack.** A company's approval evidence
+  is the pack from *their* machine under *their* policy. The release pack shows
+  the shipped binary behaves as documented; it says nothing about anyone's
+  deployment.
+- **Not model evidence.** The stub says nothing about model quality, cost, or
+  behavior.
+- **No new pack schema.** The release pack is Evidence Pack v1, byte-for-byte
+  the same format a user exports locally; only the provenance of the runs
+  differs.

--- a/docs/spec/PROVIDER-CONFORMANCE.md
+++ b/docs/spec/PROVIDER-CONFORMANCE.md
@@ -1,0 +1,285 @@
+# Provider Conformance Profile v1 (PCP-1)
+
+**Status:** draft · **Version:** 1.0.0-draft.1 · **Machine-readable:**
+[`docs/spec/provider-conformance-v1.json`](https://github.com/arthurpanhku/dvalincode/blob/main/docs/spec/provider-conformance-v1.json) ·
+**License:** MIT, same as the project — copy it, fork it, implement it, no permission needed.
+
+## Scope
+
+Every model provider an AI coding agent talks to is an **egress destination that
+receives source code**. Whether that is safe depends almost entirely on the
+adapter layer: how the request is routed, what it carries, what happens on a
+redirect, and what is recorded afterwards. Today each runtime answers those
+questions differently, informally, and usually only in prose — so "can we add
+this provider?" is re-litigated as a judgement call every time.
+
+PCP-1 is an attempt to make that question **objective and checkable**: a list of
+assertions a provider adapter either satisfies or does not, written so that any
+agent runtime — not only DvalinCode — can run them against its own adapters and
+publish the result.
+
+This document specifies:
+
+- the assertions (§3–§7), each with a test procedure and pass criteria;
+- how a suite implementing them must behave (§8);
+- two conformance levels and what may be claimed (§9);
+- a report format so results are comparable across implementations (§10).
+
+It does **not** specify an adapter API, a wire format, a policy language, or an
+audit format. It constrains observable behavior only. An implementation with a
+completely different architecture can be conformant.
+
+### Audience
+
+Agent runtime authors; security reviewers evaluating an agent; model vendors who
+want their endpoint to be addable to a governed agent without a bespoke review.
+
+### Conventions
+
+The key words MUST, MUST NOT, SHOULD, SHOULD NOT, and MAY are to be interpreted
+as described in [RFC 2119](https://www.rfc-editor.org/rfc/rfc2119). Assertion IDs
+are stable across patch and minor versions of this profile; an assertion is never
+renumbered, only deprecated.
+
+## 1. Terms
+
+| Term | Meaning |
+|---|---|
+| **Adapter** | The component that turns a runtime-internal chat request into provider protocol traffic and back. |
+| **Chokepoint** | The single function all adapter network I/O passes through. |
+| **Configured endpoint** | The base URL the operator configured for this provider. Its origin is the *only* origin the adapter is entitled to reach by default. |
+| **Governing policy** | The resolved, machine- or organization-level rules in force for the current run. |
+| **Audit record** | An entry in the runtime's tamper-evident run log. |
+| **Bypass test** | A test that fails when the control it covers is removed. Its purpose is to prevent silent regression, not to demonstrate the happy path. |
+
+## 2. The narrowing rule
+
+> **No assertion in this profile may be satisfied by weakening a control, and no
+> configuration option may relax an assertion at runtime.**
+
+A profile that can be satisfied by turning something off is worthless as a gate.
+Concretely: if an implementation offers a flag that disables destination
+validation, policy consultation, or auditing, that implementation is
+**non-conformant** regardless of its default value. Escape hatches for local
+development are acceptable only where this profile explicitly permits them
+(EG-7), and MUST be visible in the run's recorded posture.
+
+## 3. Egress containment (EG)
+
+| ID | Level | Assertion |
+|---|---|---|
+| **EG-1** | MUST | All provider network I/O passes through a single chokepoint. No adapter calls the platform HTTP client directly. |
+| **EG-2** | MUST | The destination is validated **before** each request is issued. An origin other than the configured endpoint is reachable only when the governing policy explicitly permits non-endpoint egress. |
+| **EG-3** | MUST | Redirects are followed manually, and **every hop** is re-validated (EG-2, EG-5–EG-7) and re-authorized (PO-2). Delegating redirect following to the HTTP client is non-conformant. |
+| **EG-4** | MUST | The redirect chain is bounded; exceeding the bound raises an error rather than silently returning the last response. |
+| **EG-5** | MUST | Schemes other than `http`/`https` are rejected. |
+| **EG-6** | MUST | URLs carrying embedded credentials (`user:pass@host`) are rejected. |
+| **EG-7** | MUST | Loopback, private, link-local, carrier-grade-NAT, and multicast destinations are rejected **unless** the destination is the configured endpoint (the local-model case). |
+| **EG-8** | SHOULD | The set of permitted destinations is expressible as reviewable data (an allowlist), not only as code. |
+
+**Test procedure (EG).** With a mock transport, for each adapter:
+
+1. Issue a normal request; assert the chokepoint was entered exactly once per
+   attempt and that no other network call occurred (EG-1).
+2. Configure endpoint `https://api.example.test/v1`; have the mock respond `302`
+   to `https://evil.example.net/v1`; assert the request is not re-issued to the
+   new origin under a policy that permits endpoint-only egress (EG-2, EG-3).
+3. Respond with a redirect loop; assert an error after the documented bound
+   (EG-4).
+4. Attempt `file:`, `ftp:`, and `data:` endpoints; assert rejection (EG-5).
+5. Attempt `https://user:pass@api.example.test/v1`; assert rejection (EG-6).
+6. Attempt `http://169.254.169.254/latest/meta-data` — both as configured
+   endpoint and as a redirect target — and assert rejection in the redirect case
+   (EG-7). Assert `http://127.0.0.1:<port>/v1` is permitted **only** when it is
+   the configured endpoint.
+
+**Pass criteria.** Every rejection is raised before any bytes are sent to the
+rejected destination, and each is observable as a distinct, named error.
+
+## 4. Credential containment (CR)
+
+| ID | Level | Assertion |
+|---|---|---|
+| **CR-1** | MUST | `Authorization`, `Cookie`, and `Proxy-Authorization` are stripped when a redirect crosses to a different origin. |
+| **CR-2** | MUST | Credentials never appear in audit records, logs, telemetry, error messages, or exception traces. |
+| **CR-3** | MUST | The adapter persists nothing — not credentials, not request or response bodies — outside the lifetime of the request. |
+| **CR-4** | SHOULD | Credentials are resolvable by indirection (environment variable or OS keychain reference), so an operator is not required to store them inline in configuration. |
+
+**Test procedure (CR).** Configure a recognizable sentinel key. Drive a
+same-origin redirect (headers retained) and a cross-origin redirect permitted by
+policy (headers stripped). Then search **all** artifacts produced by the run —
+audit records, stdout/stderr, thrown errors, any file the adapter wrote — for the
+sentinel.
+
+**Pass criteria.** Zero occurrences of the sentinel outside the outbound request
+headers to the configured origin.
+
+## 5. Auditability (AU)
+
+| ID | Level | Assertion |
+|---|---|---|
+| **AU-1** | MUST | Every attempt emits exactly one request record, whatever the outcome (`ok` / `error` / `blocked`). |
+| **AU-2** | MUST | The record identifies at minimum: provider id, model id, destination origin, outcome, duration, and status code when one exists. |
+| **AU-3** | MUST | Records carry no prompt text, completion text, tool arguments, file contents, or request/response headers. |
+| **AU-4** | MUST | A blocked request is recorded **before** the error is raised. |
+| **AU-5** | MUST | Provider records join the same tamper-evident run log as the rest of the run — not a separate, unchained provider log. |
+| **AU-6** | SHOULD | A policy denial additionally emits a violation record naming the rule that denied it. |
+
+**Rationale for AU-4.** A denial that is not recorded is indistinguishable from
+an outage after the fact — which is precisely the case a reviewer cares about.
+
+**Test procedure (AU).** Run the EG scenarios and inspect the emitted records:
+count them, check the field set, assert prompt/completion strings are absent by
+substring search, and verify the chain still validates after the blocked attempt.
+
+## 6. Policy binding (PO)
+
+| ID | Level | Assertion |
+|---|---|---|
+| **PO-1** | MUST | The governing policy is consulted **per request**, not once at startup. |
+| **PO-2** | MUST | Policy is re-consulted at each redirect hop. |
+| **PO-3** | MUST | An absent, malformed, or unreadable policy fails closed to a documented default. It never silently degrades to unrestricted. |
+| **PO-4** | MUST | No adapter option, environment variable, or configuration field widens what the governing policy allows. |
+| **PO-5** | MUST | Provider identity and model identity are checked against policy allowlists before the request is issued. |
+| **PO-6** | SHOULD | The policy in force is identified in the run record by a stable canonical hash. |
+
+**Test procedure (PO).** Mutate the policy between two requests in the same run
+and assert the second decision reflects the mutation (PO-1). Drive a redirect
+under a policy that permits the first origin and denies the second (PO-2). Supply
+a malformed policy and assert the run is more restricted, not less (PO-3).
+Attempt to reach a denied model or provider via every configuration surface the
+implementation exposes — CLI flag, env var, config file, profile — and assert all
+are refused (PO-4, PO-5).
+
+**Pass criteria for PO-4.** The implementation enumerates its configuration
+surfaces and the test covers each. An unenumerated surface is a fail.
+
+## 7. Behavioral contract (BE)
+
+| ID | Level | Assertion |
+|---|---|---|
+| **BE-1** | MUST | Streaming yields incremental text deltas whose concatenation equals the final content. |
+| **BE-2** | MUST | Tool/function calls round-trip: streamed, fragmented tool-call arguments reassemble to exactly what the non-streaming path returns for the same response. |
+| **BE-3** | MUST | Transport, HTTP, and provider-level errors normalize to the runtime's error type; no provider-specific error object escapes the adapter. |
+| **BE-4** | MUST | Cancellation stops the request promptly **and** still emits an audit record. |
+| **BE-5** | SHOULD | Token usage is reported when the provider exposes it, and reported as *absent* — never as zero — when it does not. |
+| **BE-6** | SHOULD | The adapter holds no cross-request state. |
+
+**Rationale.** BE exists because governance controls are only trustworthy if the
+adapter is otherwise boring. Silent truncation of a stream, or a tool call that
+reassembles differently under streaming, produces divergence between what was
+audited and what the agent acted on.
+
+**Test procedure (BE).** Replay recorded provider responses through the mock
+transport in both streaming and non-streaming modes and assert the two paths
+produce equal results; split tool-call arguments across chunk boundaries mid-token
+and mid-UTF-8-sequence; inject a 500, a malformed chunk, and a socket close
+mid-stream; abort mid-stream and inspect the audit record.
+
+## 8. Requirements on the suite
+
+| ID | Level | Requirement |
+|---|---|---|
+| **T-1** | MUST | The suite runs fully offline against a mock transport. No test makes a real provider call. |
+| **T-2** | MUST | Every MUST assertion has at least one **bypass test**: remove the control, and the test fails. |
+| **T-3** | MUST | The same suite runs unmodified against every adapter (parametrized over the adapter registry). |
+| **T-4** | MUST | Adding an adapter requires no new bespoke governance test — passing the suite is the gate. |
+| **T-5** | SHOULD | The suite emits a report in the §10 format. |
+
+T-2 is the load-bearing one. A suite whose tests still pass after the control is
+deleted proves nothing, and this profile treats it as unimplemented.
+
+## 9. Conformance levels
+
+| Level | Name | Requires |
+|---|---|---|
+| **1** | Governed | All MUST assertions in EG, CR, AU, PO, plus T-1 – T-4. |
+| **2** | Governed + Interoperable | Level 1, plus all MUST assertions in BE. |
+
+An implementation claiming a level MUST publish a report (§10) listing every
+assertion, including unmet SHOULDs. Claims are per adapter **and** per version:
+"DvalinCode 0.14.0 `openaiCompatible` — PCP-1 Level 2".
+
+**Honesty rule.** An assertion that is not implemented is reported `fail`. It is
+never omitted, and never marked `not-applicable` unless the profile's own
+applicability note covers the case. A partial claim that says so is worth more
+than a full claim that hedges — and is far easier to verify.
+
+## 10. Report format
+
+`provider-conformance-report/v1` — one JSON document:
+
+```json
+{
+  "schema": "provider-conformance-report/v1",
+  "profile": "PCP-1",
+  "profileVersion": "1.0.0-draft.1",
+  "subject": { "implementation": "dvalincode", "version": "0.14.0", "adapter": "openaiCompatible" },
+  "generatedAt": "2026-08-02T00:00:00.000Z",
+  "levelClaimed": 2,
+  "results": [
+    { "id": "EG-3", "outcome": "pass", "bypassTest": true, "evidence": "tests/providers/conformance.test.ts:redirect-reauthorized" },
+    { "id": "EG-8", "outcome": "fail", "note": "destination rules are code, not data" }
+  ]
+}
+```
+
+- `outcome` — `pass` | `fail` | `not-applicable` (with a `note` justifying it).
+- `bypassTest` — whether the covering test fails when the control is removed.
+  Required `true` for every MUST at the claimed level.
+- `evidence` — a stable pointer (test name, file:line, or log id) a reader can
+  follow.
+
+A report is a self-assessment. It is credible in proportion to the reader's
+ability to re-run it, so implementations SHOULD ship the suite alongside the
+report.
+
+## 11. Relationship to other frameworks
+
+PCP-1 is narrow on purpose: it covers the provider boundary only, and it composes
+with rather than replaces existing frameworks. For reviewers mapping it upward:
+the EG and PO assertions are the technical substance behind egress-control and
+access-control clauses; AU is what makes logging clauses verifiable rather than
+asserted; CR covers secrets handling at this boundary. It carries no
+certification, no mark, and no authority — it is a checklist with test
+procedures.
+
+## 12. Non-goals
+
+- **Not a security certification.** Passing PCP-1 means these assertions hold. It
+  says nothing about the rest of the runtime.
+- **Not an adapter API.** No interface, language, or dependency is prescribed.
+- **Not a policy language.** How policy is expressed and resolved is out of scope;
+  only that it is consulted and cannot be widened.
+- **Not a model evaluation.** Nothing here concerns model quality, cost, or
+  safety behavior.
+- **Not a registry.** There is no list of "certified" providers and no body that
+  grants conformance.
+
+## Appendix A — Reference implementation notes (informative)
+
+DvalinCode's mapping, offered as one worked example rather than as part of the
+profile:
+
+| Assertion group | Where it lives |
+|---|---|
+| EG-1 – EG-7 | `governedProviderFetch` in [`src/providers/egress.ts`](https://github.com/arthurpanhku/dvalincode/blob/main/src/providers/egress.ts) — manual `redirect: 'manual'` loop, per-hop `checkEgress` + destination classification |
+| EG-8 | `src/providers/trustedBaseUrls.ts` |
+| CR-1 | header stripping on cross-origin redirect in the same loop |
+| AU-1 – AU-5 | `provider_request` records appended to the run's hash chain (`src/audit/log.ts`) |
+| PO-1 – PO-3 | `checkEgress(policy, isConfiguredEndpoint)` per hop; policy resolution in `src/core/policy.ts` |
+| BE-1 – BE-5 | `src/providers/openaiCompatible.ts`, `src/providers/anthropic.ts` |
+
+The executable suite tracking this profile is
+[issue #118](https://github.com/arthurpanhku/dvalincode/issues/118). Where the
+implementation and this profile disagree, the profile is not automatically right
+— open an issue; gaps found this way are the point.
+
+## Appendix B — Changing this profile
+
+Assertions are added, deprecated, or clarified through issues on
+[arthurpanhku/dvalincode](https://github.com/arthurpanhku/dvalincode/issues) with
+the `spec` label. Rules: IDs are never reused; a new MUST is a minor version and
+takes effect one minor version after publication; clarifications that do not
+change what passes are patch versions. Implementations report the profile version
+they tested against.

--- a/docs/spec/provider-conformance-v1.json
+++ b/docs/spec/provider-conformance-v1.json
@@ -1,0 +1,323 @@
+{
+  "schema": "provider-conformance-profile/v1",
+  "profile": "PCP-1",
+  "version": "1.0.0-draft.1",
+  "title": "Provider Conformance Profile v1",
+  "spec": "https://github.com/arthurpanhku/dvalincode/blob/main/docs/spec/PROVIDER-CONFORMANCE.md",
+  "license": "MIT",
+  "narrowingRule": "No assertion may be satisfied by weakening a control, and no configuration option may relax an assertion at runtime. An implementation offering a flag that disables destination validation, policy consultation, or auditing is non-conformant regardless of that flag's default.",
+  "levels": [
+    {
+      "level": 1,
+      "name": "Governed",
+      "requires": { "groups": ["EG", "CR", "AU", "PO"], "assertionLevel": "MUST", "suite": ["T-1", "T-2", "T-3", "T-4"] }
+    },
+    {
+      "level": 2,
+      "name": "Governed + Interoperable",
+      "requires": { "inherits": 1, "groups": ["BE"], "assertionLevel": "MUST" }
+    }
+  ],
+  "groups": {
+    "EG": "Egress containment",
+    "CR": "Credential containment",
+    "AU": "Auditability",
+    "PO": "Policy binding",
+    "BE": "Behavioral contract",
+    "T": "Requirements on the suite"
+  },
+  "assertions": [
+    {
+      "id": "EG-1",
+      "group": "EG",
+      "level": "MUST",
+      "statement": "All provider network I/O passes through a single chokepoint. No adapter calls the platform HTTP client directly.",
+      "procedure": "Issue a normal request; assert the chokepoint was entered exactly once per attempt and no other network call occurred.",
+      "pass": "No network egress observed outside the chokepoint."
+    },
+    {
+      "id": "EG-2",
+      "group": "EG",
+      "level": "MUST",
+      "statement": "The destination is validated before each request is issued. An origin other than the configured endpoint is reachable only when the governing policy explicitly permits non-endpoint egress.",
+      "procedure": "Under an endpoint-only policy, attempt a request to a non-configured origin.",
+      "pass": "Rejected before any bytes are sent to that origin."
+    },
+    {
+      "id": "EG-3",
+      "group": "EG",
+      "level": "MUST",
+      "statement": "Redirects are followed manually and every hop is re-validated and re-authorized. Delegating redirect following to the HTTP client is non-conformant.",
+      "procedure": "Mock a 302 from the configured endpoint to a different origin under an endpoint-only policy.",
+      "pass": "The request is not re-issued to the new origin; the denial is raised and audited."
+    },
+    {
+      "id": "EG-4",
+      "group": "EG",
+      "level": "MUST",
+      "statement": "The redirect chain is bounded; exceeding the bound raises an error rather than silently returning the last response.",
+      "procedure": "Mock a redirect loop longer than the documented bound.",
+      "pass": "A named error is raised after the bound."
+    },
+    {
+      "id": "EG-5",
+      "group": "EG",
+      "level": "MUST",
+      "statement": "Schemes other than http/https are rejected.",
+      "procedure": "Attempt file:, ftp:, and data: endpoints, as configured endpoint and as redirect target.",
+      "pass": "All rejected."
+    },
+    {
+      "id": "EG-6",
+      "group": "EG",
+      "level": "MUST",
+      "statement": "URLs carrying embedded credentials (user:pass@host) are rejected.",
+      "procedure": "Configure https://user:pass@host/v1 and redirect to the same shape.",
+      "pass": "Both rejected."
+    },
+    {
+      "id": "EG-7",
+      "group": "EG",
+      "level": "MUST",
+      "statement": "Loopback, private, link-local, carrier-grade-NAT, and multicast destinations are rejected unless the destination is the configured endpoint.",
+      "procedure": "Redirect to 169.254.169.254 and to an RFC1918 address; separately configure http://127.0.0.1:<port>/v1 as the endpoint.",
+      "pass": "Redirect targets rejected; the configured loopback endpoint is permitted."
+    },
+    {
+      "id": "EG-8",
+      "group": "EG",
+      "level": "SHOULD",
+      "statement": "The set of permitted destinations is expressible as reviewable data (an allowlist), not only as code.",
+      "procedure": "Inspect the implementation for a data-defined destination list.",
+      "pass": "A reviewer can enumerate permitted destinations without reading control flow."
+    },
+    {
+      "id": "CR-1",
+      "group": "CR",
+      "level": "MUST",
+      "statement": "Authorization, Cookie, and Proxy-Authorization are stripped when a redirect crosses to a different origin.",
+      "procedure": "Drive a same-origin redirect (headers retained) and a policy-permitted cross-origin redirect (headers stripped).",
+      "pass": "Sentinel credential absent from the cross-origin request."
+    },
+    {
+      "id": "CR-2",
+      "group": "CR",
+      "level": "MUST",
+      "statement": "Credentials never appear in audit records, logs, telemetry, error messages, or exception traces.",
+      "procedure": "Search every artifact produced by the run for a sentinel credential value.",
+      "pass": "Zero occurrences outside outbound request headers to the configured origin."
+    },
+    {
+      "id": "CR-3",
+      "group": "CR",
+      "level": "MUST",
+      "statement": "The adapter persists nothing outside the lifetime of the request — not credentials, not request or response bodies.",
+      "procedure": "Snapshot the filesystem and process state around a request.",
+      "pass": "No new persisted artifact attributable to the adapter."
+    },
+    {
+      "id": "CR-4",
+      "group": "CR",
+      "level": "SHOULD",
+      "statement": "Credentials are resolvable by indirection (environment variable or OS keychain reference) rather than requiring inline storage in configuration.",
+      "procedure": "Configure a provider with an indirect key source only.",
+      "pass": "The request succeeds without the secret appearing in any config file."
+    },
+    {
+      "id": "AU-1",
+      "group": "AU",
+      "level": "MUST",
+      "statement": "Every attempt emits exactly one request record, whatever the outcome (ok / error / blocked).",
+      "procedure": "Count records across success, transport error, HTTP error, and policy-blocked scenarios.",
+      "pass": "Exactly one record per attempt in every scenario."
+    },
+    {
+      "id": "AU-2",
+      "group": "AU",
+      "level": "MUST",
+      "statement": "The record identifies at minimum provider id, model id, destination origin, outcome, duration, and status code when one exists.",
+      "procedure": "Inspect the field set of each emitted record.",
+      "pass": "All required fields present and correct."
+    },
+    {
+      "id": "AU-3",
+      "group": "AU",
+      "level": "MUST",
+      "statement": "Records carry no prompt text, completion text, tool arguments, file contents, or request/response headers.",
+      "procedure": "Substring-search records for sentinel values planted in the prompt, the completion, and the headers.",
+      "pass": "No sentinel found."
+    },
+    {
+      "id": "AU-4",
+      "group": "AU",
+      "level": "MUST",
+      "statement": "A blocked request is recorded before the error is raised.",
+      "procedure": "Trigger a policy denial and capture record ordering relative to the thrown error.",
+      "pass": "The record exists even if the error propagates to the top of the run."
+    },
+    {
+      "id": "AU-5",
+      "group": "AU",
+      "level": "MUST",
+      "statement": "Provider records join the same tamper-evident run log as the rest of the run, not a separate unchained provider log.",
+      "procedure": "Verify the run chain after a mixed sequence of tool and provider events.",
+      "pass": "Chain verification covers the provider records."
+    },
+    {
+      "id": "AU-6",
+      "group": "AU",
+      "level": "SHOULD",
+      "statement": "A policy denial additionally emits a violation record naming the rule that denied it.",
+      "procedure": "Trigger a denial and inspect for a violation record.",
+      "pass": "The rule identifier appears in the record."
+    },
+    {
+      "id": "PO-1",
+      "group": "PO",
+      "level": "MUST",
+      "statement": "The governing policy is consulted per request, not once at startup.",
+      "procedure": "Mutate the policy between two requests in the same run.",
+      "pass": "The second decision reflects the mutation."
+    },
+    {
+      "id": "PO-2",
+      "group": "PO",
+      "level": "MUST",
+      "statement": "Policy is re-consulted at each redirect hop.",
+      "procedure": "Redirect under a policy permitting the first origin and denying the second.",
+      "pass": "The second hop is denied."
+    },
+    {
+      "id": "PO-3",
+      "group": "PO",
+      "level": "MUST",
+      "statement": "An absent, malformed, or unreadable policy fails closed to a documented default and never silently degrades to unrestricted.",
+      "procedure": "Supply a malformed policy source.",
+      "pass": "The run is more restricted, not less, and the condition is surfaced."
+    },
+    {
+      "id": "PO-4",
+      "group": "PO",
+      "level": "MUST",
+      "statement": "No adapter option, environment variable, or configuration field widens what the governing policy allows.",
+      "procedure": "Enumerate every configuration surface the implementation exposes and attempt to widen policy through each.",
+      "pass": "All refused. An unenumerated surface is a fail."
+    },
+    {
+      "id": "PO-5",
+      "group": "PO",
+      "level": "MUST",
+      "statement": "Provider identity and model identity are checked against policy allowlists before the request is issued.",
+      "procedure": "Request a denied model and a denied provider.",
+      "pass": "Refused before egress."
+    },
+    {
+      "id": "PO-6",
+      "group": "PO",
+      "level": "SHOULD",
+      "statement": "The policy in force is identified in the run record by a stable canonical hash.",
+      "procedure": "Compare hashes across reordered but semantically identical policy files.",
+      "pass": "Hash is stable for unchanged policy and changes when the policy changes."
+    },
+    {
+      "id": "BE-1",
+      "group": "BE",
+      "level": "MUST",
+      "statement": "Streaming yields incremental text deltas whose concatenation equals the final content.",
+      "procedure": "Replay a recorded response in streaming and non-streaming mode.",
+      "pass": "Concatenated deltas equal the non-streaming content."
+    },
+    {
+      "id": "BE-2",
+      "group": "BE",
+      "level": "MUST",
+      "statement": "Tool/function calls round-trip: streamed, fragmented tool-call arguments reassemble to exactly what the non-streaming path returns.",
+      "procedure": "Split tool-call arguments across chunk boundaries mid-token and mid-UTF-8 sequence.",
+      "pass": "Reassembled arguments are byte-identical to the non-streaming result."
+    },
+    {
+      "id": "BE-3",
+      "group": "BE",
+      "level": "MUST",
+      "statement": "Transport, HTTP, and provider-level errors normalize to the runtime's error type; no provider-specific error object escapes the adapter.",
+      "procedure": "Inject a 500, a malformed chunk, and a socket close mid-stream.",
+      "pass": "All surface as the runtime's normalized error type."
+    },
+    {
+      "id": "BE-4",
+      "group": "BE",
+      "level": "MUST",
+      "statement": "Cancellation stops the request promptly and still emits an audit record.",
+      "procedure": "Abort mid-stream.",
+      "pass": "The request stops and exactly one record is emitted."
+    },
+    {
+      "id": "BE-5",
+      "group": "BE",
+      "level": "SHOULD",
+      "statement": "Token usage is reported when the provider exposes it, and reported as absent — never as zero — when it does not.",
+      "procedure": "Replay responses with and without usage fields.",
+      "pass": "Absent usage is distinguishable from zero usage."
+    },
+    {
+      "id": "BE-6",
+      "group": "BE",
+      "level": "SHOULD",
+      "statement": "The adapter holds no cross-request state.",
+      "procedure": "Interleave requests with conflicting configuration through one adapter instance.",
+      "pass": "No cross-contamination of results."
+    },
+    {
+      "id": "T-1",
+      "group": "T",
+      "level": "MUST",
+      "statement": "The suite runs fully offline against a mock transport. No test makes a real provider call.",
+      "procedure": "Run the suite with network access removed.",
+      "pass": "Suite passes unchanged."
+    },
+    {
+      "id": "T-2",
+      "group": "T",
+      "level": "MUST",
+      "statement": "Every MUST assertion has at least one bypass test: remove the control and the test fails.",
+      "procedure": "For each MUST, disable the control and re-run.",
+      "pass": "The covering test fails. A suite that still passes is treated as not implementing the assertion."
+    },
+    {
+      "id": "T-3",
+      "group": "T",
+      "level": "MUST",
+      "statement": "The same suite runs unmodified against every adapter, parametrized over the adapter registry.",
+      "procedure": "Register an additional adapter and run the suite.",
+      "pass": "No suite edits required."
+    },
+    {
+      "id": "T-4",
+      "group": "T",
+      "level": "MUST",
+      "statement": "Adding an adapter requires no new bespoke governance test — passing the suite is the gate.",
+      "procedure": "Review the contribution path for a new provider.",
+      "pass": "The documented gate is the suite."
+    },
+    {
+      "id": "T-5",
+      "group": "T",
+      "level": "SHOULD",
+      "statement": "The suite emits a report in the provider-conformance-report/v1 format.",
+      "procedure": "Run the suite and inspect its output.",
+      "pass": "A valid report document is produced."
+    }
+  ],
+  "reportFormat": {
+    "schema": "provider-conformance-report/v1",
+    "required": ["schema", "profile", "profileVersion", "subject", "generatedAt", "levelClaimed", "results"],
+    "result": {
+      "id": "assertion id",
+      "outcome": ["pass", "fail", "not-applicable"],
+      "bypassTest": "boolean — required true for every MUST at the claimed level",
+      "evidence": "stable pointer a reader can follow (test name, file:line, log id)",
+      "note": "required when outcome is not-applicable"
+    },
+    "honestyRule": "An unimplemented assertion is reported fail. It is never omitted, and never marked not-applicable unless the profile's applicability note covers the case."
+  }
+}

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "build:release:darwin": "bash scripts/build-release.sh darwin",
     "build:release:linux": "bash scripts/build-release.sh linux",
     "build:release:windows": "bash scripts/build-release.sh windows",
+    "evidence:release": "node scripts/release-evidence.mjs",
     "build:binaries": "bash scripts/build-binaries.sh",
     "build:binaries:darwin": "bash scripts/build-binaries.sh darwin",
     "build:binaries:linux": "bash scripts/build-binaries.sh linux",

--- a/scripts/release-evidence.mjs
+++ b/scripts/release-evidence.mjs
@@ -1,0 +1,342 @@
+#!/usr/bin/env node
+/**
+ * Build the per-release Evidence Pack.
+ *
+ * Every DvalinCode release ships one `dvalincode-v<version>-evidence.json`
+ * produced by the released binary itself, from real governed runs performed on
+ * the build machine — not a hand-written claim about what the binary does.
+ *
+ * The pack contains (see docs/EVIDENCE-PACK.md for the format):
+ *   - the resolved policy in force + its canonical hash
+ *   - the `trust` posture the released build self-reports
+ *   - the hash-chained audit records of the runs below
+ *   - the compliance map (OpenSSF / ISO-42001), backed vs unbacked
+ *
+ * Two runs are recorded on purpose:
+ *   1. `allowed`  — a read-only Plan-mode run over the release tree, proving the
+ *                   normal path is fully audited.
+ *   2. `denied`   — a run under a default-deny command policy where the agent
+ *                   asks for a shell command and the policy blocks it, proving
+ *                   enforcement is real and the denial lands in the chain.
+ *
+ * The model is a deterministic local stub (127.0.0.1, no key, no egress): a
+ * release build must be reproducible and offline, and the evidence being made
+ * is about *governance*, not about model quality. The stub is named in the audit
+ * records (`provider: evidence-stub`), so the pack never implies a real model ran.
+ *
+ * Usage:
+ *   node scripts/release-evidence.mjs [--bin "<command>"] [--out <file>]
+ *                                     [--repo <dir>] [--sums <file>]
+ *
+ *   --bin   command that runs the CLI (default: the built release binary for
+ *           this host, else `node dist/index.js`)
+ *   --out   output path (default: release/dvalincode-v<version>-evidence.json)
+ *   --sums  SHA256SUMS file to append the pack's checksum to
+ *           (default: release/SHA256SUMS.txt when it exists)
+ */
+
+import { spawn } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { createServer } from 'node:http';
+import { appendFileSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const VERSION = JSON.parse(readFileSync(path.join(ROOT, 'package.json'), 'utf8')).version;
+
+const STUB_MODEL = 'deterministic-stub-v1';
+const STUB_PROVIDER = 'evidence-stub';
+
+// ── args ─────────────────────────────────────────────────────────────────────
+
+function parseArgs(argv) {
+  const out = {};
+  for (let i = 0; i < argv.length; i += 2) {
+    const key = argv[i]?.replace(/^--/, '');
+    if (!key || argv[i + 1] === undefined) fail(`bad argument: ${argv[i]}`);
+    out[key] = argv[i + 1];
+  }
+  return out;
+}
+
+const args = parseArgs(process.argv.slice(2));
+const repoDir = path.resolve(args.repo ?? ROOT);
+const outFile = path.resolve(args.out ?? path.join(ROOT, 'release', `dvalincode-v${VERSION}-evidence.json`));
+const binCommand = (args.bin ?? defaultBin()).trim();
+const sumsFile = args.sums ? path.resolve(args.sums) : path.join(ROOT, 'release', 'SHA256SUMS.txt');
+
+/** Prefer the freshly built release binary for this host; fall back to dist/. */
+function defaultBin() {
+  const plat = process.platform === 'darwin' ? 'macos' : process.platform === 'win32' ? 'windows' : 'linux';
+  const arch = process.arch === 'arm64' ? 'arm64' : 'x64';
+  const suffix = plat === 'windows' ? '.exe' : '';
+  const built = path.join(ROOT, 'release', 'tmp', `dvalincode-${plat}-${arch}${suffix}`);
+  if (existsSync(built)) return built;
+  return `node ${path.join(ROOT, 'dist', 'index.js')}`;
+}
+
+function fail(message) {
+  console.error(`release-evidence: ${message}`);
+  process.exit(1);
+}
+
+// ── deterministic local model stub ───────────────────────────────────────────
+
+/**
+ * Minimal OpenAI-compatible endpoint. It ignores the prompt and replays a fixed
+ * script, so the run — and therefore the audit chain — is decided here, not by a
+ * model. Supports both the streaming and non-streaming shapes the adapter uses.
+ */
+function startStub() {
+  let script = [];
+  let step = 0;
+
+  const server = createServer((req, res) => {
+    if (req.method !== 'POST' || !req.url?.endsWith('/chat/completions')) {
+      res.writeHead(404).end();
+      return;
+    }
+    let raw = '';
+    req.on('data', chunk => {
+      raw += chunk;
+    });
+    req.on('end', () => {
+      let stream = false;
+      try {
+        stream = JSON.parse(raw).stream === true;
+      } catch {
+        /* body shape is the adapter's concern; default to non-streaming */
+      }
+      const turn = script[step] ?? { text: 'Done.' };
+      step++;
+      if (stream) writeStream(res, turn);
+      else writeJson(res, turn);
+    });
+  });
+
+  return {
+    listen: () =>
+      new Promise(resolve => {
+        server.listen(0, '127.0.0.1', () => resolve(`http://127.0.0.1:${server.address().port}/v1`));
+      }),
+    load: next => {
+      script = next;
+      step = 0;
+    },
+    close: () => new Promise(resolve => server.close(resolve)),
+  };
+}
+
+const USAGE = { prompt_tokens: 0, completion_tokens: 0 };
+
+function writeJson(res, turn) {
+  const message = turn.tool
+    ? {
+        content: '',
+        tool_calls: [
+          {
+            id: 'call_evidence_1',
+            type: 'function',
+            function: { name: turn.tool.name, arguments: JSON.stringify(turn.tool.arguments) },
+          },
+        ],
+      }
+    : { content: turn.text };
+  const body = {
+    model: STUB_MODEL,
+    choices: [{ index: 0, finish_reason: turn.tool ? 'tool_calls' : 'stop', message }],
+    usage: USAGE,
+  };
+  res.writeHead(200, { 'Content-Type': 'application/json' }).end(JSON.stringify(body));
+}
+
+function writeStream(res, turn) {
+  res.writeHead(200, { 'Content-Type': 'text/event-stream', 'Cache-Control': 'no-cache' });
+  const send = payload => res.write(`data: ${JSON.stringify(payload)}\n\n`);
+  const frame = (delta, finish) => ({
+    model: STUB_MODEL,
+    choices: [{ index: 0, delta, finish_reason: finish ?? null }],
+  });
+
+  if (turn.tool) {
+    send(
+      frame({
+        tool_calls: [
+          {
+            index: 0,
+            id: 'call_evidence_1',
+            type: 'function',
+            function: { name: turn.tool.name, arguments: JSON.stringify(turn.tool.arguments) },
+          },
+        ],
+      }),
+    );
+    send(frame({}, 'tool_calls'));
+  } else {
+    send(frame({ content: turn.text }));
+    send(frame({}, 'stop'));
+  }
+  send({ model: STUB_MODEL, choices: [], usage: USAGE });
+  res.write('data: [DONE]\n\n');
+  res.end();
+}
+
+// ── CLI driver ───────────────────────────────────────────────────────────────
+
+function runCli(cliArgs, env, cwd) {
+  const parts = binCommand.split(/\s+/);
+  return new Promise(resolve => {
+    const child = spawn(parts[0], [...parts.slice(1), ...cliArgs], {
+      cwd,
+      env,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', d => {
+      stdout += d;
+    });
+    child.stderr.on('data', d => {
+      stderr += d;
+    });
+    child.on('error', err => resolve({ code: 127, stdout, stderr: String(err) }));
+    child.on('close', code => resolve({ code: code ?? 1, stdout, stderr }));
+  });
+}
+
+/** One governed run against the stub. Returns the parsed harness result. */
+async function governedRun({ stub, env, cwd, prompt, permissionMode, script, label }) {
+  stub.load(script);
+  const result = await runCli(
+    ['run', '--cwd', cwd, '--permission-mode', permissionMode, '--output-format', 'json', '--quiet', prompt],
+    env,
+    cwd,
+  );
+  const line = result.stdout.trim().split('\n').filter(Boolean).pop();
+  let parsed;
+  try {
+    parsed = JSON.parse(line ?? '');
+  } catch {
+    fail(`${label} run produced no JSON result (exit ${result.code})\n${result.stderr || result.stdout}`);
+  }
+  if (!parsed.runId) fail(`${label} run recorded no audit run (exit ${result.code}): ${parsed.error ?? 'unknown'}`);
+  console.log(`  ✓ ${label} run ${parsed.runId} — ${parsed.toolCalls} tool call(s), exit ${result.code}`);
+  return parsed;
+}
+
+// ── main ─────────────────────────────────────────────────────────────────────
+
+const home = mkdtempSync(path.join(os.tmpdir(), 'dvalin-evidence-home-'));
+const denyWorkspace = mkdtempSync(path.join(os.tmpdir(), 'dvalin-evidence-deny-'));
+
+try {
+  console.log(`▶ Release Evidence Pack — DvalinCode v${VERSION}`);
+  console.log(`  binary   ${binCommand}`);
+  console.log(`  repo     ${repoDir}`);
+
+  const stub = startStub();
+  const baseUrl = await stub.listen();
+
+  // A throwaway HOME isolates config, sessions, and the audit dir, so the pack
+  // contains only the runs made here — nothing from the build machine.
+  const env = {
+    ...process.env,
+    HOME: home,
+    USERPROFILE: home,
+    DVALINCODE_PROVIDER: STUB_PROVIDER,
+    DVALINCODE_BASE_URL: baseUrl,
+    DVALINCODE_MODEL: STUB_MODEL,
+    DVALINCODE_API_KEY: '',
+    NO_COLOR: '1',
+  };
+
+  // Run 1 — read-only over the release tree.
+  await governedRun({
+    stub,
+    env,
+    cwd: repoDir,
+    label: 'allowed',
+    permissionMode: 'plan',
+    prompt: 'Read the project README and report what this release ships.',
+    script: [
+      { tool: { name: 'read_file', arguments: { filePath: 'README.md', limit: 40 } } },
+      { text: `Release evidence run for DvalinCode v${VERSION}: README read under Plan mode (read-only).` },
+    ],
+  });
+
+  // Run 2 — the same agent, blocked by policy. `defaultDeny` with no allowlist
+  // blocks every shell command; the probe is a harmless echo either way.
+  writeFileSync(
+    path.join(denyWorkspace, 'dvalin.policy.json'),
+    JSON.stringify({ commands: { defaultDeny: true } }, null, 2),
+    'utf8',
+  );
+  writeFileSync(path.join(denyWorkspace, 'README.md'), 'Policy-denial fixture for the release Evidence Pack.\n', 'utf8');
+  await governedRun({
+    stub,
+    env,
+    cwd: denyWorkspace,
+    label: 'denied ',
+    permissionMode: 'auto',
+    prompt: 'Run the probe command in this workspace.',
+    script: [
+      { tool: { name: 'shell', arguments: { command: 'echo', args: ['dvalincode-policy-probe'] } } },
+      { text: 'The shell command was refused by policy; nothing was executed.' },
+    ],
+  });
+
+  await stub.close();
+
+  // Export from the repo root so the pack's policy section is the release's own
+  // resolved policy.
+  mkdirSync(path.dirname(outFile), { recursive: true });
+  const exported = await runCli(['evidence', 'export', '--last', '10', '--out', outFile], env, repoDir);
+  if (exported.code !== 0) fail(`evidence export failed:\n${exported.stderr || exported.stdout}`);
+  process.stdout.write(exported.stdout);
+
+  // Independent re-verification of what we just wrote.
+  const verified = await runCli(['evidence', 'verify', outFile], env, repoDir);
+  if (verified.code !== 0) fail(`evidence verify failed:\n${verified.stderr || verified.stdout}`);
+  process.stdout.write(verified.stdout);
+
+  assertPack(outFile);
+
+  // Fold the pack into the release checksum file so the existing build
+  // provenance attestation (which signs SHA256SUMS.txt) covers it too.
+  if (existsSync(sumsFile)) {
+    const digest = createHash('sha256').update(readFileSync(outFile)).digest('hex');
+    appendFileSync(sumsFile, `${digest}  ${path.basename(outFile)}\n`, 'utf8');
+    console.log(`  ✓ checksum appended to ${path.relative(ROOT, sumsFile)}`);
+  }
+
+  console.log(`\n✓ Release Evidence Pack: ${path.relative(ROOT, outFile)}`);
+  console.log(`  anyone can re-check it offline:  dvalincode evidence verify ${path.basename(outFile)}`);
+} finally {
+  rmSync(home, { recursive: true, force: true });
+  rmSync(denyWorkspace, { recursive: true, force: true });
+}
+
+/**
+ * The pack must be *useful*, not merely well-formed: both runs present, both
+ * chains intact, the denial actually recorded, and no credential-shaped values.
+ */
+function assertPack(file) {
+  const pack = JSON.parse(readFileSync(file, 'utf8'));
+  const problems = [];
+
+  if (pack.runs.length < 2) problems.push(`expected 2 runs, got ${pack.runs.length}`);
+  for (const run of pack.runs) {
+    if (!run.verify.ok) problems.push(`run ${run.runId} chain broken: ${run.verify.reason ?? run.verify.brokenAtSeq}`);
+  }
+  const denials = pack.runs.flatMap(r => r.records.filter(rec => rec.type === 'policy_violation'));
+  if (denials.length === 0) problems.push('no policy_violation record — the denial run did not prove enforcement');
+  if (pack.tool.version !== VERSION) problems.push(`pack version ${pack.tool.version} != package.json ${VERSION}`);
+  if (!pack.policy.hash) problems.push('pack carries no policy hash');
+
+  if (problems.length > 0) fail(`pack assertions failed:\n  - ${problems.join('\n  - ')}`);
+
+  const backed = pack.compliance.filter(c => c.backed).length;
+  console.log(`  ✓ pack asserted: ${pack.runs.length} verified runs, ${denials.length} recorded denial(s), ${backed}/${pack.compliance.length} controls backed`);
+}


### PR DESCRIPTION
## Summary

Two moves that make the project's claims checkable by someone who has not installed anything yet.

**1. Every release ships an Evidence Pack.** `dvalincode-v<version>-evidence.json`, produced by the *shipped binary* on the build machine from two real governed runs:

| Run | Setup | Proves |
|---|---|---|
| allowed | Plan mode (read-only) over the release tree | the normal path is fully audited — the chain contains a `file_read` whose sha256 is the released `README.md` itself |
| denied | fixture workspace with `commands.defaultDeny` | enforcement is real — the agent asks for a shell command, policy blocks it, and `policy_violation` (naming the rule) lands in the same hash chain |

A pack with only the happy path shows a tool that logs. A pack containing a recorded denial shows a tool that *stops*, and lets the reader check the stop is in the same chain as everything else.

The runs are driven by a deterministic OpenAI-compatible stub on `127.0.0.1` (no key, no egress) so the release path stays offline and reproducible. This is recorded, not hidden: audit records carry `provider: evidence-stub`, `model: deterministic-stub-v1`, and a loopback `provider_request`. The pack never implies a real model ran — it is evidence about governance, which is the part that must behave identically whichever model a user later brings.

No new pack schema: it is Evidence Pack v1, byte-for-byte the format a user exports locally. Only the provenance of the runs differs.

**2. PCP-1 published as an open spec.** The provider adapter contract behind #118 is written as a vendor-neutral profile rather than a DvalinCode test file: 35 assertions over egress containment (EG), credential containment (CR), auditability (AU), policy binding (PO), and the behavioral contract (BE), plus requirements on the suite itself (T). Each has an ID, MUST/SHOULD level, test procedure, and pass criteria. A machine-readable list and a comparable self-assessment report format ship alongside.

It constrains observable behavior only — no adapter API, no policy language, no audit format — so a runtime with a completely different architecture can be conformant. Two rules do the load bearing:

- **Narrowing rule** — no assertion may be satisfied by weakening a control, and an implementation that offers a flag disabling destination validation, policy consultation, or auditing is non-conformant *regardless of that flag's default*.
- **T-2** — every MUST needs a bypass test that fails when the control is removed. A suite that still passes after the control is deleted is treated as not implementing the assertion.

Also an honesty rule: an unimplemented assertion is reported `fail`, never omitted.

## Testing

- `npm test` → **298 passed (47 files)**, `npm run site:build` → build complete (VitePress dead-link check passes; the spec's JSON link points at the GitHub blob URL because assets outside `docs/public` are not copied to the site).
- `node scripts/release-evidence.mjs` end-to-end against `dist/`:
  ```
  ✓ allowed run 2026-08-02T06-45-48-035Z-… — 1 tool call(s), exit 0
  ✓ denied  run 2026-08-02T06-45-48-280Z-… — 1 tool call(s), exit 0
  ✓ Evidence Pack intact — 2 run chain(s) verified, all section hashes match
  ✓ pack asserted: 2 verified runs, 1 recorded denial(s), 6/6 controls backed
  ```
  Inspected the resulting records directly: the denied run contains `policy_violation` with rule `command blocked by default-deny (no allowlist match)` at seq 2, between two `provider_request` records — i.e. the block happened mid-run and is inside the chain.
- Checksum path exercised with a seeded `release/SHA256SUMS.txt`: the appended pack line verifies with `shasum -a 256 -c SHA256SUMS.txt`.
- `.github/workflows/release.yml` parses as valid YAML. The CI step itself only runs on a release build; it is the one part not exercised locally end-to-end.

## Security and AI Governance

- [x] This change does not expand file, shell, network, model, or approval permissions. No `src/` change at all — the script is a release-time driver that spawns the CLI as a child process and talks to a loopback stub. Runs execute under a throwaway `HOME`, so nothing from the build machine leaks into the pack.
- [x] It changes release/build security, and the governance evidence is updated in `docs/`: new `docs/RELEASE-EVIDENCE.md` (design + acceptance matrix + non-goals), new `docs/spec/PROVIDER-CONFORMANCE.md`.
- [x] No new model, provider, tool, or data flow. The stub is a test double on loopback, not a provider — `docs/governance/AI-CHANGE-IMPACT-ASSESSMENT.md` does not apply.

Minimization is preserved: the pack goes through the existing `evidence verify` structural secret scan, which fails the build on any credential-shaped key with a value.

## Notes

- **The release pack is not a certification and not a substitute for the per-install pack.** It proves what those two runs did and that the records are intact. A company's approval evidence is still the pack from their own machine under their own policy. Both non-goals are stated in the doc.
- **Follow-ups I did not take unilaterally:** #118 could be re-scoped to "the executable suite implementing PCP-1", and Appendix B assumes a `spec` label for profile changes that does not exist yet.
- Where the implementation and PCP-1 disagree, the profile is not automatically right — gaps found that way are the point of publishing it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
