### PR TITLE
feat: zero-install Dvalin scans via GitHub Action + SARIF output

### DIFF
--- a/.dvalincodeignore
+++ b/.dvalincodeignore
@@ -1,0 +1,12 @@
+# Paths excluded from `dvalincode dvalin` scans.
+#
+# These test files contain deliberately vulnerable-looking strings — they are
+# the fixtures that prove the scanner fires. Scanning them reports the tool's
+# own test data as findings.
+#
+# Keep this list surgical. Excluding a file because a finding is inconvenient
+# defeats the point; exclude only where the vulnerable pattern is the fixture.
+
+tests/evidence/evidence.test.ts
+tests/remediationLocalScan.test.ts
+tests/remediationScannerSuite.test.ts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,3 +64,20 @@ jobs:
       - run: npm run typecheck
       - name: Test native command execution and cancellation
         run: npx vitest run tests/shellSeatbeltExec.test.ts tests/subprocessAbort.test.ts tests/shellSandbox.test.ts
+
+  # Dogfood the published action against this repository. Also the smoke test
+  # that keeps action.yml working — it breaks here before it breaks for users.
+  dvalin:
+    name: Dvalin self-scan
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      # actions/checkout v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          persist-credentials: false
+      - uses: ./
+        with:
+          fail-on: high

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,8 +65,12 @@ jobs:
       - name: Test native command execution and cancellation
         run: npx vitest run tests/shellSeatbeltExec.test.ts tests/subprocessAbort.test.ts tests/shellSandbox.test.ts
 
-  # Dogfood the published action against this repository. Also the smoke test
-  # that keeps action.yml working — it breaks here before it breaks for users.
+  # Dogfood the action against this repository. Also the smoke test that keeps
+  # action.yml working — it breaks here before it breaks for users.
+  #
+  # `version: local` scans with the build from this checkout, not the released
+  # npm package, so the job validates the code in the pull request rather than
+  # whatever is currently published.
   dvalin:
     name: Dvalin self-scan
     runs-on: ubuntu-latest
@@ -78,6 +82,14 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           persist-credentials: false
+      # actions/setup-node v6.4.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npm run build
       - uses: ./
         with:
+          version: local
           fail-on: high

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ permissions:
   security-events: write
 steps:
   - uses: actions/checkout@v5
-  - uses: arthurpanhku/dvalincode@v0.14.1
+  - uses: arthurpanhku/dvalincode@v0.15.0
     with:
       fail-on: high
 ```

--- a/README.md
+++ b/README.md
@@ -9,47 +9,61 @@
 <p align="center">
   <a href="https://github.com/arthurpanhku/dvalincode/releases/latest"><img src="https://img.shields.io/github/v/release/arthurpanhku/dvalincode?style=for-the-badge&color=818cf8&label=Release" alt="Release"></a>
   <a href="https://github.com/arthurpanhku/dvalincode/releases"><img src="https://img.shields.io/github/downloads/arthurpanhku/dvalincode/total?style=for-the-badge&color=blue&label=Downloads" alt="Downloads"></a>
-  <a href="#-tests"><img src="https://img.shields.io/badge/Tests-316%20%2F%20316%20%E2%9C%93-success?style=for-the-badge" alt="Tests"></a>
+  <a href="#-tests"><img src="https://img.shields.io/badge/Tests-323%20%2F%20323%20%E2%9C%93-success?style=for-the-badge" alt="Tests"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-green?style=for-the-badge" alt="License"></a>
   <a href="https://scorecard.dev/viewer/?uri=github.com/arthurpanhku/dvalincode"><img src="https://api.scorecard.dev/projects/github.com/arthurpanhku/dvalincode/badge" alt="OpenSSF Scorecard"></a>
-  <a href="docs/governance/ISO-42001-AIMS.md"><img src="https://img.shields.io/badge/ISO%2FIEC%2042001-AIMS%20Aligned-0F766E?style=for-the-badge" alt="ISO/IEC 42001 AIMS aligned"></a>
-  <a href="docs/EVIDENCE-PACK.md"><img src="https://img.shields.io/badge/Compliance-Evidence%20Pack-2563EB?style=for-the-badge" alt="Compliance evidence pack"></a>
-  <a href="docs/security/OPENSSF-SCORECARD.md"><img src="https://img.shields.io/badge/DevSecOps-Native-B91C1C?style=for-the-badge" alt="DevSecOps native"></a>
   <a href="#-quick-install"><img src="https://img.shields.io/badge/Platforms-macOS%20·%20Windows%20·%20Linux-blue?style=for-the-badge" alt="Platforms"></a>
   <a href="#-providers"><img src="https://img.shields.io/badge/LLM-OpenAI%20·%20Claude%20·%20DeepSeek%20·%20Ollama%20·%20Groq-7C3AED?style=for-the-badge" alt="LLM Support"></a>
   <a href="README.zh-CN.md"><img src="https://img.shields.io/badge/i18n-EN%20·%20中文-orange?style=for-the-badge" alt="English / 中文"></a>
 </p>
 
 <p align="center">
-  <b>Build code. Then use Dvalin to scan it, harden it, test it, and ship a reviewable security PR.</b><br>
-  <b>The local-first, approvable coding agent for regulated and security-sensitive teams.</b>
-</p>
-
-<p align="center">
-  <b>🔑 Any model · local-first · policy-bound · audit-ready — the agent your security team can actually approve.</b>
-</p>
-
-<p align="center">
-  Bring your own model — DeepSeek, OpenAI, Claude (via OpenRouter), Groq, Ollama, or any OpenAI-compatible endpoint. Switch with one click, no code changes, no lock-in.
+  <b>Find the security holes in your repo, fix them, and prove the fix — in one command.</b><br>
+  Every fix is diffed, tested, re-scanned, and recorded in a tamper-evident audit log before it can become a PR.
 </p>
 
 ---
 
-## ⏱️ 60 seconds to a real Dvalin scan
-
-Install DvalinCode, then scan the current repository with the built-in rules and
-any supported open-source engines available on `PATH`:
+## ⏱️ 30 seconds, no install, no API key
 
 ```sh
