### PR TITLE
feat(mcp): expose dvalin_scan so any agent can call the scanner

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,22 @@ Findings land inline on the pull request diff and in your Security tab.
 No API key, no secrets, no model — the scan is deterministic and local to the
 runner. [Full example →](docs/examples/dvalin-scan.yml)
 
+### Or let your agent call it
+
+If an agent is writing the code, something other than that agent has to check
+it. DvalinCode is an MCP server, so any agent that speaks MCP can:
+
+```sh
+claude mcp add dvalin -- npx -y dvalincode mcp-serve --workspace .
+```
+
+`dvalin_scan` is read-only and deterministic — no model runs, no credentials are
+needed, no files are touched — so an agent can call it after every edit. A real
+call against a vulnerable fixture returns in ~170ms with a ~600 byte payload.
+The same server also exposes `dvalin_run_task` for delegating a whole governed
+task, plus the session and audit-evidence tools.
+[Agent integrations →](integrations/)
+
 ### Then let it fix what it found
 
 ```sh

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -52,6 +52,20 @@ steps:
 不需要任何 secret、不调用模型 —— 扫描是确定性的，且只在 runner 本地进行。
 [完整示例 →](docs/examples/dvalin-scan.yml)
 
+### 或者让你的 agent 调用它
+
+如果代码是 agent 写的，那检查它的就不能是同一个 agent。DvalinCode 本身是个 MCP
+server，任何支持 MCP 的 agent 都能接：
+
+```sh
+claude mcp add dvalin -- npx -y dvalincode mcp-serve --workspace .
+```
+
+`dvalin_scan` 只读且确定性 —— 不跑模型、不需要任何凭据、不改文件 —— 所以 agent
+可以每次改完就调一次。对一个真实漏洞样本的实测：约 170ms 返回，payload 约 600 字节。
+同一个 server 还提供 `dvalin_run_task`（委派完整的受管任务）以及会话、审计证据工具。
+[Agent 集成 →](integrations/)
+
 ### 然后让它把找到的问题修掉
 
 ```sh

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -1,0 +1,19 @@
+# Integrations
+
+Ways to reach DvalinCode from something other than its own CLI.
+
+| Path | What it is |
+|---|---|
+| [`claude-code/`](claude-code/) | A Claude Code skill that runs a Dvalin scan and reads the result. |
+| [`../editors/vscode/`](../editors/vscode/) | The VS Code extension — findings in the Problems panel. |
+| [`../action.yml`](../action.yml) | The GitHub Action — findings on the pull request diff. |
+| `dvalincode mcp-serve` | The MCP server, for any agent that speaks MCP. See the repository README. |
+
+## Two different things called "skills"
+
+- **DvalinCode skills** are DvalinCode's own portable instruction bundles, a
+  JSON format stored under `~/.dvalincode/skills`. See [docs/SKILLS.md](../docs/SKILLS.md).
+- **Claude Code skills** are Anthropic's `SKILL.md` directory format, loaded by
+  Claude Code. That is what lives in `claude-code/skills/`.
+
+They are unrelated formats that happen to share a word.

--- a/integrations/claude-code/README.md
+++ b/integrations/claude-code/README.md
@@ -1,0 +1,51 @@
+# DvalinCode in Claude Code
+
+Two independent ways to use them together. The MCP server is the richer one; the
+skill works with nothing but `npx`.
+
+## MCP server
+
+```sh
+claude mcp add dvalin -- npx -y dvalincode mcp-serve --workspace .
+```
+
+Or in `.mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "dvalin": {
+      "command": "npx",
+      "args": ["-y", "dvalincode", "mcp-serve", "--workspace", "."]
+    }
+  }
+}
+```
+
+This exposes four tools:
+
+| Tool | Needs a model? | Notes |
+|---|---|---|
+| `dvalin_scan` | no | Read-only, deterministic, no credentials. Safe to call after every edit. |
+| `dvalin_run_task` | yes | Delegates a whole governed coding task; needs DvalinCode's provider configured. |
+| `dvalin_get_session` | no | Session summary and its audit anchor. |
+| `dvalin_get_evidence` | no | The Markdown audit trail for a run. |
+
+`--workspace` bounds what the server will touch; a call naming a path outside it
+is refused.
+
+## Skill
+
+Copy the skill into a project or your home directory:
+
+```sh
+mkdir -p .claude/skills
+cp -R integrations/claude-code/skills/dvalin-security-scan .claude/skills/
+```
+
+It teaches Claude when to scan, how to read the result, and — as importantly —
+not to declare code secure because a scan came back clean.
+
+The skill uses `npx -y dvalincode` when no MCP server is configured, so it works
+with nothing installed. With the MCP server configured it uses `dvalin_scan`
+instead, which is faster since there is no per-call process start.

