### PR TITLE
docs: correct contradictory test counts in both READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 <p align="center">
   <a href="https://github.com/arthurpanhku/dvalincode/releases/latest"><img src="https://img.shields.io/github/v/release/arthurpanhku/dvalincode?style=for-the-badge&color=818cf8&label=Release" alt="Release"></a>
   <a href="https://github.com/arthurpanhku/dvalincode/releases"><img src="https://img.shields.io/github/downloads/arthurpanhku/dvalincode/total?style=for-the-badge&color=blue&label=Downloads" alt="Downloads"></a>
-  <a href="#-tests"><img src="https://img.shields.io/badge/Tests-770%20%2F%20770%20%E2%9C%93-success?style=for-the-badge" alt="Tests"></a>
+  <a href="#-tests"><img src="https://img.shields.io/badge/Tests-306%20%2F%20306%20%E2%9C%93-success?style=for-the-badge" alt="Tests"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-green?style=for-the-badge" alt="License"></a>
   <a href="https://scorecard.dev/viewer/?uri=github.com/arthurpanhku/dvalincode"><img src="https://api.scorecard.dev/projects/github.com/arthurpanhku/dvalincode/badge" alt="OpenSSF Scorecard"></a>
   <a href="docs/governance/ISO-42001-AIMS.md"><img src="https://img.shields.io/badge/ISO%2FIEC%2042001-AIMS%20Aligned-0F766E?style=for-the-badge" alt="ISO/IEC 42001 AIMS aligned"></a>
@@ -602,7 +602,7 @@ RESTORE → COMPACT → COMMAND → BUILD → RUN → SAVE → RESPOND → DONE
 npm test
 ```
 
-**229 tests · 40 files · all green.**
+**306 tests · 47 files · all green.**
 
 ---
 
@@ -723,7 +723,7 @@ Contributions welcome. The codebase is intentionally small and surgical — see 
 ```sh
 git clone https://github.com/arthurpanhku/dvalincode
 cd dvalincode && npm install
-npm test                # 65/65 ✅
+npm test                # 306/306 ✅
 npm run typecheck
 ```
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -9,7 +9,7 @@
 <p align="center">
   <a href="https://github.com/arthurpanhku/dvalincode/releases/latest"><img src="https://img.shields.io/github/v/release/arthurpanhku/dvalincode?style=for-the-badge&color=818cf8&label=Release" alt="Release"></a>
   <a href="https://github.com/arthurpanhku/dvalincode/releases"><img src="https://img.shields.io/github/downloads/arthurpanhku/dvalincode/total?style=for-the-badge&color=blue&label=Downloads" alt="Downloads"></a>
-  <a href="#-测试"><img src="https://img.shields.io/badge/Tests-770%20%2F%20770%20%E2%9C%93-success?style=for-the-badge" alt="Tests"></a>
+  <a href="#-测试"><img src="https://img.shields.io/badge/Tests-306%20%2F%20306%20%E2%9C%93-success?style=for-the-badge" alt="Tests"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-green?style=for-the-badge" alt="License"></a>
   <a href="https://scorecard.dev/viewer/?uri=github.com/arthurpanhku/dvalincode"><img src="https://api.scorecard.dev/projects/github.com/arthurpanhku/dvalincode/badge" alt="OpenSSF Scorecard"></a>
   <a href="docs/governance/ISO-42001-AIMS.md"><img src="https://img.shields.io/badge/ISO%2FIEC%2042001-AIMS%20Aligned-0F766E?style=for-the-badge" alt="ISO/IEC 42001 AIMS aligned"></a>
@@ -530,7 +530,7 @@ RESTORE → COMPACT → COMMAND → BUILD → RUN → SAVE → RESPOND → DONE
 npm test
 ```
 
-**229 个测试 · 40 个文件 · 全部通过。**
+**306 个测试 · 47 个文件 · 全部通过。**
 
 ---
 
@@ -657,7 +657,7 @@ Linux 与 macOS 命令通过 <code>/bin/sh</code> 执行；Windows 命令通过�
 ```sh
 git clone https://github.com/arthurpanhku/dvalincode
 cd dvalincode && npm install
-npm test                # 65/65 ✅
+npm test                # 306/306 ✅
 npm run typecheck
 ```
 


### PR DESCRIPTION
## Summary

The READMEs advertised **three mutually contradictory test counts**, none of which matched reality:

| Location | Claimed | Actual |
|---|---|---|
| Header badge (line 12) | `Tests 770 / 770` | `306 / 306` |
| `## 🧪 Tests` section | `229 tests · 40 files` | `306 tests · 47 files` |
| `## 🤝 Contributing` section | `npm test # 65/65` | `npm test # 306/306` |

All three are now the real number, in both `README.md` and `README.zh-CN.md` (6 locations total).

## Testing

Ran `npm test` (vitest 4.1.10) to establish ground truth:

```
Test Files  47 passed (47)
     Tests  306 passed (306)
```

`web/package.json` has no `test` script, so the root `npm test` is the entire suite — 306/306 is the only correct figure, not a partial count. Verified afterwards that no `770` / `229` / `65/65` / `40 files` strings remain in either README.

Diff is 6 insertions / 6 deletions: numbers only, no other content touched.

## Security and AI Governance

- [x] This change does not expand file, shell, network, model, or approval permissions.
- [x] If it changes agent behavior, prompts, policy, providers, audit logging, or release/build security, I updated the relevant governance evidence in `docs/`. — N/A, documentation-only change to two README files.
- [x] If it introduces a new model/provider/tool or new data flow, I completed `docs/governance/AI-CHANGE-IMPACT-ASSESSMENT.md`. — N/A, no new model, provider, tool, or data flow.

## Notes

**This will drift again.** Three hardcoded counts in two files is exactly the setup that produced the 770/229/65 three-way split in the first place — every PR that adds a test silently invalidates all six. Worth a follow-up: drive the badge from CI (shields.io endpoint or a workflow that writes it back) and add a CI check that fails when the prose counts disagree with the actual vitest output. Out of scope here, since this PR is deliberately numbers-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)