-curl -fsSL https://raw.githubusercontent.com/arthurpanhku/dvalincode/main/scripts/install.sh | bash
-dvalincode trust
-dvalincode dvalin . --scanners builtin,semgrep,trivy,osv-scanner
+npx dvalincode dvalin .
 ```
 
-Use `--fix --verify --in-place` to let the configured model prepare focused
-repairs, run tests, and require a clean re-scan before the result can proceed to
-a draft PR. Dvalin never treats its health score as certification; source review
-and verification remain mandatory.
+That is the whole thing. It runs the built-in rules for injection, hardcoded
+secrets, XSS, `eval`, and unsafe shell use against the current directory and
+prints what it found. No account, no model, no config, no code leaves your
+machine. Add `--scanners builtin,semgrep,trivy,osv-scanner` to pull in whichever
+of those engines you already have on `PATH`.
+
+### Or put it on every pull request — nothing to install at all
+
+```yaml
+# .github/workflows/security.yml
+permissions:
+  contents: read
+  security-events: write
+steps:
+  - uses: actions/checkout@v5
+  - uses: arthurpanhku/dvalincode@v0.14.1
+    with:
+      fail-on: high
+```
+
+Findings land inline on the pull request diff and in your Security tab.
+No API key, no secrets, no model — the scan is deterministic and local to the
+runner. [Full example →](docs/examples/dvalin-scan.yml)
+
+### Then let it fix what it found
+
+```sh
+dvalincode dvalin . --fix --verify --draft-pr
+```
+
+This step *does* use a model — your model, any OpenAI-compatible endpoint. It
+prepares focused repairs in an isolated worktree, runs your tests, and requires
+a clean re-scan before anything can proceed to a draft PR. It never auto-merges,
+and a clean scan is never treated as proof that the code is safe.
 
 <p align="center">
   <img src="assets/dvalin-remediation.gif" alt="Dvalin scanning a vulnerable OWASP NodeGoat example at 22/100 F with 10 findings, then showing a clean verified re-scan at 100/100 A" width="100%">
@@ -60,11 +74,10 @@ Apache-2.0-licensed example adapted from
 [OWASP NodeGoat](https://github.com/OWASP/NodeGoat/tree/c5cb68a7084e4ae7dcc60e6a98768720a81841e8/app/routes),
 whose contribution route evaluated user-controlled text.
 
-## 🛡️ Dvalin is the security counterpart to Code
+## 🛡️ What that run actually did
 
-Code builds software. **Dvalin is the second major product surface:** it turns
-open-source scanner evidence into a controlled scan → fix → test → re-scan →
-draft-PR workflow.
+Dvalin turns open-source scanner evidence into a controlled scan → fix → test →
+re-scan → draft-PR workflow. Here is the run in the animation above, measured:
 
 | Real NodeGoat-derived run | Before | After Dvalin remediation |
 |---|---:|---:|
@@ -97,6 +110,22 @@ You can still prove what the agent did after the fact:
 ```sh
 dvalincode report verify    # re-derive the hash chain of the last run's audit log
 ```
+
+---
+
+## 🏛️ And it survives a security review
+
+That last command is the part that matters once more than one person depends on
+this. DvalinCode is a full coding agent — terminal, web GUI, and desktop app —
+built so that an organization, not the developer, bounds what it may do: a
+policy file constrains modes, commands, paths, tools, and models; every run is
+hash-chained into a tamper-evident audit log; nothing reaches a provider that
+the egress guard did not allow. A repo policy can only ever *narrow* the
+machine-level one.
+
+If you are the person who has to approve this class of tool, start at
+[APPROVABILITY-PLAN.md](docs/APPROVABILITY-PLAN.md) and the
+[Evidence Pack](docs/EVIDENCE-PACK.md) that every release ships of itself.
 
 ---
 
@@ -168,6 +197,12 @@ it can touch production repositories.
 ---
 
 ## 🛡️ Security & Governance
+
+<p align="center">
+  <a href="docs/governance/ISO-42001-AIMS.md"><img src="https://img.shields.io/badge/ISO%2FIEC%2042001-AIMS%20Aligned-0F766E?style=for-the-badge" alt="ISO/IEC 42001 AIMS aligned"></a>
+  <a href="docs/EVIDENCE-PACK.md"><img src="https://img.shields.io/badge/Compliance-Evidence%20Pack-2563EB?style=for-the-badge" alt="Compliance evidence pack"></a>
+  <a href="docs/security/OPENSSF-SCORECARD.md"><img src="https://img.shields.io/badge/DevSecOps-Native-B91C1C?style=for-the-badge" alt="DevSecOps native"></a>
+</p>
 
 DvalinCode maintains project-level governance evidence for open-source and
 enterprise review. This is the differentiator for teams where AI coding must
@@ -606,7 +641,7 @@ RESTORE → COMPACT → COMMAND → BUILD → RUN → SAVE → RESPOND → DONE
 npm test
 ```
 
-**316 tests · 48 files · all green.**
+**323 tests · 49 files · all green.**
 
 ---
 
@@ -727,7 +762,7 @@ Contributions welcome. The codebase is intentionally small and surgical — see 
 ```sh
 git clone https://github.com/arthurpanhku/dvalincode
 cd dvalincode && npm install
-npm test                # 316/316 ✅
+npm test                # 323/323 ✅
 npm run typecheck
 ```
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -43,7 +43,7 @@ permissions:
   security-events: write
 steps:
   - uses: actions/checkout@v5
