### PR TITLE
fix: type-check src/gui instead of excluding it

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dvalincode",
-  "version": "0.14.1",
+  "version": "0.15.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dvalincode",
-      "version": "0.14.1",
+      "version": "0.15.0",
       "license": "MIT",
       "dependencies": {
         "chalk": "^6.0.0",
@@ -23,6 +23,7 @@
         "dvalincode": "dist/index.js"
       },
       "devDependencies": {
+        "@types/bun": "^1.3.14",
         "@types/cors": "^2.8.17",
         "@types/express": "^5.0.3",
         "@types/node": "^26.1.0",
@@ -1691,6 +1692,16 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/bun": {
+      "version": "1.3.14",
+      "resolved": "https://registry.npmjs.org/@types/bun/-/bun-1.3.14.tgz",
+      "integrity": "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bun-types": "1.3.14"
+      }
+    },
     "node_modules/@types/chai": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
@@ -2739,6 +2750,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/bun-types": {
+      "version": "1.3.14",
+      "resolved": "https://registry.npmjs.org/bun-types/-/bun-types-1.3.14.tgz",
+      "integrity": "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/bytes": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "test": "vitest run",
     "test:e2e": "playwright test",
     "typecheck": "tsc -p tsconfig.json --noEmit",
-    "check": "npm run typecheck && npm test",
+    "check": "npm run typecheck && npm run typecheck:gui && npm test",
     "prepublishOnly": "npm run build && npm run check",
     "build:release": "bash scripts/build-release.sh",
     "build:release:darwin": "bash scripts/build-release.sh darwin",
@@ -41,7 +41,8 @@
     "gui:dev": "bun src/gui/index.ts",
     "build:gui": "bash scripts/build-gui.sh",
     "build:gui:darwin": "bash scripts/build-gui.sh darwin",
-    "notices:update": "node scripts/generate-third-party-notices.mjs"
+    "notices:update": "node scripts/generate-third-party-notices.mjs",
+    "typecheck:gui": "tsc -p tsconfig.gui.json"
   },
   "keywords": [
     "cli",
@@ -65,6 +66,7 @@
     "zod": "^4.1.13"
   },
   "devDependencies": {
+    "@types/bun": "^1.3.14",
     "@types/cors": "^2.8.17",
     "@types/express": "^5.0.3",
     "@types/node": "^26.1.0",

--- a/src/gui/index.ts
+++ b/src/gui/index.ts
@@ -39,7 +39,9 @@ if (process.env.DVALINCODE_GUI_ROLE === 'server') {
 
   // The server prints "…http://localhost:<port>" once it's listening. Keep
   // draining stdout afterwards so the child never blocks on a full pipe.
-  let resolveUrl: (url: string) => void;
+  // Definite assignment: a Promise executor runs synchronously, so this is set
+  // before the reader below can reach it — TypeScript cannot see that.
+  let resolveUrl!: (url: string) => void;
   const urlPromise = new Promise<string>((resolve) => (resolveUrl = resolve));
   (async () => {
     const decoder = new TextDecoder();

--- a/tsconfig.gui.json
+++ b/tsconfig.gui.json
@@ -1,0 +1,21 @@
+{
+  // src/gui runs under Bun, not Node, so it cannot join the main tsconfig: it
+  // uses `Bun`, `import.meta.path`, and webview-bun's FFI types. It was simply
+  // excluded, which left it unchecked while it imports from src/core — a
+  // signature change there would only surface during a GUI release.
+  //
+  // `exclude` must be restated. It is inherited from the base config, and an
+  // inherited exclude wins over the include below, which silently turns this
+  // whole check into a no-op.
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    // Bun resolves like a bundler, not like Node. nodenext makes TypeScript
+    // reject webview-bun's own extensionless relative imports.
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "types": ["bun"],
+    "noEmit": true
+  },
+  "include": ["src/gui/**/*.ts", "src/core/**/*.ts", "src/version.ts"],
+  "exclude": ["dist", "node_modules"]
+}


### PR DESCRIPTION
## Summary

`src/gui` was listed in `tsconfig.json`'s `exclude` and has no tests, yet it imports from `src/core/guiUpdate.js`, `src/core/selfUpdate.js`, and `src/version.js`. Nothing checked it, so a signature change in `core` would only surface when `release-gui.yml` runs — which was three weeks ago.

It cannot just join the main tsconfig: it runs under Bun, using `Bun`, `import.meta.path`, and webview-bun's FFI types, and Bun resolves modules like a bundler rather than like Node. So it gets `tsconfig.gui.json`, wired into `npm run check` as `typecheck:gui`.

## Two things the check found once it was actually running

**The first version of this config checked nothing.** `exclude` is inherited from the base config and beats the `include` in the derived one, so `src/gui` stayed excluded — the check reported success with a deliberate type error sitting in `src/gui/index.ts`. Restating `exclude` fixes it, and the comment says why so it does not get "simplified" back later. A check that cannot fail is worse than no check: it manufactures confidence.

**`resolveUrl` tripped TS2454** (used before assigned). A Promise executor runs synchronously, so it is assigned before the reader can reach it — this is a false positive, and a definite assignment assertion states what TypeScript cannot infer. Not a behaviour change.

## Testing

Verified the check can actually fail, twice: planted `const __p: number = "x"` in `src/gui/index.ts`, confirmed `typecheck:gui` reports the error, removed it, confirmed the check passes. Without that step this PR would have looked identical while doing nothing.

`npm run check` green: typecheck, typecheck:gui, and 323 tests across 49 files.

## Security and AI Governance

- [x] This change does not expand file, shell, network, model, or approval permissions.
- [x] If it changes agent behavior, prompts, policy, providers, audit logging, or release/build security, I updated the relevant governance evidence in `docs/`.
- [x] If it introduces a new model/provider/tool or new data flow, I completed `docs/governance/AI-CHANGE-IMPACT-ASSESSMENT.md`.

Second and third boxes: this adds a type check and one `!` assertion. No runtime behaviour, no new model, provider, tool, or data flow. `@types/bun` is added as a devDependency.

## Notes

Found while auditing which workflow steps have never executed under real conditions. The other finding from that audit is not fixed here and needs your decision: **the macOS binaries ship ad-hoc signed and Gatekeeper-rejected** — verified on the actual v0.15.0 download with `codesign` (`Signature=adhoc`, `TeamIdentifier=not set`) and `spctl` (`rejected`). Four signing and notarization steps across `release.yml` and `release-gui.yml` have never run because none of the six Apple secrets are configured. That needs an Apple Developer account, so it is a product decision, not a patch.