--- a/integrations/claude-code/skills/dvalin-security-scan/SKILL.md
+++ b/integrations/claude-code/skills/dvalin-security-scan/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: dvalin-security-scan
+description: Scan code for injection, hardcoded secrets, XSS, dynamic code execution, and unsafe shell use. Use after writing or modifying code that handles user input, builds queries or commands, touches authentication, or adds a dependency — and whenever the user asks for a security check, audit, or review. Runs locally with no API key and no model.
+---
+
+# Dvalin security scan
+
+A deterministic scanner. No model runs, nothing is sent anywhere, and it never
+edits files — so it is safe to call as often as you like, including on code you
+just wrote yourself.
+
+## Running it
+
+If a `dvalin` MCP server is configured, call `dvalin_scan`. Otherwise:
+
+```sh
+npx -y dvalincode dvalin . --scanners builtin --json
+```
+
+Scan the whole workspace — the scanner takes a directory, not a file. `builtin`
+needs nothing installed. Add `semgrep`, `trivy`, or `osv-scanner` only if they
+are already on `PATH`; missing engines are reported, not fatal.
+
+## Reading the result
+
+```json
+{ "score": 88, "grade": "B", "metrics": { "critical": 0, "high": 1 },
+  "findings": [ { "ruleId": "dvalin/eval", "path": "app.js", "startLine": 3,
+                  "securitySeverity": "7.5", "helpUri": "https://cwe.mitre.org/..." } ] }
+```
+
+Report findings by **file and line**, with the rule and why it matters. Cite
+`helpUri` when the user may not know the vulnerability class. `securitySeverity`
+is CVSS-shaped: ≥9 critical, ≥7 high, ≥4 medium.
+
+## What to do next
+
+Fix findings the way you would fix any other bug: read the surrounding code
+first, then make the smallest change that removes the vulnerability class
+rather than the symptom. Add a regression test that fails on the old code.
+Re-run the scan to confirm.
+
+If the user wants Dvalin itself to do the repair under policy, with tests and a
+clean re-scan required before anything can become a PR:
+
+```sh
+dvalincode dvalin . --fix --verify --draft-pr
+```
+
+That command **does** use a model and edits files, so propose it rather than
+running it unprompted.
+
+## Honest limits
+
+- A clean scan is not proof the code is safe. It finds known high-signal
+  patterns; it does not find business-logic flaws, and it can produce false
+  positives. Say so instead of declaring the code secure.
+- Do not suppress a finding to make the scan pass. If something is genuinely a
+  test fixture, exclude that path in `.dvalincodeignore` and say why.
+- The score is a triage heuristic, not a certification. Lead with the findings,
+  not the number.