-  - uses: arthurpanhku/dvalincode@v0.14.1
+  - uses: arthurpanhku/dvalincode@v0.15.0
     with:
       fail-on: high
 ```

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -9,45 +9,58 @@
 <p align="center">
   <a href="https://github.com/arthurpanhku/dvalincode/releases/latest"><img src="https://img.shields.io/github/v/release/arthurpanhku/dvalincode?style=for-the-badge&color=818cf8&label=Release" alt="Release"></a>
   <a href="https://github.com/arthurpanhku/dvalincode/releases"><img src="https://img.shields.io/github/downloads/arthurpanhku/dvalincode/total?style=for-the-badge&color=blue&label=Downloads" alt="Downloads"></a>
-  <a href="#-测试"><img src="https://img.shields.io/badge/Tests-316%20%2F%20316%20%E2%9C%93-success?style=for-the-badge" alt="Tests"></a>
+  <a href="#-测试"><img src="https://img.shields.io/badge/Tests-323%20%2F%20323%20%E2%9C%93-success?style=for-the-badge" alt="Tests"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-green?style=for-the-badge" alt="License"></a>
   <a href="https://scorecard.dev/viewer/?uri=github.com/arthurpanhku/dvalincode"><img src="https://api.scorecard.dev/projects/github.com/arthurpanhku/dvalincode/badge" alt="OpenSSF Scorecard"></a>
-  <a href="docs/governance/ISO-42001-AIMS.md"><img src="https://img.shields.io/badge/ISO%2FIEC%2042001-AIMS%20Aligned-0F766E?style=for-the-badge" alt="ISO/IEC 42001 AIMS aligned"></a>
-  <a href="docs/EVIDENCE-PACK.md"><img src="https://img.shields.io/badge/Compliance-Evidence%20Pack-2563EB?style=for-the-badge" alt="Compliance evidence pack"></a>
-  <a href="docs/security/OPENSSF-SCORECARD.md"><img src="https://img.shields.io/badge/DevSecOps-Native-B91C1C?style=for-the-badge" alt="DevSecOps native"></a>
   <a href="#-一行安装"><img src="https://img.shields.io/badge/Platforms-macOS%20·%20Windows%20·%20Linux-blue?style=for-the-badge" alt="Platforms"></a>
   <a href="#-providers"><img src="https://img.shields.io/badge/LLM-OpenAI%20·%20Claude%20·%20DeepSeek%20·%20Ollama%20·%20Groq-7C3AED?style=for-the-badge" alt="LLM Support"></a>
   <a href="README.md"><img src="https://img.shields.io/badge/i18n-EN%20·%20中文-orange?style=for-the-badge" alt="English / 中文"></a>
 </p>
 
 <p align="center">
-  <b>先构建代码，再由 Dvalin 扫描、加固、测试，并生成可审查的安全 PR。</b><br>
-  <b>面向高合规与安全敏感团队、本地优先且真正可审批的 AI 编码代理。</b>
-</p>
-
-<p align="center">
-  <b>🔑 模型自由 · 本地优先 · 策略约束 · 审计就绪 —— 安全团队真正批得下来的编码代理。</b>
-</p>
-
-<p align="center">
-  自带模型 —— DeepSeek、OpenAI、Claude (via OpenRouter)、Groq、Ollama，或任何 OpenAI 兼容端点。一键切换，无需改代码，无供应商绑定。
+  <b>找出仓库里的安全漏洞，修掉它，并且证明确实修好了 —— 一条命令。</b><br>
+  每一处修复都会先出 diff、跑测试、重新扫描，并写入防篡改审计日志，然后才允许变成 PR。
 </p>
 
 ---
 
-## ⏱️ 60 秒完成一次真实 Dvalin 扫描
-
-安装 DvalinCode，然后用内置规则与 `PATH` 中可用的开源扫描器检查当前仓库：
+## ⏱️ 30 秒，免安装，不需要 API Key
 
 ```sh
-curl -fsSL https://raw.githubusercontent.com/arthurpanhku/dvalincode/main/scripts/install.sh | bash
-dvalincode trust
-dvalincode dvalin . --scanners builtin,semgrep,trivy,osv-scanner
+npx dvalincode dvalin .
 ```
 
-加上 `--fix --verify --in-place`，配置的模型会准备聚焦修复；Dvalin 会运行
-测试并强制重新扫描，通过后才能进入 Draft PR 阶段。健康分只是分诊启发式，不是
-安全认证；源码审查与验证始终必不可少。
+就这一条。它用内置规则扫描当前目录里的注入、硬编码密钥、XSS、`eval` 和不安全的
+shell 调用，然后把结果打出来。不需要注册、不需要模型、不需要配置，代码不出本机。
+想接入你已经装好的引擎，加上 `--scanners builtin,semgrep,trivy,osv-scanner` 即可。
+
+### 或者挂到每个 PR 上 —— 完全不用装任何东西
+
+```yaml
+# .github/workflows/security.yml
+permissions:
+  contents: read
+  security-events: write
+steps:
+  - uses: actions/checkout@v5
+  - uses: arthurpanhku/dvalincode@v0.14.1
+    with:
+      fail-on: high
+```
+
+扫描结果会直接标注在 PR 的 diff 上，同时进入仓库的 Security 页。不需要 API Key、
+不需要任何 secret、不调用模型 —— 扫描是确定性的，且只在 runner 本地进行。
+[完整示例 →](docs/examples/dvalin-scan.yml)
+
+### 然后让它把找到的问题修掉
+
+```sh
+dvalincode dvalin . --fix --verify --draft-pr
+```
+
+这一步**才**会用到模型 —— 你自己的模型，任何 OpenAI 兼容端点。它在隔离的 worktree
+里准备聚焦修复，运行你的测试，并且必须通过一次干净的复扫，才允许进入 Draft PR。
+它不会自动合并，也不会把「扫描干净」当成「代码安全」的证明。
 
 <p align="center">
   <img src="assets/dvalin-remediation.gif" alt="Dvalin 扫描有漏洞的 OWASP NodeGoat 示例得到 22/100 F 与 10 条发现，修复后复扫为 100/100 A" width="100%">
@@ -57,10 +70,10 @@ dvalincode dvalin . --scanners builtin,semgrep,trivy,osv-scanner
 许可的 [OWASP NodeGoat](https://github.com/OWASP/NodeGoat/tree/c5cb68a7084e4ae7dcc60e6a98768720a81841e8/app/routes)，
 原始 contribution route 会执行用户可控文本。
 
-## 🛡️ Dvalin：与 Code 并列的安全主功能
+## 🛡️ 上面那次运行到底做了什么
 
-Code 负责构建软件。**Dvalin 是本项目第二条产品主线**：把开源扫描器的证据
-组织成受控的“扫描 → 修复 → 测试 → 复扫 → Draft PR”闭环。
+Dvalin 把开源扫描器的证据组织成受控的“扫描 → 修复 → 测试 → 复扫 → Draft PR”
+闭环。上面动图里那次运行，量化如下：
 
 | NodeGoat 改编案例真实运行 | 修复前 | Dvalin 修复后 |
 |---|---:|---:|
@@ -88,6 +101,20 @@ Ollama 选择开放权重模型；托管模型的许可取决于相应 provider�
 ```sh
 dvalincode report verify    # 重新推导上次运行审计日志的哈希链
 ```
+
+---
+
+## 🏛️ 而且它过得了安全评审
+
+当依赖这套工具的不止你一个人时，上面那条命令才是真正要紧的东西。DvalinCode 是一个
+完整的编码代理 —— 终端、Web GUI、桌面应用 —— 但它的设计前提是：**由组织、而不是
+开发者本人**来划定它能做什么。策略文件约束模式、命令、路径、工具和模型；每次运行
+都以哈希链写入防篡改审计日志；没有被出网守卫放行的东西不会到达任何 provider。
+仓库级策略只能**收紧**机器级策略，永远不能放宽。
+
+如果你正是那个需要审批这类工具的人，请从
+[APPROVABILITY-PLAN.md](docs/APPROVABILITY-PLAN.md) 和每个版本随包发布的
+[Evidence Pack](docs/EVIDENCE-PACK.md) 开始看。
 
 ---
 
@@ -150,6 +177,12 @@ DvalinCode 的差异化在于 **可审批性**。它面向那些必须先通过�
 ---
 
 ## 🛡️ 安全与治理
+
+<p align="center">
+  <a href="docs/governance/ISO-42001-AIMS.md"><img src="https://img.shields.io/badge/ISO%2FIEC%2042001-AIMS%20Aligned-0F766E?style=for-the-badge" alt="ISO/IEC 42001 AIMS aligned"></a>
+  <a href="docs/EVIDENCE-PACK.md"><img src="https://img.shields.io/badge/Compliance-Evidence%20Pack-2563EB?style=for-the-badge" alt="Compliance evidence pack"></a>
+  <a href="docs/security/OPENSSF-SCORECARD.md"><img src="https://img.shields.io/badge/DevSecOps-Native-B91C1C?style=for-the-badge" alt="DevSecOps native"></a>
+</p>
 
 DvalinCode 维护项目级治理证据，便于开源用户和企业安全评审。这是面向
 高合规团队的核心差异化：AI 编码工具进入生产仓库前，必须先能过安全审批。
@@ -532,7 +565,7 @@ RESTORE → COMPACT → COMMAND → BUILD → RUN → SAVE → RESPOND → DONE
 npm test
 ```
 
