### PR TITLE
feat(cli): add run-tool --json for machine-readable results

### DIFF
--- a/docs/HARNESS-MODE.md
+++ b/docs/HARNESS-MODE.md
@@ -176,6 +176,40 @@ same `runId` as the `result` line.
 
 ---
 
+## `run-tool --json` — one tool, machine-readable
+
+`dvalincode run` drives a whole governed turn. When a caller wants a single
+tool instead, `run-tool` takes JSON in; `--json` makes it give JSON back.
+
+```sh
+dvalincode run-tool list_files -i '{"pattern":"src/**/*.ts"}' --json
+```
+
+```json
+{ "ok": true, "tool": "list_files", "title": "Listed 42 files",
+  "output": "...", "metadata": { "totalMatches": 42 } }
+```
+
+Failures use the same envelope, with a code that is decided **structurally** —
+from a typed error or the registry's own metadata, never by matching an error
+message, so rewording a message cannot silently reclassify a failure:
+
+| `error.code` | Cause |
+|---|---|
+| `invalid_input` | `-i` was not valid JSON |
+| `unknown_tool` | no such tool, or it is outside the allowed set |
+| `invalid_tool_input` | JSON parsed, but failed the tool's schema |
+| `permission_denied` | the tool writes or executes and `--yes` was absent |
+| `policy_denied` | org policy blocked the tool, command, or path |
+| `tool_error` | the tool itself failed |
+
+Exit code is 0 on success and 1 on any failure. Diagnostics — including the
+malformed-policy warning — go to stderr, so stdout stays parseable.
+
+Without `--json` the behaviour is unchanged: prose on stdout, the original
+error thrown. That matters beyond formatting — `PolicyViolationError` is what
+proves enforcement to a caller, and it is rethrown rather than wrapped.
+
 ## Phase 2 — MCP server (stdio)
 
 ### Shape

--- a/src/commands/runTool.ts
+++ b/src/commands/runTool.ts
@@ -1,8 +1,26 @@
+import { z } from 'zod';
 import type { Command } from 'commander';
 import { createDvalinContext } from '../core/context.js';
-import { loadPolicy } from '../core/policy.js';
+import { loadPolicy, PolicyViolationError } from '../core/policy.js';
 import type { ToolRegistry } from '../tools/registry.js';
 import { renderToolResult } from '../ui/output.js';