--- a/server.json
+++ b/server.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-07-09/server.schema.json",
+  "name": "io.github.arthurpanhku/dvalincode",
+  "description": "Deterministic security scanning and governed coding tasks. dvalin_scan is read-only and needs no model or credentials.",
+  "repository": {
+    "url": "https://github.com/arthurpanhku/dvalincode",
+    "source": "github"
+  },
+  "version": "0.15.0",
+  "packages": [
+    {
+      "registryType": "npm",
+      "identifier": "dvalincode",
+      "version": "0.15.0",
+      "transport": {
+        "type": "stdio"
+      },
+      "runtimeArguments": [
+        {
+          "type": "positional",
+          "value": "mcp-serve",
+          "isRequired": true
+        },
+        {
+          "type": "named",
+          "name": "--workspace",
+          "description": "Workspace root the server is allowed to touch. Repeatable. Defaults to the working directory.",
+          "isRepeated": true
+        },
+        {
+          "type": "named",
+          "name": "--max-permission-mode",
+          "description": "Permission ceiling for dvalin_run_task: plan, auto, or bypass. Defaults to auto.",
+          "isRequired": false
+        }
+      ]
+    }
+  ]
+}

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -13,9 +13,18 @@ import {
   type HarnessRunRequest,
 } from '../harness/run.js';
 import type { UnattendedPermissionMode } from '../core/policy.js';
+import {
+  runDvalinScanSuite,
+  type DvalinScannerId,
+  type DvalinScanSuiteResult,
+} from '../remediation/scannerSuite.js';
 import { readJournal, type JournalTurnEnd } from '../sessions/journal.js';
 import { loadSession, type Session } from '../sessions/store.js';
 import { VERSION } from '../version.js';