-**316 个测试 · 48 个文件 · 全部通过。**
+**323 个测试 · 49 个文件 · 全部通过。**
 
 ---
 
@@ -659,7 +692,7 @@ Linux 与 macOS 命令通过 <code>/bin/sh</code> 执行；Windows 命令通过�
 ```sh
 git clone https://github.com/arthurpanhku/dvalincode
 cd dvalincode && npm install
-npm test                # 316/316 ✅
+npm test                # 323/323 ✅
 npm run typecheck
 ```
 

--- a/action.yml
+++ b/action.yml
@@ -21,7 +21,11 @@ inputs:
     required: false
     default: 'none'
   version:
-    description: 'npm version of the dvalincode package to run.'
+    description: >-
+      npm version of the dvalincode package to run. The literal value `local`
+      runs the build already present in the action's own checkout instead of
+      fetching from npm — used by this repository to test itself, and by anyone
+      vendoring the action. `local` requires the caller to have built first.
     required: false
     default: 'latest'
   timeout:
@@ -85,10 +89,30 @@ runs:
         DVALIN_SARIF: ${{ inputs.sarif-file }}
       run: |
         set -o pipefail
+
+        # Built as an array so the version input is never interpolated into a
+        # shell string. Anything outside the npm version charset is rejected.
+        if [ "${DVALIN_VERSION}" = "local" ]; then
+          cli_entry="${GITHUB_ACTION_PATH}/dist/index.js"
+          if [ ! -f "${cli_entry}" ]; then
+            echo "::error::version 'local' needs a prior build — no ${cli_entry}. Run your build step before this action."
+            exit 1
+          fi
+          cli=(node "${cli_entry}")
+        else
+          case "${DVALIN_VERSION}" in
+            ''|*[!A-Za-z0-9._@/-]*)
+              echo "::error::Invalid version '${DVALIN_VERSION}'."
+              exit 1
+              ;;
+          esac
+          cli=(npx -y "dvalincode@${DVALIN_VERSION}")
+        fi
+
         # The gate must not abort the job before the SARIF upload and summary
         # run, so the exit code is captured and re-applied at the end.
         code=0
