### PR TITLE
release: 0.16.0, and publish the MCP server to the registry on tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -317,3 +317,51 @@ jobs:
           git add Formula/dvalincode.rb
           git commit -m "chore(homebrew): pin formula to ${GITHUB_REF_NAME}"
           git push origin main
+
+  # Listing the MCP server is what makes it findable by agents at all. OIDC
+  # rather than a token: the registry derives the namespace from this
+  # repository's owner, so `io.github.arthurpanhku/*` needs no stored secret.
+  #
+  # Runs after npm, because the listing points at the published package.
+  mcp-registry:
+    name: Publish to the MCP registry
+    needs: [npm]
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write   # OIDC authentication to the registry
+    steps:
+      # actions/checkout v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          persist-credentials: false
+
+      # Three files carry the version independently. Fail loudly on a mismatch
+      # rather than quietly listing a version nobody can install.
+      - name: Check the tag, package.json, and server.json agree
+        run: |
+          tag="${GITHUB_REF_NAME#v}"
+          pkg="$(node -p "require('./package.json').version")"
+          srv="$(node -p "require('./server.json').version")"
+          srvpkg="$(node -p "require('./server.json').packages[0].version")"
+          for pair in "package.json:${pkg}" "server.json:${srv}" "server.json packages[0]:${srvpkg}"; do
+            name="${pair%%:*}"; value="${pair##*:}"
+            if [ "$value" != "$tag" ]; then
+              echo "::error::${name} is ${value} but the tag is ${tag}."
+              exit 1
+            fi
+          done
+
+      - name: Install mcp-publisher
+        run: |
+          set -euo pipefail
+          os="$(uname -s | tr '[:upper:]' '[:lower:]')"
+          arch="$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')"
+          curl -fsSL "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_${os}_${arch}.tar.gz" \
+            | tar xz mcp-publisher
+
+      - name: Authenticate and publish
+        run: |
+          ./mcp-publisher login github-oidc
+          ./mcp-publisher publish

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dvalincode",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "A local-first, provider-neutral CLI foundation for agentic coding workflows.",
   "type": "module",
   "license": "MIT",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/arthurpanhku/dvalincode",
     "source": "github"
   },
-  "version": "0.15.0",
+  "version": "0.16.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "dvalincode",
-      "version": "0.15.0",
+      "version": "0.16.0",
       "transport": {
         "type": "stdio"
       },

--- a/src/version.ts
+++ b/src/version.ts
@@ -5,4 +5,4 @@
  * Everything that reports a version — the CLI `--version`, the trust report, and
  * the self-update check — imports from here so the copies can never drift.
  */
-export const VERSION = '0.15.0';
+export const VERSION = '0.16.0';


### PR DESCRIPTION
## Why this is needed before anything else

`dvalin_scan` is on `main` but not on npm. I checked what users actually get:

```
$ npx -y dvalincode@0.15.0 mcp-serve  →  tools/list
  dvalin_run_task
  dvalin_get_session
  dvalin_get_evidence
```

No `dvalin_scan`. So a registry listing, an awesome-list entry, or the README section describing it are all **false until a release ships**. This is that release.

## What it adds

**0.16.0** across all three places the version lives: `package.json`, `src/version.ts`, and `server.json` (twice — top level and `packages[0]`).

**An `mcp-registry` job**, rather than publishing by hand once. The listing is what makes the server findable by agents at all, and a manual step here would drift exactly the way npm did before it was automated — v0.14.1 was tagged and released on GitHub but never reached npm, and nobody noticed for a month.

- **OIDC, not a stored token.** The registry derives the namespace from this repository's owner, so `io.github.arthurpanhku/*` needs no secret at all. Follows the registry's own documented GitHub Actions pattern.
- **Runs after `npm`**, because the listing points at the published package.
- **Refuses to publish on a version mismatch.** Four values must equal the tag. A listing nobody can install is worse than a failed build — the same reasoning as the npm job's `package.json` check.

## Testing

Version guard exercised locally against a matching tag (passes) and a mismatched one (fails). `npm run check` green at 332 tests / 50 files; the built CLI reports `0.16.0`.

The publish path itself cannot be exercised without a real tag and OIDC — **the first live run will be the next release.** Given that the Evidence Pack step broke on its own first run, this one is worth watching.

## Security and AI Governance

- [x] This change does not expand file, shell, network, model, or approval permissions.
- [x] If it changes agent behavior, prompts, policy, providers, audit logging, or release/build security, I updated the relevant governance evidence in `docs/`.
- [ ] If it introduces a new model/provider/tool or new data flow, I completed `docs/governance/AI-CHANGE-IMPACT-ASSESSMENT.md`.

Third box unticked; this is release security, and two facts deserve review:

- The job downloads `mcp-publisher` from the registry's GitHub releases at run time, resolved through `latest`. That is an unpinned dependency in the release path — the registry's own documented pattern, but worth naming rather than glossing.
- It grants `id-token: write` to mint an OIDC token for `registry.modelcontextprotocol.io`, and publishes metadata (name, description, package identifier) — no code and no credentials leave the runner.

## Notes

**The awesome-mcp-servers PR is written but not submitted.** Submitting now would advertise `dvalin_scan` to ~92k stargazers when `npx` cannot yet install it. The entry is ready and goes out once 0.16.0 is on npm.

Their CONTRIBUTING asks automated agents to mark PR titles with `🤖🤖🤖` to opt into a fast-track review, so that submission will carry it — the maintainers ask for the disclosure, and it is accurate.

**To release:** merge this, then `git tag v0.16.0 && git push origin v0.16.0`. The tag now drives binaries, Evidence Pack, provenance, GitHub Release, npm, the Homebrew formula, and the registry listing.