### PR TITLE
release: 0.16.1 — add the mcpName the registry requires

### DIFF
--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -47,6 +47,15 @@ jobs:
             echo "::error::server.json description is ${len} characters; the registry allows 100."
             exit 1
           fi
+          # The registry rejects a package whose package.json does not carry
+          # mcpName matching the listing — its proof that the npm package and
+          # the listing are the same owner. It only says so after auth.
+          mcp="$(node -p "require('./package.json').mcpName || ''")"
+          name="$(node -p "require('./server.json').name")"
+          if [ "$mcp" != "$name" ]; then
+            echo "::error::package.json mcpName is '${mcp}' but server.json name is '${name}'."
+            exit 1
+          fi
           echo "::notice::Publishing listing for dvalincode@${srv}."
 
       - name: Install mcp-publisher

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -384,6 +384,15 @@ jobs:
             echo "::error::server.json description is ${len} characters; the registry allows 100."
             exit 1
           fi
+          # The registry rejects a package whose package.json does not carry
+          # mcpName matching the listing — its proof that the npm package and
+          # the listing are the same owner. It only says so after auth.
+          mcp="$(node -p "require('./package.json').mcpName || ''")"
+          name="$(node -p "require('./server.json').name")"
+          if [ "$mcp" != "$name" ]; then
+            echo "::error::package.json mcpName is '${mcp}' but server.json name is '${name}'."
+            exit 1
+          fi
 
       - name: Install mcp-publisher
         run: |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dvalincode",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "description": "A local-first, provider-neutral CLI foundation for agentic coding workflows.",
   "type": "module",
   "license": "MIT",
@@ -8,6 +8,7 @@
     "type": "git",
     "url": "git+https://github.com/arthurpanhku/dvalincode.git"
   },
+  "mcpName": "io.github.arthurpanhku/dvalincode",
   "bin": {
     "dvalincode": "dist/index.js"
   },

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/arthurpanhku/dvalincode",
     "source": "github"
   },
-  "version": "0.16.0",
+  "version": "0.16.1",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "dvalincode",
-      "version": "0.16.0",
+      "version": "0.16.1",
       "transport": {
         "type": "stdio"
       },

--- a/src/version.ts
+++ b/src/version.ts
@@ -5,4 +5,4 @@
  * Everything that reports a version — the CLI `--version`, the trust report, and
  * the self-update check — imports from here so the copies can never drift.
  */
-export const VERSION = '0.16.0';
+export const VERSION = '0.16.1';


### PR DESCRIPTION
## Why 0.16.1 exists

The MCP registry rejected the listing a second time — and this one cannot be fixed without a new npm version:

```
400 — registry validation failed for package 0 (dvalincode):
NPM package 'dvalincode' is missing required 'mcpName' field.
Add this to your package.json: "mcpName": "io.github.arthurpanhku/dvalincode"
```

`mcpName` is the registry's proof that the npm package and the listing belong to the same owner, and it has to be **inside the published package**. 0.16.0 is already on npm without it, so it can never be listed. Hence 0.16.1.

**This settles the earlier call not to move the v0.16.0 tag.** Rebuilding and replacing seven public, attested artifacts would not have helped — a new npm version was required either way.

## Guards, so this stops costing a release each time

Both release paths now check `package.json.mcpName === server.json.name`, alongside the description-length check from #164. The registry validates **only after authenticating** — so without these, a rejection lands after npm has published and the GitHub Release exists, which is the most expensive moment to learn about a typo.

Two registry rejections in a row, both discovered at that point, is what motivated moving every check the registry performs into a pre-flight step.

## Also: deletes `chore/homebrew-v0.16.0`

The CI job pushed that branch **before #164 merged**, so it was behind main. Opening a PR from it would have reverted `publish-mcp-registry.yml` (deleting it), plus the `release.yml` and `server.json` changes:

```
 .github/workflows/publish-mcp-registry.yml | 63 ------------------
 .github/workflows/release.yml              | 12 +-----
 Formula/dvalincode.rb                      | 18 ++++-----
 server.json                                |  2 +-
```

Its formula content was correct (checksums matched the real release), but the 0.16.1 release regenerates the formula anyway, so the stale branch is gone rather than rebased.

## Testing

Guards exercised locally: matching `mcpName` passes, a missing one fails. Both workflow files parse. `npm run check` green at 332 tests / 50 files; the built CLI reports `0.16.1`. Verified `mcpName` sits in `package.json` itself, which npm always ships regardless of the `files` allowlist.

## Security and AI Governance

- [x] This change does not expand file, shell, network, model, or approval permissions.
- [x] If it changes agent behavior, prompts, policy, providers, audit logging, or release/build security, I updated the relevant governance evidence in `docs/`.
- [x] If it introduces a new model/provider/tool or new data flow, I completed `docs/governance/AI-CHANGE-IMPACT-ASSESSMENT.md`.

A metadata field, a version bump, and two pre-flight checks. `mcpName` is published metadata asserting ownership of a namespace this account already controls.

## Notes

**v0.16.0 stays as it is** — published, attested, and installable. 0.16.1 supersedes it on npm and is the version that gets listed.

**Homebrew still needs the repository setting.** `Settings → Actions → General → Workflow permissions → "Allow GitHub Actions to create and approve pull requests"`. Without it the release pushes the formula branch but cannot open the PR; with it, the whole path is hands-off.