-        npx -y "dvalincode@${DVALIN_VERSION}" dvalin "${DVALIN_PATH}" \
+        "${cli[@]}" dvalin "${DVALIN_PATH}" \
           --scanners "${DVALIN_SCANNERS}" \
           --timeout "${DVALIN_TIMEOUT}" \
           --fail-on "${DVALIN_FAIL_ON}" \

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,196 @@
+name: 'Dvalin Security Scan'
+description: 'Scan a repository for injection, secrets, XSS, eval and unsafe shell use. No API key, no model, no install.'
+author: 'DvalinCode'
+branding:
+  icon: 'shield'
+  color: 'blue'
+
+inputs:
+  path:
+    description: 'Directory to scan, relative to the workspace.'
+    required: false
+    default: '.'
+  scanners:
+    description: >-
+      Comma-separated scanners: builtin, semgrep, trivy, osv-scanner.
+      Only `builtin` runs with no extra setup; the others must already be on PATH.
+    required: false
+    default: 'builtin'
+  fail-on:
+    description: 'Fail the job at or above this severity: critical, high, medium, low, none.'
+    required: false
+    default: 'none'
+  version:
+    description: 'npm version of the dvalincode package to run.'
+    required: false
+    default: 'latest'
+  timeout:
+    description: 'Per-scanner timeout, in seconds.'
+    required: false
+    default: '300'
+  upload-sarif:
+    description: >-
+      Upload findings to GitHub code scanning so they appear inline on the pull
+      request diff and in the Security tab. Needs `security-events: write`.
+    required: false
+    default: 'true'
+  comment:
+    description: 'Post (and update) a summary comment on pull requests. Needs `pull-requests: write`.'
+    required: false
+    default: 'false'
+  sarif-file:
+    description: 'Where to write the SARIF report.'
+    required: false
+    default: 'dvalin.sarif'
+
+outputs:
+  score:
+    description: 'Security health score, 0-100.'
+    value: ${{ steps.scan.outputs.score }}
+  grade:
+    description: 'Letter grade, A-F.'
+    value: ${{ steps.scan.outputs.grade }}
+  findings:
+    description: 'Total number of findings.'
+    value: ${{ steps.scan.outputs.findings }}
+  sarif-file:
+    description: 'Path to the generated SARIF report.'
+    value: ${{ steps.scan.outputs.sarif-file }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Check Node.js
+      shell: bash
+      run: |
+        if ! command -v node >/dev/null 2>&1; then
+          echo "::error::Dvalin needs Node.js 20+ on PATH. Add actions/setup-node before this step."
+          exit 1
+        fi
+        major="$(node -p 'process.versions.node.split(".")[0]')"
+        if [ "$major" -lt 20 ]; then
+          echo "::error::Dvalin needs Node.js 20+, found $(node -v). Add actions/setup-node before this step."
+          exit 1
+        fi
+
+    - name: Run Dvalin scan
+      id: scan
+      shell: bash
+      env:
+        DVALIN_PATH: ${{ inputs.path }}
+        DVALIN_SCANNERS: ${{ inputs.scanners }}
+        DVALIN_FAIL_ON: ${{ inputs.fail-on }}
+        DVALIN_VERSION: ${{ inputs.version }}
+        DVALIN_TIMEOUT: ${{ inputs.timeout }}
+        DVALIN_SARIF: ${{ inputs.sarif-file }}
+      run: |
+        set -o pipefail
+        # The gate must not abort the job before the SARIF upload and summary
+        # run, so the exit code is captured and re-applied at the end.
+        code=0
+        npx -y "dvalincode@${DVALIN_VERSION}" dvalin "${DVALIN_PATH}" \
+          --scanners "${DVALIN_SCANNERS}" \
+          --timeout "${DVALIN_TIMEOUT}" \
+          --fail-on "${DVALIN_FAIL_ON}" \
+          --sarif "${DVALIN_SARIF}" \
+          --json > dvalin-result.json || code=$?
+
+        if [ ! -s dvalin-result.json ]; then
+          echo "::error::Dvalin produced no output (exit ${code})."
+          exit 1
+        fi
+
+        node -e '
+          const r = JSON.parse(require("fs").readFileSync("dvalin-result.json", "utf8"));
+          const out = process.env.GITHUB_OUTPUT;
+          const append = (k, v) => require("fs").appendFileSync(out, `${k}=${v}\n`);
+          append("score", r.score);
+          append("grade", r.grade);
+          append("findings", r.findings.length);
+          append("sarif-file", process.env.DVALIN_SARIF);
+        '
+        echo "gate-exit=${code}" >> "$GITHUB_OUTPUT"
+
+    - name: Build summary
+      id: summary
+      shell: bash
+      env:
+        DVALIN_SCANNERS: ${{ inputs.scanners }}
+      run: |
+        node -e '
+          const fs = require("fs");
+          const r = JSON.parse(fs.readFileSync("dvalin-result.json", "utf8"));
+          const m = r.metrics;
+          const icon = r.findings.length === 0 ? "✅" : (m.critical || m.high) ? "❌" : "⚠️";
+          const lines = [
+            `## ${icon} Dvalin security scan`,
+            "",
+            `**Health ${r.score}/100 (${r.grade})** · ${r.findings.length} ${r.findings.length === 1 ? "finding" : "findings"} across ${m.files} ${m.files === 1 ? "file" : "files"}`,
+            "",
+            "| Critical | High | Medium | Low |",
+            "|---:|---:|---:|---:|",
+            `| ${m.critical} | ${m.high} | ${m.medium} | ${m.low} |`,
+            "",
+          ];
+          if (r.findings.length) {
+            lines.push("| Severity | Location | Rule | Issue |", "|---|---|---|---|");
+            for (const f of r.findings.slice(0, 20)) {
+              const sev = f.severity === "error" ? "critical" : f.severity === "warning" ? "high" : "low";
+              const where = f.startLine ? `\`${f.path}:${f.startLine}\`` : `\`${f.path}\``;
+              const rule = f.helpUri ? `[${f.ruleId}](${f.helpUri})` : `\`${f.ruleId}\``;
+              lines.push(`| ${sev} | ${where} | ${rule} | ${f.message.replace(/\|/g, "\\|")} |`);
+            }
+            if (r.findings.length > 20) lines.push("", `_…and ${r.findings.length - 20} more._`);
+          } else {
+            lines.push("No findings. 🎉");
+          }
+          const skipped = r.scanners.filter(s => s.status === "missing").map(s => s.id);
+          if (skipped.length) lines.push("", `_Scanners not installed on this runner: ${skipped.join(", ")}._`);
+          lines.push("", "<sub>Scanned by [Dvalin](https://github.com/arthurpanhku/dvalincode) — no API key, no model, no code leaves the runner.</sub>");
+          const body = lines.join("\n");
+          fs.writeFileSync("dvalin-summary.md", body);
+          if (process.env.GITHUB_STEP_SUMMARY) fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, body + "\n");
+        '
+
+    - name: Upload SARIF to code scanning
+      if: ${{ inputs.upload-sarif == 'true' }}
+      # github/codeql-action/upload-sarif v4.37.1 — pinned by digest, same as
+      # every action in this repository's own workflows.
+      uses: github/codeql-action/upload-sarif@e0647621c2984b5ed2f768cb892365bf2a616ad1
+      with:
+        sarif_file: ${{ inputs.sarif-file }}
+        category: dvalin
+
+    - name: Comment on pull request
+      if: ${{ inputs.comment == 'true' && github.event_name == 'pull_request' }}
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+        REPO: ${{ github.repository }}
+      run: |
+        # One sticky comment per PR: edit the previous one instead of stacking.
+        marker="<!-- dvalin-scan -->"
+        printf '%s\n' "$marker" >> dvalin-summary.md
+        existing="$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" --paginate \
+          --jq "[.[] | select(.body | contains(\"${marker}\"))] | first | .id // empty" 2>/dev/null || true)"
+        if [ -n "$existing" ]; then
+          gh api --method PATCH "repos/${REPO}/issues/comments/${existing}" \
+            -F body=@dvalin-summary.md >/dev/null \
+            || echo "::warning::Could not update the Dvalin comment (needs pull-requests: write)."
+        else
+          gh api --method POST "repos/${REPO}/issues/${PR_NUMBER}/comments" \
+            -F body=@dvalin-summary.md >/dev/null \
+            || echo "::warning::Could not post the Dvalin comment (needs pull-requests: write)."
+        fi
+
+    - name: Apply severity gate
+      shell: bash
+      env:
+        GATE_EXIT: ${{ steps.scan.outputs.gate-exit }}
+        DVALIN_FAIL_ON: ${{ inputs.fail-on }}
+      run: |
+        if [ "${GATE_EXIT}" != "0" ]; then
+          echo "::error::Dvalin found findings at or above '${DVALIN_FAIL_ON}'."
+          exit 1
+        fi

--- a/docs/DVALIN.md
+++ b/docs/DVALIN.md
@@ -30,6 +30,7 @@ Run the same scanner suite without opening the GUI:
 dvalincode dvalin .
 dvalincode dvalin . --scanners builtin --limit 10
 dvalincode dvalin . --json
+dvalincode dvalin . --sarif dvalin.sarif
 dvalincode dvalin . --fail-on high
 dvalincode dvalin . --scanners builtin --fix
 dvalincode dvalin . --fix --verify
@@ -40,6 +41,40 @@ The default run detects all four engines and reports optional scanners that are
 not installed. `--fail-on` is opt-in so interactive scans remain informational;
 in CI it exits with code 2 when a finding at or above the selected severity is
 present.
