### PR TITLE
feat(release): publish to npm from the tag, with provenance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,10 +10,20 @@ name: Release (CLI + Web bundle)
 # The native desktop GUI app ships on a separate, experimental pre-release
 # track — see .github/workflows/release-gui.yml.
 #
+# Pushing a version tag does everything: build, Evidence Pack, provenance,
+# the GitHub Release, and the npm publish. There is no manual publish step —
+# npm previously drifted from the tags because that step was done by hand.
+#
 # Recommended flow:
-#   1. Run manually (workflow_dispatch) → download + inspect the artifacts.
-#   2. When satisfied, push the version tag to publish:
+#   1. Bump the version in BOTH package.json and src/version.ts (they are
+#      separate constants; the npm job refuses a tag that disagrees with
+#      package.json).
+#   2. Run manually (workflow_dispatch) → download + inspect the artifacts.
+#      A manual run never publishes: every publishing job is tag-gated.
+#   3. When satisfied, push the version tag:
 #        git tag v0.7.0 && git push origin v0.7.0
+#
+# Requires the NPM_TOKEN repository secret (an npm Automation token).
 
 on:
   push:
@@ -208,3 +218,64 @@ jobs:
             release/dvalincode-v*-windows-x64.zip
             release/dvalincode-v*-evidence.json
             release/SHA256SUMS.txt
+
+  # npm has drifted from the git tags before: v0.14.1 was tagged and released on
+  # GitHub but never published to npm, so `npx dvalincode` served a stale build
+  # until someone noticed. This closes that gap by hand-off, not by discipline.
+  npm:
+    name: Publish to npm
+    needs: [build, attest]
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write   # npm provenance attestation
+    steps:
+      # actions/checkout v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          persist-credentials: false
+      # actions/setup-node v6.4.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+        with:
+          node-version: 22
+          cache: npm
+          registry-url: https://registry.npmjs.org
+
+      # A tag that disagrees with package.json would publish a version nobody
+      # can trace back to a release. Fail loudly instead.
+      - name: Check the tag matches package.json
+        id: version
+        run: |
+          tag="${GITHUB_REF_NAME#v}"
+          pkg="$(node -p "require('./package.json').version")"
+          if [ "$tag" != "$pkg" ]; then
+            echo "::error::Tag ${GITHUB_REF_NAME} does not match package.json ${pkg}."
+            exit 1
+          fi
+          echo "version=${pkg}" >> "$GITHUB_OUTPUT"
+
+      # Re-running a release (a moved tag, a retried job) must not turn into a
+      # red build just because the version is already on the registry.
+      - name: Skip when the version is already published
+        id: published
+        run: |
+          if npm view "dvalincode@${{ steps.version.outputs.version }}" version >/dev/null 2>&1; then
+            echo "already=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::dvalincode@${{ steps.version.outputs.version }} is already on npm — skipping publish."
+          else
+            echo "already=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Install dependencies
+        if: steps.published.outputs.already == 'false'
+        run: npm ci
+
+      # `prepublishOnly` re-runs the build and the full check before anything
+      # leaves the runner. --provenance ties the published tarball to this
+      # workflow run, the same guarantee the release archives get from attest.
+      - name: Publish
+        if: steps.published.outputs.already == 'false'
+        run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

Publishing to npm was a manual step, and it was already missed once: **v0.14.1 was tagged and had a GitHub Release, but was never published to npm**, so `npx dvalincode` served 0.14.0 for a month until it happened to get checked during the 0.15.0 release.

That used to be an inconvenience. Now that the README leads with `npx dvalincode dvalin .`, a missed publish means the first command on the front page is broken — so the hand-off moves into the workflow.

Pushing a version tag now builds, produces the Evidence Pack, attests, publishes the GitHub Release, **and publishes to npm**.

## Guards

Two, both of which map to things that actually happened this week:

- **Tag must match `package.json`.** A mismatch fails loudly rather than publishing a version no release points at. Relevant because the version lives in two separate constants (`package.json` and `src/version.ts`) — `src/version.ts` was still on 0.14.1 during the 0.15.0 prep and would have shipped a CLI that misreported itself.
- **An already-published version is skipped with a notice, not a failure.** Re-running a release must stay green. Moving the `v0.15.0` tag today would have hit exactly this case, since 0.15.0 was already on the registry.

`--provenance` ties the published tarball to the workflow run, giving the npm artifact the same traceability the release archives get from the `attest` job. `prepublishOnly` still re-runs `npm run build && npm run check` before anything leaves the runner.

Every publishing job is tag-gated (`startsWith(github.ref, 'refs/tags/')`), so `workflow_dispatch` remains a safe dry run.

## Testing

The two guard conditions were exercised against the live registry before wiring them in:

| case | result |
|---|---|
| `npm view dvalincode@0.15.0` (published) | found → publish skipped |
| `npm view dvalincode@9.9.9` (absent) | not found → publish proceeds |
| tag `v0.15.0` vs `package.json` 0.15.0 | match → proceeds |
| tag `v0.99.0` vs `package.json` 0.15.0 | mismatch → fails |

Workflow YAML parses; all four jobs and their `if` gates confirmed.

The publish path itself cannot be exercised without the secret and a real tag — the first live run will be the next release.

## Security and AI Governance

- [x] This change does not expand file, shell, network, model, or approval permissions.
- [x] If it changes agent behavior, prompts, policy, providers, audit logging, or release/build security, I updated the relevant governance evidence in `docs/`.
- [ ] If it introduces a new model/provider/tool or new data flow, I completed `docs/governance/AI-CHANGE-IMPACT-ASSESSMENT.md`.

Second box: this is release security. The workflow header documented a flow where npm was a human's job to remember, and that comment is now corrected in the same commit; no separate evidence doc covers the release runbook.

Third box, deliberately unticked: this does add an outbound flow — the release pipeline now pushes a tarball to registry.npmjs.org — and grants `id-token: write` to the new job for provenance. It involves no model, provider, or agent tool, so the assessment template does not fit, but a reviewer should weigh those two facts on their own terms.

## Notes — action required before this helps

**Add an `NPM_TOKEN` repository secret** (Settings → Secrets and variables → Actions). It must be an npm **Automation** token; Automation tokens bypass 2FA on publish, which a CI publish requires.

Until the secret exists, the npm job will fail on the next tag while everything else still succeeds.

**Unrelated but urgent:** the token intended for this was pasted in plaintext into a chat transcript. It should be revoked on npmjs.com and replaced with a freshly generated one before being added as a secret.