+
+/**
+ * Machine-readable failure kinds. Every one is decided structurally — from a
+ * typed error or from the registry's own metadata — never by matching an error
+ * message, so a reworded message cannot silently reclassify a failure.
+ */
+export type RunToolErrorCode =
+  | 'invalid_input'
+  | 'unknown_tool'
+  | 'permission_denied'
+  | 'policy_denied'
+  | 'invalid_tool_input'
+  | 'tool_error';
+
+export type RunToolJsonResult =
+  | { ok: true; tool: string; title: string; output: string; metadata?: Record<string, unknown> }
+  | { ok: false; tool: string; error: { code: RunToolErrorCode; message: string } };
 
 export function registerRunToolCommand(program: Command, registry: ToolRegistry): void {
   program
@@ -11,34 +29,76 @@ export function registerRunToolCommand(program: Command, registry: ToolRegistry)
     .argument('<name>', 'tool name')
     .requiredOption('-i, --input <json>', 'tool input as JSON')
     .option('-y, --yes', 'allow tools that execute processes or modify files', false)
-    .action(async (name: string, options: { input: string; yes: boolean }) => {
-      const input = parseJson(options.input);
+    .option('--json', 'print the result as JSON, including structured errors')
+    .action(async (name: string, options: { input: string; yes: boolean; json?: boolean }) => {
+      const emit = (result: RunToolJsonResult): void => {
+        if (options.json) console.log(JSON.stringify(result, null, 2));
+        else if (result.ok) console.log(renderToolResult(result));
+        else console.error(`dvalincode: ${result.error.message}`);
+        if (!result.ok) process.exitCode = 1;
+      };
+
+      // Without --json the historic behaviour is kept exactly: throw, and let
+      // the top-level handler print to stderr and exit 1. The original error
+      // is rethrown rather than a copy — PolicyViolationError is what proves
+      // enforcement to callers and to the #45 regression tests, and wrapping
+      // it in a plain Error would quietly discard that.
+      const fail = (code: RunToolErrorCode, message: string, original?: unknown): void => {
+        if (!options.json) throw original ?? new Error(message);
+        emit({ ok: false, tool: name, error: { code, message } });
+      };
+
+      let input: unknown;
+      try {
+        input = JSON.parse(options.input);
+      } catch (error) {
+        const message = `Invalid JSON input: ${error instanceof Error ? error.message : String(error)}`;
+        fail('invalid_input', message);
+        return;
+      }
+
       // Org policy applies to every entrypoint, including this one (#45).
       // Mirrors runAgentTurn: malformed sources are skipped loudly, never
-      // silently treated as "allow everything".
+      // silently treated as "allow everything". Warnings go to stderr, so
+      // --json keeps stdout parseable.
       const loadedPolicy = loadPolicy(process.cwd());
       for (const source of loadedPolicy.sources) {
         if (source.error) {
           console.warn(`⚠ Ignored malformed policy at ${source.path}: ${source.error}`);
         }
       }
+
+      const tool = registry.get(name);
+      if (!tool) {
+        fail('unknown_tool', `Unknown tool: ${name}`);
+        return;
+      }
+
       const context = createDvalinContext({
         cwd: process.cwd(),
         allowExecute: options.yes,
         allowWrite: options.yes,
         policy: loadedPolicy.policy,
       });
-      const result = await registry.run(name, input, context);
-      console.log(renderToolResult(result));
+
+      try {
+        const result = await registry.run(name, input, context);
+        emit({ ok: true, tool: name, title: result.title, output: result.output, ...(result.metadata ? { metadata: result.metadata } : {}) });
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        fail(classify(error, tool.access, options.yes), message, error);
+      }
     });
 }
 
-function parseJson(value: string): unknown {
-  try {
-    return JSON.parse(value);
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    throw new Error(`Invalid JSON input: ${message}`);
-  }
+/**
+ * `registry.run` throws plain Errors for a missing --yes, so permission is
+ * recognised from the tool's declared access and the flag rather than from the
+ * message. The other kinds carry their own types.
+ */
+function classify(error: unknown, access: string, allowed: boolean): RunToolErrorCode {
+  if (error instanceof PolicyViolationError) return 'policy_denied';
+  if (error instanceof z.ZodError) return 'invalid_tool_input';
+  if (!allowed && (access === 'write' || access === 'execute')) return 'permission_denied';
+  return 'tool_error';
 }
-

--- a/tests/commands/runTool.test.ts
+++ b/tests/commands/runTool.test.ts
@@ -108,3 +108,146 @@ describe('run-tool org policy enforcement (#45)', () => {
     expect(ran.value).toBe(true); // fail-safe matches runAgentTurn semantics
   });
 });
+
+// `--json` exists so an agent does not have to parse prose. These pin the
+// shape and, more importantly, that every failure kind is distinguishable
+// without matching on the message text.
+
+function jsonProgram(registry: ToolRegistry) {
+  const program = new Command();
+  program.exitOverride();
+  registerRunToolCommand(program, registry);
+  return program;
+}
+
+function captureJson(): { read: () => any; restore: () => void } {
+  let captured = '';
+  const spy = vi.spyOn(console, 'log').mockImplementation(line => {
+    captured += String(line);
+  });
+  return { read: () => JSON.parse(captured), restore: () => spy.mockRestore() };
+}
+
+describe('run-tool --json', () => {
+  let dir: string;
+  const originalExitCode = process.exitCode;
+
+  afterEach(() => {
+    delete process.env.DVALINCODE_POLICY_FILE;
+    if (dir) rmSync(dir, { recursive: true, force: true });
+    process.exitCode = originalExitCode;
+    vi.restoreAllMocks();
+  });
+
+  function noPolicy(): void {
+    dir = mkdtempSync(join(tmpdir(), 'dc-runtool-json-'));
+    process.env.DVALINCODE_POLICY_FILE = join(dir, 'absent.json');
+  }
+
+  it('reports success with the tool result and its metadata', async () => {
+    noPolicy();
+    const registry = new ToolRegistry();
+    registry.register({
+      ...testTool({ value: false }),
+      async run(input: { text: string }) {
+        return { title: 'Echo', output: input.text, metadata: { length: input.text.length } };
+      },
+    } as Tool<{ text: string }>);
+    const out = captureJson();
+
+    await invoke(jsonProgram(registry), ['echo_test', '-i', '{"text":"hi"}', '-y', '--json']);
+
+    expect(out.read()).toEqual({
+      ok: true,
+      tool: 'echo_test',
+      title: 'Echo',
+      output: 'hi',
+      metadata: { length: 2 },
+    });
+    expect(process.exitCode).toBeUndefined();
+  });
+
+  it('distinguishes an unknown tool without running anything', async () => {
+    noPolicy();
+    const ran = { value: false };
+    const registry = new ToolRegistry();
+    registry.register(testTool(ran));
+    const out = captureJson();
+
+    await invoke(jsonProgram(registry), ['not_a_tool', '-i', '{}', '--json']);
+
+    expect(out.read()).toMatchObject({ ok: false, tool: 'not_a_tool', error: { code: 'unknown_tool' } });
+    expect(ran.value).toBe(false);
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('distinguishes malformed JSON input', async () => {
+    noPolicy();
+    const registry = new ToolRegistry();
+    registry.register(testTool({ value: false }));
+    const out = captureJson();
+
+    await invoke(jsonProgram(registry), ['echo_test', '-i', 'not-json', '-y', '--json']);
+
+    expect(out.read().error.code).toBe('invalid_input');
+  });
+
+  it('distinguishes input that does not match the tool schema', async () => {
+    noPolicy();
+    const registry = new ToolRegistry();
+    registry.register(testTool({ value: false }));
+    const out = captureJson();
+
+    await invoke(jsonProgram(registry), ['echo_test', '-i', '{"text":123}', '-y', '--json']);
+
+    expect(out.read().error.code).toBe('invalid_tool_input');
+  });
+
+  it('distinguishes a missing --yes from a policy denial', async () => {
+    noPolicy();
+    const ran = { value: false };
+    const registry = new ToolRegistry();
+    registry.register(testTool(ran));
+    const out = captureJson();
+
+    await invoke(jsonProgram(registry), ['echo_test', '-i', '{"text":"hi"}', '--json']);
+
+    expect(out.read().error.code).toBe('permission_denied');
+    expect(ran.value).toBe(false);
+  });
+
+  it('reports a policy denial as such, and still does not run the tool', async () => {
+    dir = mkdtempSync(join(tmpdir(), 'dc-runtool-json-'));
+    const policyFile = join(dir, 'policy.json');
+    writeFileSync(policyFile, JSON.stringify({ tools: { deny: ['echo_test'] } }));
+    process.env.DVALINCODE_POLICY_FILE = policyFile;
+
+    const ran = { value: false };
+    const registry = new ToolRegistry();
+    registry.register(testTool(ran));
+    const out = captureJson();
+
+    await invoke(jsonProgram(registry), ['echo_test', '-i', '{"text":"hi"}', '-y', '--json']);
+
+    expect(out.read()).toMatchObject({ ok: false, error: { code: 'policy_denied' } });
+    expect(ran.value).toBe(false);
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('keeps stdout parseable when a malformed policy warns', async () => {
+    dir = mkdtempSync(join(tmpdir(), 'dc-runtool-json-'));
+    const policyFile = join(dir, 'policy.json');
+    writeFileSync(policyFile, '{ not json');
+    process.env.DVALINCODE_POLICY_FILE = policyFile;
+
+    const registry = new ToolRegistry();
+    registry.register(testTool({ value: false }));
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const out = captureJson();
+
+    await invoke(jsonProgram(registry), ['echo_test', '-i', '{"text":"hi"}', '-y', '--json']);
+
+    expect(warn).toHaveBeenCalled();          // the warning went to stderr
+    expect(out.read().ok).toBe(true);         // stdout stayed valid JSON
+  });
+});


### PR DESCRIPTION
## Why

`run-tool` took JSON in and gave prose back:

```
$ dvalincode run-tool list_files -i '{"pattern":"*.js"}'
Listed 1 file
vuln.js
```

That is the wrong shape for the callers this command exists to serve. An agent hands it a structured payload and then has to regex the answer. It was the most obvious gap when I went through the CLI as an agent would: only 3 of 13 commands have machine-readable output, and this one was already half-structured.

## What it returns

```json
{ "ok": true, "tool": "list_files", "title": "Listed 1 file",
  "output": "vuln.js", "metadata": { "totalMatches": 1, "limit": 200 } }
```

Failures use the same envelope with a code:

| `error.code` | Cause |
|---|---|
| `invalid_input` | `-i` was not valid JSON |
| `unknown_tool` | no such tool, or outside the allowed set |
| `invalid_tool_input` | parsed, but failed the tool's schema |
| `permission_denied` | tool writes or executes and `--yes` was absent |
| `policy_denied` | org policy blocked the tool, command, or path |
| `tool_error` | the tool itself failed |

**Every code is decided structurally** — from a typed error (`PolicyViolationError`, `ZodError`) or from the registry's own metadata (does this tool exist; does its declared access require `--yes`) — never by matching an error message. Rewording a message therefore cannot silently reclassify a failure.

That matters most for `policy_denied`: distinguishing "org policy blocked this" from "you forgot `--yes`" is the difference between a caller retrying and a caller correctly giving up. String-matching would have made that distinction rot the first time someone edited a message.

## A regression I introduced and had to back out

The first version routed every failure through a helper that threw `new Error(message)`. That broke the two #45 regression tests, which assert a `PolicyViolationError` reaches the caller on the non-JSON path.

They were right to fail. The error *type* is what proves policy enforcement to a caller; wrapping it in a copy preserves the text and discards the proof. The original error object is now rethrown, and the comment at that line says why so it does not get "tidied" later.

## Testing

7 new tests, one per path, added to the existing `tests/commands/runTool.test.ts`:

- success including `metadata`, and that `process.exitCode` stays unset
- each of `unknown_tool`, `invalid_input`, `invalid_tool_input`, `permission_denied`, `policy_denied`
- for the denial paths, that the tool **did not run**
- that a malformed-policy warning goes to stderr and leaves stdout valid JSON

Also exercised against the built binary for all six paths plus both backward-compatible paths — same stdout, same stderr text, same exit codes as before the change.

`npm run check`: 339 tests / 50 files.

## Security and AI Governance

- [x] This change does not expand file, shell, network, model, or approval permissions.
- [x] If it changes agent behavior, prompts, policy, providers, audit logging, or release/build security, I updated the relevant governance evidence in `docs/`.
- [x] If it introduces a new model/provider/tool or new data flow, I completed `docs/governance/AI-CHANGE-IMPACT-ASSESSMENT.md`.

Output formatting only. `--yes` still gates write and execute, org policy is still resolved and enforced on this entrypoint exactly as #45 established, and the denial tests assert the tool does not run.

One thing worth a reviewer's eye: `error.message` passes the underlying message through unchanged, including the policy rule that matched. That is the same text the non-JSON path has always printed to stderr, so it is not new exposure — but it is now easier for a caller to log wholesale.

## Notes

Documented in `docs/HARNESS-MODE.md`, which had no `run-tool` section at all before this.

Two gaps remain from the same review, not addressed here:

- **`tools` has no `--json`** and its columns do not align once a tool name is long (`list_remediation_cases` breaks the layout), so an agent parsing by column position gets it wrong. This is the capability-discovery entry point, so it is the natural next one.
- **Exit codes are inconsistent across commands** — `dvalin --fail-on` uses 2, `run` documents 0/1/3/4, `run-tool` uses 1 for everything. There is no single place that states the convention.