+
+`--sarif <file>` additionally writes the result as SARIF 2.1.0, with
+`security-severity` on each rule and a stable fingerprint per finding so an
+unchanged finding is not re-alerted on every run. It composes with `--json` and
+with `--fix`, in which case it reflects the post-remediation state rather than
+the baseline.
+
+## GitHub Action
+
+The repository publishes itself as a composite action, so a scan needs nothing
+installed and no secrets:
+
+```yaml
+permissions:
+  contents: read
+  security-events: write   # to publish findings to code scanning
+  pull-requests: write     # only when comment: 'true'
+steps:
+  - uses: actions/checkout@v5
+  - uses: arthurpanhku/dvalincode@v0.14.1
+    with:
+      fail-on: high        # critical | high | medium | low | none
+      scanners: builtin    # add semgrep,trivy,osv-scanner if on PATH
+      comment: 'true'      # sticky PR comment, updated in place
+```
+
+The action uploads SARIF to code scanning, writes a job summary, and applies the
+severity gate *after* both — so a failing gate still leaves the findings visible.
+Inputs and outputs are documented in [`action.yml`](../action.yml); a complete
+workflow is in [`examples/dvalin-scan.yml`](examples/dvalin-scan.yml).
+
+Only `builtin` runs with no extra setup. The external engines are used when they
+are already on `PATH`, and are reported as `missing` rather than failing the run
+when they are not.
 
 `--fix` validates and remediates up to 20 findings in an isolated git worktree
 by default (`--max-fixes` changes the cap; `--in-place` is an explicit opt-in).

--- a/docs/DVALIN.md
+++ b/docs/DVALIN.md
@@ -60,7 +60,7 @@ permissions:
   pull-requests: write     # only when comment: 'true'
 steps:
   - uses: actions/checkout@v5
-  - uses: arthurpanhku/dvalincode@v0.14.1
+  - uses: arthurpanhku/dvalincode@v0.15.0
     with:
       fail-on: high        # critical | high | medium | low | none
       scanners: builtin    # add semgrep,trivy,osv-scanner if on PATH

--- a/docs/examples/dvalin-scan.yml
+++ b/docs/examples/dvalin-scan.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5   # pin by commit digest in production
 
-      - uses: arthurpanhku/dvalincode@v0.14.1
+      - uses: arthurpanhku/dvalincode@v0.15.0
         with:
           # Fail the build on high or critical findings. Use 'none' to report
           # without blocking while you work through the backlog.
@@ -30,6 +30,6 @@ jobs:
       # Optional: add the external engines. Dvalin picks up whatever is on PATH.
       #
       # - run: pipx install semgrep
-      # - uses: arthurpanhku/dvalincode@v0.14.1
+      # - uses: arthurpanhku/dvalincode@v0.15.0
       #   with:
       #     scanners: builtin,semgrep,trivy,osv-scanner

--- a/docs/examples/dvalin-scan.yml
+++ b/docs/examples/dvalin-scan.yml
@@ -1,0 +1,35 @@
+# Dvalin security scan — copy this into .github/workflows/ in your repository.
+#
+# No API key, no model, no account. Findings show up inline on the pull request
+# diff and in the Security tab.
+
+name: Security
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  dvalin:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write   # required to publish findings to code scanning
+      pull-requests: write     # only needed when comment: 'true'
+    steps:
+      - uses: actions/checkout@v5   # pin by commit digest in production
+
+      - uses: arthurpanhku/dvalincode@v0.14.1
+        with:
+          # Fail the build on high or critical findings. Use 'none' to report
+          # without blocking while you work through the backlog.
+          fail-on: high
+          comment: 'true'
+
+      # Optional: add the external engines. Dvalin picks up whatever is on PATH.
+      #
+      # - run: pipx install semgrep
+      # - uses: arthurpanhku/dvalincode@v0.14.1
+      #   with:
+      #     scanners: builtin,semgrep,trivy,osv-scanner

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dvalincode",
-  "version": "0.14.1",
+  "version": "0.15.0",
   "description": "A local-first, provider-neutral CLI foundation for agentic coding workflows.",
   "type": "module",
   "license": "MIT",

--- a/src/commands/dvalin.ts
+++ b/src/commands/dvalin.ts
@@ -1,4 +1,5 @@
 import path from 'node:path';
+import { mkdir, writeFile } from 'node:fs/promises';
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 import type { Command } from 'commander';
@@ -11,6 +12,7 @@ import {
   type DvalinScannerId,
   type DvalinScanSuiteResult,
 } from '../remediation/scannerSuite.js';
+import { buildDvalinSarif } from '../remediation/sarifExport.js';
 import {
   buildAutomatedFixPrompt,
   buildAutomatedVerificationPrompt,
@@ -37,6 +39,7 @@ type DvalinOptions = {
   inPlace?: boolean;
   maxFixes: string;
   provider?: string;
+  sarif?: string;
 };
 
 export function parseDvalinScannerIds(value: string): DvalinScannerId[] {
@@ -111,6 +114,7 @@ export function registerDvalinCommand(program: Command): void {
     .option('--timeout <seconds>', 'timeout for each external scanner', '300')
     .option('--limit <count>', 'maximum findings shown in text output', '20')
     .option('--json', 'print the complete scan result as JSON')
+    .option('--sarif <file>', 'also write the scan result as SARIF 2.1.0 (for GitHub code scanning)')
     .option('--fail-on <severity>', 'exit non-zero at or above: critical, high, medium, low, none', 'none')
     .option('--fix', 'validate and remediate findings with the configured agent in an isolated worktree')
     .option('--verify', 'after fixing, run tests and an independent security re-scan gate')
@@ -152,6 +156,14 @@ export function registerDvalinCommand(program: Command): void {
         });
       } else if (shouldFix) {
         console.log('\nNo findings require remediation.');
+      }
+      if (options.sarif) {
+        // Reflects the final state, so a --fix run uploads what is left rather
+        // than the pre-remediation baseline.
+        const sarifPath = path.resolve(process.cwd(), options.sarif);
+        await mkdir(path.dirname(sarifPath), { recursive: true });
+        await writeFile(sarifPath, `${JSON.stringify(buildDvalinSarif(thresholdResult, root), null, 2)}\n`, 'utf8');
+        if (!options.json) console.log(`\nSARIF written to ${sarifPath}`);
       }
       if (dvalinFailureThresholdMet(thresholdResult, failOn)) process.exitCode = 2;
     });

