### PR TITLE
fix(release): resolve a relative --bin before the governed runs

### DIFF
--- a/scripts/release-evidence.mjs
+++ b/scripts/release-evidence.mjs
@@ -64,8 +64,26 @@ function parseArgs(argv) {
 const args = parseArgs(process.argv.slice(2));
 const repoDir = path.resolve(args.repo ?? ROOT);
 const outFile = path.resolve(args.out ?? path.join(ROOT, 'release', `dvalincode-v${VERSION}-evidence.json`));
-const binCommand = (args.bin ?? defaultBin()).trim();
+const binCommand = absoluteCommand((args.bin ?? defaultBin()).trim());
 const sumsFile = args.sums ? path.resolve(args.sums) : path.join(ROOT, 'release', 'SHA256SUMS.txt');
+
+/**
+ * Pin every path-like token in the CLI command to an absolute path.
+ *
+ * The two governed runs deliberately spawn with different working directories —
+ * the repo for the allowed run, a throwaway workspace for the denied one — so a
+ * relative `--bin` resolves for the first and fails with ENOENT for the second.
+ * `defaultBin()` is already absolute, which is why this only bites callers that
+ * pass `--bin`, as the release workflow does.
+ *
+ * Bare command names (`node`) carry no separator and are left for PATH lookup.
+ */
+function absoluteCommand(command) {
+  return command
+    .split(/\s+/)
+    .map(token => (/[\\/]/.test(token) ? path.resolve(token) : token))
+    .join(' ');
+}
 
 /** Prefer the freshly built release binary for this host; fall back to dist/. */
 function defaultBin() {


### PR DESCRIPTION
## Summary

The `v0.15.0` release failed in **Build release Evidence Pack**, so no GitHub Release was produced:

```
✓ allowed run 2026-08-07T16-47-39-074Z-… — 1 tool call(s), exit 0
release-evidence: denied  run produced no JSON result (exit 127)
Error: spawn release/evidence-bin/dvalincode-macos-arm64/dvalincode-macos-arm64 ENOENT
```

The same binary worked seconds earlier, which is the tell. The two governed runs spawn with deliberately different working directories — `repoDir` for the allowed run, a throwaway `denyWorkspace` for the denied one. `release.yml` derives `--bin` from `find release/evidence-bin …`, which yields a **relative** path, so it resolved for the first run and could not be found from the second.

`defaultBin()` returns absolute paths, so this never reproduced locally. It only surfaced now because the Evidence Pack step landed in #146, *after* v0.14.1 shipped — **v0.15.0 is the first release to ever execute it.**

Path-like tokens in the `--bin` command are now resolved to absolute paths up front. Bare command names (`node`) carry no separator and are left for PATH lookup.

## Why this matters beyond a red build

The denied run is the half of the Evidence Pack that proves policy *blocks* things. With it failing, the release could never ship the artifact the README points reviewers at — and had the step been non-fatal, it would have shipped a pack with zero recorded denials while still claiming to demonstrate enforcement.

## Testing

Reproduced first, then fixed:

| `--bin` | before | after |
|---|---|---|
| relative (`node dist/index.js`) | `MODULE_NOT_FOUND`, run 2 dies | `2 verified runs, 1 recorded denial(s), 6/6 controls backed` |
| absolute | passed | passed (no regression) |
| default (omitted) | passed | passed (no regression) |

`npm run check` — 323 tests / 49 files, all green.

## Security and AI Governance

- [x] This change does not expand file, shell, network, model, or approval permissions.
- [x] If it changes agent behavior, prompts, policy, providers, audit logging, or release/build security, I updated the relevant governance evidence in `docs/`.
- [x] If it introduces a new model/provider/tool or new data flow, I completed `docs/governance/AI-CHANGE-IMPACT-ASSESSMENT.md`.

Second box: this touches release tooling, but it restores the documented behaviour in `docs/RELEASE-EVIDENCE.md` rather than changing it, so there was no evidence doc to update. Third box: no new model, provider, tool, or data flow — the fix is path resolution.

## Notes

**The `v0.15.0` tag currently points at a commit without this fix** (`9f5fa04`), so re-running the release needs a decision:

- **Re-point `v0.15.0`** to the fixed commit. The failed run published no Release and no artifacts, so nothing downstream ever consumed that tag, and npm `0.15.0` is unaffected — `scripts/` is not in the package `files`, so the published CLI never contained this bug. Keeps one coherent version.
- **Bump to `v0.15.1`**, which needs another `npm publish` to keep npm and the tags in step.

I'd take the first: the shipped artifact is already correct and the tag never produced anything to invalidate. Moving a public tag is the caller's call, though, so I have not touched it.