+
+const SCANNER_IDS: DvalinScannerId[] = ['builtin', 'semgrep', 'trivy', 'osv-scanner'];
+/** Keeps a large scan from flooding the caller's context window. */
+const DEFAULT_FINDING_LIMIT = 50;
 
 type JsonRpcId = string | number | null;
 type JsonRpcResponse = {
@@ -40,6 +49,7 @@ export type McpServerOptions = {
 
 export type McpServerDependencies = {
   executeRun: (request: HarnessRunRequest, hooks?: HarnessRunHooks) => Promise<HarnessRunExecution>;
+  runScan: (cwd: string, options: { scanners?: DvalinScannerId[]; timeoutMs?: number }) => Promise<DvalinScanSuiteResult>;
   loadSession: (id: string) => Promise<Session | null>;
   renderReport: (runId: string) => string;
   latestRun: () => string | null;
@@ -50,6 +60,32 @@ export type DvalinMcpServer = {
 };
 
 const MCP_TOOLS = [
+  {
+    name: 'dvalin_scan',
+    description:
+      'Scan a workspace for injection, hardcoded secrets, XSS, dynamic code execution, and unsafe shell use. '
+      + 'Deterministic and read-only: it runs no model, needs no credentials, and never edits files — safe to call '
+      + 'after writing code. Returns findings with file, line, severity, and rule reference.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        cwd: { type: 'string', description: 'Workspace to scan. Defaults to the server workspace.' },
+        scanners: {
+          type: 'array',
+          items: { type: 'string', enum: SCANNER_IDS },
+          description: 'Defaults to builtin only, which needs nothing installed. The others are used when on PATH.',
+        },
+        limit: { type: 'integer', minimum: 1, description: `Maximum findings returned (default ${DEFAULT_FINDING_LIMIT}).` },
+        timeout_seconds: { type: 'number', exclusiveMinimum: 0 },
+        include_remediation_prompts: {
+          type: 'boolean',
+          description: 'Include the per-finding repair prompt. Verbose; off by default.',
+        },
+      },
+      additionalProperties: false,
+    },
+    annotations: { readOnlyHint: true },
+  },
   {
     name: 'dvalin_run_task',
     description: 'Run a complete governed coding task inside DvalinCode. Long calls are expected; callers should use a generous timeout.',
@@ -97,6 +133,7 @@ export async function createMcpServer(
 ): Promise<DvalinMcpServer> {
   const deps: McpServerDependencies = {
     executeRun: executeHarnessRun,
+    runScan: runDvalinScanSuite,
     loadSession,
     renderReport: runId => renderReport(runId),
     latestRun: () => latestRun(),
@@ -171,6 +208,51 @@ async function callTool(
     maxPermissionMode: UnattendedPermissionMode;
   },
 ): Promise<{ content: Array<{ type: 'text'; text: string }>; isError?: boolean }> {
+  if (name === 'dvalin_scan') {
+    const cwd = args.cwd === undefined ? context.serverCwd : requireString(args.cwd, 'cwd');
+    const resolvedCwd = await resolveAllowedWorkspace(cwd, context.allowedWorkspaces);
+    const scanners = optionalScannerIds(args.scanners);
+    const limit = optionalPositiveNumber(args.limit, 'limit', true) ?? DEFAULT_FINDING_LIMIT;
+    const timeoutSeconds = optionalPositiveNumber(args.timeout_seconds, 'timeout_seconds', false);
+    const includePrompts = args.include_remediation_prompts === true;
+
+    const result = await context.deps.runScan(resolvedCwd, {
+      scanners,
+      timeoutMs: timeoutSeconds === undefined ? undefined : timeoutSeconds * 1000,
+    });
+
+    // Trimmed by default: the per-finding repair prompt and source snippet are
+    // ~1KB each, and a caller that wants context can read the file itself.
+    const findings = result.findings.slice(0, limit).map(finding => ({
+      ruleId: finding.ruleId,
+      ruleName: finding.ruleName,
+      severity: finding.severity,
+      securitySeverity: finding.securitySeverity,
+      message: finding.message,
+      path: finding.path,
+      startLine: finding.startLine,
+      endLine: finding.endLine,
+      helpUri: finding.helpUri,
+      tags: finding.tags,
+      ...(includePrompts ? { prompt: finding.prompt } : {}),
+    }));
+
+    return toolResult(JSON.stringify({
+      score: result.score,
+      grade: result.grade,
+      metrics: result.metrics,
+      totalFindings: result.findings.length,
+      returnedFindings: findings.length,
+      findings,
+      scanners: result.scanners.map(scanner => ({
+        id: scanner.id,
+        status: scanner.status,
+        findings: scanner.findings,
+        ...(scanner.error ? { error: scanner.error } : {}),
+      })),
+    }));
+  }
+
   if (name === 'dvalin_run_task') {
     const prompt = requireString(args.prompt, 'prompt');
     if (!prompt.trim()) throw new Error('prompt must not be empty');
@@ -281,6 +363,19 @@ function optionalPermissionMode(value: unknown): UnattendedPermissionMode | unde
   if (value === undefined) return undefined;
   if (value === 'plan' || value === 'auto' || value === 'bypass') return value;
   throw new Error('permission_mode must be plan, auto, or bypass');
+}
+
+/**
+ * Omitted means `builtin` only — the one engine that needs nothing installed,
+ * so the default call works on any machine without prior setup.
+ */
+function optionalScannerIds(value: unknown): DvalinScannerId[] {
+  if (value === undefined) return ['builtin'];
+  if (!Array.isArray(value)) throw new Error('scanners must be an array');
+  const unknown = value.filter(id => !SCANNER_IDS.includes(id as DvalinScannerId));
+  if (unknown.length) throw new Error(`Unknown scanner(s): ${unknown.join(', ')}. Choose from ${SCANNER_IDS.join(', ')}.`);
+  if (!value.length) throw new Error('scanners must not be empty');
+  return [...new Set(value as DvalinScannerId[])];
 }
 
 function optionalPositiveNumber(value: unknown, field: string, integer: boolean): number | undefined {

--- a/tests/mcp/scanTool.test.ts
+++ b/tests/mcp/scanTool.test.ts
@@ -1,0 +1,158 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { createMcpServer } from '../../src/mcp/server.js';
+import type { DvalinScanSuiteResult } from '../../src/remediation/scannerSuite.js';
+
+const cleanups: Array<() => void> = [];
+afterEach(() => {
+  while (cleanups.length) cleanups.pop()!();
+});
+
+function tempDir(): string {
+  const dir = mkdtempSync(path.join(tmpdir(), 'dvalin-mcp-scan-'));
+  cleanups.push(() => rmSync(dir, { recursive: true, force: true }));
+  return dir;
+}
+
+function call(id: number, args: Record<string, unknown> = {}): string {
+  return JSON.stringify({
+    jsonrpc: '2.0',
+    id,
+    method: 'tools/call',
+    params: { name: 'dvalin_scan', arguments: args },
+  });
+}
+
+function finding(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'LocalScan:dvalin-eval:app.js:3',
+    source: 'Dvalin Local Scan',
+    ruleId: 'dvalin/eval',
+    ruleName: 'Dynamic code execution',
+    severity: 'warning' as const,
+    securitySeverity: '7.5',
+    message: 'Dynamic code execution detected.',
+    path: 'app.js',
+    startLine: 3,
+    endLine: 3,
+    helpUri: 'https://cwe.mitre.org/data/definitions/94.html',
+    tags: ['security'],
+    // Only asserted to be absent from the response, so the value is a
+    // placeholder — deliberately not a vulnerable pattern, to keep this file
+    // out of .dvalincodeignore.
+    snippet: '   3 | <source line>',
+    prompt: 'a very long remediation prompt'.repeat(30),
+    ...overrides,
+  };
+}
+
+function scanResult(findings: ReturnType<typeof finding>[]): DvalinScanSuiteResult {
+  return {
+    id: 'scan-1',
+    source: 'Dvalin Security Suite',
+    startedAt: '2026-08-08T00:00:00.000Z',
+    completedAt: '2026-08-08T00:00:01.000Z',
+    score: 88,
+    grade: 'B',
+    findings,
+    totalResults: findings.length,
+    skippedResults: 0,
+    scanners: [
+      { id: 'builtin', name: 'Built-in', category: 'secrets', description: '', available: true, homepage: '', status: 'completed', findings: findings.length, durationMs: 5 },
+      { id: 'semgrep', name: 'Semgrep', category: 'sast', description: '', available: false, homepage: '', status: 'missing', findings: 0, durationMs: 0 },
+    ],
+    metrics: { critical: 0, high: findings.length, medium: 0, low: 0, files: 1, rules: 1 },
+  } as DvalinScanSuiteResult;
+}
+
+async function serverWith(runScan: ReturnType<typeof vi.fn>, cwd = tempDir()) {
+  return { cwd, server: await createMcpServer({ cwd, workspaces: [cwd], maxPermissionMode: 'auto' }, { runScan }) };
+}
+
+function payload(response: unknown): any {
+  return JSON.parse((response as any).result.content[0].text);
+}
+
+describe('dvalin_scan', () => {
+  it('defaults to the builtin scanner, which needs nothing installed', async () => {
+    const runScan = vi.fn().mockResolvedValue(scanResult([]));
+    const { server } = await serverWith(runScan);
+    await server.handleLine(call(1));
+    expect(runScan.mock.calls[0]![1].scanners).toEqual(['builtin']);
+  });
+
+  it('returns the score and findings without the verbose repair prompt', async () => {
+    const runScan = vi.fn().mockResolvedValue(scanResult([finding()]));
+    const { server } = await serverWith(runScan);
+    const body = payload(await server.handleLine(call(1)));
+    expect(body.score).toBe(88);
+    expect(body.findings[0].ruleId).toBe('dvalin/eval');
+    expect(body.findings[0].startLine).toBe(3);
+    expect(body.findings[0].helpUri).toContain('cwe.mitre.org');
+    expect(body.findings[0]).not.toHaveProperty('prompt');
+    expect(body.findings[0]).not.toHaveProperty('snippet');
+  });
+
+  it('includes the repair prompt only when asked', async () => {
+    const runScan = vi.fn().mockResolvedValue(scanResult([finding()]));
+    const { server } = await serverWith(runScan);
+    const body = payload(await server.handleLine(call(1, { include_remediation_prompts: true })));
+    expect(body.findings[0].prompt).toBeTruthy();
+  });
+
+  it('caps findings so one scan cannot flood the caller, and says how many there were', async () => {
+    const many = Array.from({ length: 120 }, (_, i) => finding({ id: `f${i}`, startLine: i + 1 }));
+    const runScan = vi.fn().mockResolvedValue(scanResult(many));
+    const { server } = await serverWith(runScan);
+
+    const capped = payload(await server.handleLine(call(1)));
+    expect(capped.returnedFindings).toBe(50);
+    expect(capped.totalFindings).toBe(120);
+
+    const smaller = payload(await server.handleLine(call(2, { limit: 5 })));
+    expect(smaller.returnedFindings).toBe(5);
+  });
+
+  it('reports which engines were not installed rather than failing', async () => {
+    const runScan = vi.fn().mockResolvedValue(scanResult([]));
+    const { server } = await serverWith(runScan);
+    const body = payload(await server.handleLine(call(1)));
+    expect(body.scanners.find((s: any) => s.id === 'semgrep').status).toBe('missing');
+  });
+
+  it('rejects an unknown scanner instead of silently ignoring it', async () => {
+    const runScan = vi.fn().mockResolvedValue(scanResult([]));
+    const { server } = await serverWith(runScan);
+    const response: any = await server.handleLine(call(1, { scanners: ['builtin', 'nessus'] }));
+    expect(response.result.isError).toBe(true);
+    expect(response.result.content[0].text).toContain('nessus');
+    expect(runScan).not.toHaveBeenCalled();
+  });
+
+  it('refuses a workspace outside the allowed list', async () => {
+    const runScan = vi.fn().mockResolvedValue(scanResult([]));
+    const { server } = await serverWith(runScan);
+    const outside = tempDir();
+    writeFileSync(path.join(outside, 'a.js'), 'const a = 1;\n');
+    const response: any = await server.handleLine(call(1, { cwd: outside }));
+    expect(response.result.isError).toBe(true);
+    expect(runScan).not.toHaveBeenCalled();
+  });
+
+  it('passes the timeout through in milliseconds', async () => {
+    const runScan = vi.fn().mockResolvedValue(scanResult([]));
+    const { server } = await serverWith(runScan);
+    await server.handleLine(call(1, { timeout_seconds: 12 }));
+    expect(runScan.mock.calls[0]![1].timeoutMs).toBe(12_000);
+  });
+
+  it('scans the server workspace when no cwd is given', async () => {
+    const runScan = vi.fn().mockResolvedValue(scanResult([]));
+    const { cwd, server } = await serverWith(runScan);
+    await server.handleLine(call(1));
+    expect(runScan.mock.calls[0]![0]).toContain(path.basename(cwd));
+  });
+});

--- a/tests/mcp/server.test.ts
+++ b/tests/mcp/server.test.ts
@@ -29,7 +29,7 @@ function toolPayload(response: Awaited<ReturnType<Awaited<ReturnType<typeof crea
 }
 
 describe('task-level stdio MCP server', () => {
-  it('implements initialize and lists exactly the three task-level tools', async () => {
+  it('implements initialize and lists exactly the task-level tools', async () => {
     const cwd = tempDir();
     const server = await createMcpServer({ cwd, workspaces: [cwd], maxPermissionMode: 'auto' });
     const initialized = await server.handleLine(request(1, 'initialize', { protocolVersion: '2024-11-05' }));
@@ -37,11 +37,20 @@ describe('task-level stdio MCP server', () => {
 
     const listed = await server.handleLine(request(2, 'tools/list'));
     const tools = (listed as any).result.tools;
+    // dvalin_scan leads deliberately: it is the only tool a caller can use with
+    // no model, no credentials, and no configuration.
     expect(tools.map((tool: any) => tool.name)).toEqual([
-      'dvalin_run_task', 'dvalin_get_session', 'dvalin_get_evidence',
+      'dvalin_scan', 'dvalin_run_task', 'dvalin_get_session', 'dvalin_get_evidence',
     ]);
-    expect(tools[0].annotations.readOnlyHint).toBe(false);
-    expect(tools.slice(1).every((tool: any) => tool.annotations.readOnlyHint)).toBe(true);
+    const readOnly = Object.fromEntries(
+      tools.map((tool: any) => [tool.name, tool.annotations.readOnlyHint]),
+    );
+    expect(readOnly).toEqual({
+      dvalin_scan: true,
+      dvalin_run_task: false,
+      dvalin_get_session: true,
+      dvalin_get_evidence: true,
+    });
   });
 
   it('returns JSON-RPC parse and method-not-found errors', async () => {


### PR DESCRIPTION
## Summary

If an agent writes the code, something other than that agent has to check it. That is the same governance argument this project already makes, applied to who is actually writing code now — and the MCP server was not set up for it.

All three existing tools were heavyweight. `dvalin_run_task` asks a calling agent to hand over an entire coding task, which needs DvalinCode's own provider configured and a lot of trust. Nothing let an agent do the cheap, obvious thing: check what it just wrote.

**`dvalin_scan` is read-only and deterministic** — no model, no credentials, no edits. That property matters more for an agent than for a person: it does not stack another layer of nondeterminism on top of the caller's own. It is listed first and defaults to the `builtin` engine, so the default call works on a machine with nothing installed.

## Designed for a caller with a context window

- **Trimmed by default.** The per-finding repair prompt and source snippet are ~1KB each; an agent that wants context can read the file itself. `include_remediation_prompts` opts back in.
- **Capped at 50 findings**, with the true total reported, so one scan on a large repo cannot flood the caller.
- Measured: **~170ms** including process start, **~600 byte** payload for a single finding.

## Testing

Verified end to end over real stdio MCP against a vulnerable fixture — full `initialize` → `tools/call` handshake with a separate client process, correct file and line reported.

10 unit tests cover the default scanner set, trimming, the cap and `limit`, unknown-scanner rejection, the workspace guard refusing a path outside `--workspace`, timeout conversion to milliseconds, and the missing-engine report.

The existing "exactly the three task-level tools" test is **updated, not loosened** — it exists to pin the surface, so it now pins four and asserts each tool's `readOnlyHint` by name.

`npm run check` green at 332 tests / 50 files. Repo self-scan clean.

## Also in this PR (second commit)

- README section in both languages.
- `integrations/claude-code/` — MCP setup snippet plus a Claude Code skill. The skill falls back to `npx -y dvalincode` when no MCP server is configured, so it works with nothing installed. It also states what a scan does *not* prove, which matters more than the invocation: a clean scan is not a safety certificate, and suppressing a finding to make it pass is not a fix.
- `server.json` — the MCP registry manifest.
- `integrations/README.md` separates the two unrelated things called "skills" here: DvalinCode's JSON bundles, and Anthropic's SKILL.md directories.

Every flag documented was checked against `mcp-serve --help`, not written from memory.

## Security and AI Governance

- [x] This change does not expand file, shell, network, model, or approval permissions.
- [x] If it changes agent behavior, prompts, policy, providers, audit logging, or release/build security, I updated the relevant governance evidence in `docs/`.
- [ ] If it introduces a new model/provider/tool or new data flow, I completed `docs/governance/AI-CHANGE-IMPACT-ASSESSMENT.md`.

Third box unticked, but this is the one where a reviewer should push back hardest if they disagree — it **does** add a new agent-facing tool:

- `dvalin_scan` is strictly narrower than what the server already exposed. It runs no model, resolves no provider, and cannot write; `dvalin_run_task` beside it can do all three. It goes through the same `resolveAllowedWorkspace` guard, so `--workspace` still bounds it.
- No new egress: the builtin scanner is local. The optional engines may fetch rule databases, exactly as they already do from the CLI and under the same command policy.

I did not fill out the assessment because the template covers agent permissions, prompts, provider handling, audit, and release security, and this touches none — but the call is yours.

## Notes

**Not done, needs your decision:** submitting to the MCP registry and to `awesome-mcp-servers`. Both mean opening a pull request on someone else's repository under your identity, so I prepared `server.json` and stopped there. Say the word and I will draft both submissions.

**`.dvalincodeignore` did not grow.** The self-scan flagged this PR's own test file, on a mock `snippet` value. Unlike the three fixtures already excluded, that value is not load-bearing — the test only asserts the field is *absent* — so it became a neutral placeholder instead of a fifth exclusion. The exclusion list is supposed to stay surgical; this was a case where the vulnerable pattern was not actually the fixture.