--- a/src/remediation/sarifExport.ts
+++ b/src/remediation/sarifExport.ts
@@ -1,0 +1,120 @@
+import path from 'node:path';
+import type { DvalinScanSuiteResult } from './scannerSuite.js';
+import type { RemediationFinding } from './sarif.js';
+
+/**
+ * Emit a scan suite result as SARIF 2.1.0.
+ *
+ * The target consumer is GitHub code scanning (`upload-sarif`), which renders
+ * findings inline on the pull request diff and in the Security tab. That
+ * imposes a few constraints beyond the base schema: locations must be
+ * repository-relative with forward slashes, `security-severity` must live on
+ * the rule as a numeric string, and every result needs a stable fingerprint so
+ * the same finding is not re-alerted on each run.
+ */
+
+const SARIF_SCHEMA = 'https://json.schemastore.org/sarif-2.1.0.json';
+const SARIF_VERSION = '2.1.0';
+
+type SarifLevel = 'error' | 'warning' | 'note' | 'none';
+
+export type DvalinSarifLog = {
+  $schema: string;
+  version: string;
+  runs: unknown[];
+};
+
+/** SARIF regions are 1-based; findings without a line anchor to the file head. */
+function startLine(finding: RemediationFinding): number {
+  const line = finding.startLine ?? 1;
+  return line > 0 ? line : 1;
+}
+
+function endLine(finding: RemediationFinding): number {
+  const start = startLine(finding);
+  const end = finding.endLine ?? start;
+  return end >= start ? end : start;
+}
+
+/** GitHub rejects absolute paths and Windows separators in artifact locations. */
+function artifactUri(filePath: string, root: string): string {
+  const relative = path.isAbsolute(filePath) ? path.relative(root, filePath) : filePath;
+  return relative.split(path.sep).join('/');
+}
+
+function toLevel(severity: RemediationFinding['severity']): SarifLevel {
+  return severity;
+}
+
+export function buildDvalinSarif(result: DvalinScanSuiteResult, root: string): DvalinSarifLog {
+  // One rule per ruleId. Findings that share a ruleId are the same rule, even
+  // when different scanners reported them.
+  const ruleIndex = new Map<string, number>();
+  const rules: unknown[] = [];
+
+  const results = result.findings.map(finding => {
+    let index = ruleIndex.get(finding.ruleId);
+    if (index === undefined) {
+      index = rules.length;
+      ruleIndex.set(finding.ruleId, index);
+      rules.push({
+        id: finding.ruleId,
+        name: finding.ruleName ?? finding.ruleId,
+        shortDescription: { text: finding.ruleName ?? finding.ruleId },
+        fullDescription: { text: finding.message },
+        ...(finding.helpUri ? { helpUri: finding.helpUri } : {}),
+        properties: {
+          tags: finding.tags,
+          // GitHub maps this number onto its own critical/high/medium/low bands.
+          ...(finding.securitySeverity ? { 'security-severity': finding.securitySeverity } : {}),
+        },
+      });
+    }
+    return {
+      ruleId: finding.ruleId,
+      ruleIndex: index,
+      level: toLevel(finding.severity),
+      message: { text: finding.message },
+      locations: [
+        {
+          physicalLocation: {
+            artifactLocation: { uri: artifactUri(finding.path, root) },
+            region: { startLine: startLine(finding), endLine: endLine(finding) },
+          },
+        },
+      ],
+      // Keeps an unchanged finding from re-alerting on every scan.
+      partialFingerprints: { dvalinFindingId: finding.id },
+      properties: { scanner: finding.source },
+    };
+  });
+
+  return {
+    $schema: SARIF_SCHEMA,
+    version: SARIF_VERSION,
+    runs: [
+      {
+        tool: {
+          driver: {
+            name: 'Dvalin',
+            informationUri: 'https://github.com/arthurpanhku/dvalincode',
+            rules,
+          },
+        },
+        results,
+        invocations: [
+          {
+            executionSuccessful: true,
+            startTimeUtc: result.startedAt,
+            endTimeUtc: result.completedAt,
+          },
+        ],
+        properties: {
+          score: result.score,
+          grade: result.grade,
+          scanners: result.scanners.map(scanner => ({ id: scanner.id, status: scanner.status })),
+        },
+      },
+    ],
+  };
+}

--- a/src/version.ts
+++ b/src/version.ts
@@ -5,4 +5,4 @@
  * Everything that reports a version — the CLI `--version`, the trust report, and
  * the self-update check — imports from here so the copies can never drift.
  */
-export const VERSION = '0.14.1';
+export const VERSION = '0.15.0';

--- a/tests/remediationSarifExport.test.ts
+++ b/tests/remediationSarifExport.test.ts
@@ -1,0 +1,97 @@
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { buildDvalinSarif } from '../src/remediation/sarifExport.js';
+import type { DvalinScanSuiteResult } from '../src/remediation/scannerSuite.js';
+import type { RemediationFinding } from '../src/remediation/sarif.js';
+
+const ROOT = path.sep === '\\' ? 'C:\\repo' : '/repo';
+
+function finding(overrides: Partial<RemediationFinding> = {}): RemediationFinding {
+  return {
+    id: 'LocalScan:dvalin-eval:app.js:3',
+    source: 'Dvalin Local Scan',
+    ruleId: 'dvalin/eval',
+    ruleName: 'Dynamic code execution',
+    severity: 'warning',
+    securitySeverity: '7.5',
+    message: 'Dynamic code execution detected.',
+    path: 'app.js',
+    startLine: 3,
+    endLine: 3,
+    helpUri: 'https://cwe.mitre.org/data/definitions/94.html',
+    tags: ['security', 'cwe-094'],
+    prompt: 'irrelevant to SARIF',
+    ...overrides,
+  };
+}
+
+function suite(findings: RemediationFinding[]): DvalinScanSuiteResult {
+  return {
+    id: 'scan-1',
+    source: 'Dvalin Security Suite',
+    startedAt: '2026-08-07T00:00:00.000Z',
+    completedAt: '2026-08-07T00:00:01.000Z',
+    score: 88,
+    grade: 'B',
+    findings,
+    totalResults: findings.length,
+    skippedResults: 0,
+    scanners: [],
+    metrics: { critical: 0, high: findings.length, medium: 0, low: 0, files: 1, rules: 1 },
+  };
+}
+
+function firstRun(log: ReturnType<typeof buildDvalinSarif>): any {
+  return log.runs[0] as any;
+}
+
+describe('buildDvalinSarif', () => {
+  it('emits a SARIF 2.1.0 log with one rule per ruleId', () => {
+    const log = buildDvalinSarif(suite([finding(), finding({ id: 'second', startLine: 9 })]), ROOT);
+    expect(log.version).toBe('2.1.0');
+    const run = firstRun(log);
+    expect(run.tool.driver.rules).toHaveLength(1);
+    expect(run.results).toHaveLength(2);
+    expect(run.results[1].ruleIndex).toBe(0);
+  });
+
+  it('puts security-severity on the rule so GitHub can band the alert', () => {
+    const run = firstRun(buildDvalinSarif(suite([finding()]), ROOT));
+    expect(run.tool.driver.rules[0].properties['security-severity']).toBe('7.5');
+    expect(run.tool.driver.rules[0].helpUri).toBe('https://cwe.mitre.org/data/definitions/94.html');
+  });
+
+  it('emits repository-relative locations with forward slashes', () => {
+    const absolute = path.join(ROOT, 'src', 'app.js');
+    const run = firstRun(buildDvalinSarif(suite([finding({ path: absolute })]), ROOT));
+    expect(run.results[0].locations[0].physicalLocation.artifactLocation.uri).toBe('src/app.js');
+  });
+
+  it('anchors findings without a line to line 1 and never inverts the region', () => {
+    const run = firstRun(
+      buildDvalinSarif(suite([finding({ startLine: undefined, endLine: undefined })]), ROOT),
+    );
+    const region = run.results[0].locations[0].physicalLocation.region;
+    expect(region.startLine).toBe(1);
+    expect(region.endLine).toBe(1);
+  });
+
+  it('keeps the end line at or after the start line when a scanner reports them reversed', () => {
+    const run = firstRun(buildDvalinSarif(suite([finding({ startLine: 12, endLine: 4 })]), ROOT));
+    const region = run.results[0].locations[0].physicalLocation.region;
+    expect(region.endLine).toBe(region.startLine);
+  });
+
+  it('carries a stable fingerprint so unchanged findings do not re-alert', () => {
+    const run = firstRun(buildDvalinSarif(suite([finding()]), ROOT));
+    expect(run.results[0].partialFingerprints.dvalinFindingId).toBe('LocalScan:dvalin-eval:app.js:3');
+  });
+
+  it('omits optional rule fields a scanner did not provide', () => {
+    const run = firstRun(
+      buildDvalinSarif(suite([finding({ helpUri: undefined, securitySeverity: undefined })]), ROOT),
+    );
+    expect(run.tool.driver.rules[0]).not.toHaveProperty('helpUri');
+    expect(run.tool.driver.rules[0].properties).not.toHaveProperty('security-severity');
+  });
+});


### PR DESCRIPTION
## Summary

Makes the Dvalin scan reachable without installing anything, and reorders the README so the first screen offers a reason to try it.

**1. `--sarif <file>` on `dvalincode dvalin`** (`fdb16b1`)

Dvalin already consumed SARIF from Semgrep, Trivy, and OSV-Scanner but could not emit it, so results could not be handed to GitHub code scanning or any other SARIF consumer. The output targets GitHub's constraints specifically: `security-severity` on the rule (what GitHub bands alerts by), repository-relative locations with forward slashes, and a stable per-finding fingerprint so an unchanged finding is not re-alerted every run. Composes with `--json`; with `--fix` it reflects the post-remediation state, not the baseline.

**2. A composite GitHub Action** (`57af645`)

A scan needs no API key, no model, and no config — but until now it needed an install first. The repository now publishes itself as an action, so a scan costs one `uses:` line and zero secrets:

```yaml
- uses: arthurpanhku/dvalincode@v0.14.1
  with:
    fail-on: high
```

It scans → uploads SARIF to code scanning (findings land inline on the PR diff) → writes a job summary → optionally posts a sticky PR comment → applies the severity gate **last**, so a failing gate still leaves the findings visible instead of aborting before they are published. `upload-sarif` is pinned by digest, matching this repo's own workflows.

**3. README reordered around the scan** (`35617ad`)

The first screen led with "the agent your security team can actually approve" — what a CISO buys, but not what makes a developer run the install command. The person who benefits was not the person being asked to act. Now: outcome headline → `npx dvalincode dvalin .` → the Action → `--fix --verify --draft-pr` (flagged as the step that does use a model) → governance as its own second-screen section, reached from `report verify`, with the three compliance badges moved down to join it.

The previous first command was a `curl … | bash`, which is a weak opening move for a tool whose audience is security-conscious.

## Testing

- `npm run check` — 323 tests / 49 files, all green (7 new SARIF export tests).
- SARIF output verified end-to-end against a fixture repo with a real `eval` finding: valid SARIF 2.1.0, correct `--fail-on` exit codes (`high` → 2, `critical` → 0), and a valid empty log on a clean repo.
- `npx dvalincode dvalin .` verified to run with zero config — no provider resolution, no API key, no `trust` step.
- Both inline Node scripts in `action.yml` executed against real scan JSON; missing external scanners degrade to `missing` rather than failing the run.
- All three YAML files parse.
- CI now dogfoods the action via `uses: ./`, which doubles as the smoke test for `action.yml`.

## Security and AI Governance

- [x] This change does not expand file, shell, network, model, or approval permissions.
- [x] If it changes agent behavior, prompts, policy, providers, audit logging, or release/build security, I updated the relevant governance evidence in `docs/`.
- [ ] If it introduces a new model/provider/tool or new data flow, I completed `docs/governance/AI-CHANGE-IMPACT-ASSESSMENT.md`.

On the third box — deliberately unticked rather than silently skipped. The assessment template covers agent permissions, prompts, model/provider handling, audit, and release security; this change touches none of them, and the scan path invokes no model at all. Two things a reviewer should still weigh:

- The action publishes scan findings to GitHub code scanning and (opt-in) to a PR comment. That is a new outbound flow, though it stays inside the user's own repository and uses `github.token`.
- The action resolves `dvalincode@latest` from npm at CI time. That is a deliberate trade for zero-install convenience; pinning `version:` is supported for anyone who wants it.

Neither involves the model path or the policy chokepoint. Say the word if you'd rather I fill out the assessment anyway.

## Notes

**⚠️ Merge order matters — this PR is not self-consistent until a release ships.**

The README and `docs/examples/dvalin-scan.yml` reference `arthurpanhku/dvalincode@v0.14.1`, but `action.yml` is not in that tag, and the npm `dvalincode@0.14.0` that `npx` resolves has no `--sarif`. Both snippets on the new first screen will fail for anyone who tries them before a release. Either:

1. `npm publish` a version containing `--sarif`, then tag it, then merge this; or
2. change both references to `@main`, merge, and switch back to a tag after release.

Happy to do (2) if you'd rather land the review first.

**Branch base.** Built on current `main` (`2ed2686`), not the older tree I started from. That was deliberate: `#151` had already corrected the contradictory test counts and `#153` had re-shot the README figures (22/100 F, 10 findings). Both are preserved intact — the only test-count edit here is 316 → 323, caused by the 7 tests this branch adds.

**`.dvalincodeignore`.** The CI self-scan surfaced 4 findings, all of them the scanner's own test fixtures — files whose vulnerable-looking strings are the thing under test. Three files are excluded, with a note in the file that the list stays surgical: excluding a file because a finding is inconvenient defeats the point. Verified afterwards that `src/` is still scanned by planting a real `eval` and confirming it was caught.
