### PR TITLE
docs: record that both MCP clients were verified, and the approval gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 <p align="center">
   <a href="https://github.com/arthurpanhku/dvalincode/releases/latest"><img src="https://img.shields.io/github/v/release/arthurpanhku/dvalincode?style=for-the-badge&color=818cf8&label=Release" alt="Release"></a>
   <a href="https://github.com/arthurpanhku/dvalincode/releases"><img src="https://img.shields.io/github/downloads/arthurpanhku/dvalincode/total?style=for-the-badge&color=blue&label=Downloads" alt="Downloads"></a>
-  <a href="#-tests"><img src="https://img.shields.io/badge/Tests-323%20%2F%20323%20%E2%9C%93-success?style=for-the-badge" alt="Tests"></a>
+  <a href="#-tests"><img src="https://img.shields.io/badge/Tests-343%20%2F%20343%20%E2%9C%93-success?style=for-the-badge" alt="Tests"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-green?style=for-the-badge" alt="License"></a>
   <a href="https://scorecard.dev/viewer/?uri=github.com/arthurpanhku/dvalincode"><img src="https://api.scorecard.dev/projects/github.com/arthurpanhku/dvalincode/badge" alt="OpenSSF Scorecard"></a>
   <a href="#-quick-install"><img src="https://img.shields.io/badge/Platforms-macOS%20·%20Windows%20·%20Linux-blue?style=for-the-badge" alt="Platforms"></a>
@@ -45,7 +45,7 @@ permissions:
   security-events: write
 steps:
   - uses: actions/checkout@v5
-  - uses: arthurpanhku/dvalincode@v0.15.0
+  - uses: arthurpanhku/dvalincode@v0.16.1
     with:
       fail-on: high
 ```
@@ -68,6 +68,9 @@ needed, no files are touched — so an agent can call it after every edit. A rea
 call against a vulnerable fixture returns in ~170ms with a ~600 byte payload.
 The same server also exposes `dvalin_run_task` for delegating a whole governed
 task, plus the session and audit-evidence tools.
+
+Verified end to end with both Claude Code and Codex driving a real tool call
+against the published package, not only completing a handshake.
 [Agent integrations →](integrations/)
 
 ### Then let it fix what it found
@@ -668,7 +671,7 @@ RESTORE → COMPACT → COMMAND → BUILD → RUN → SAVE → RESPOND → DONE
 npm test
 ```
 
-**323 tests · 49 files · all green.**
+**343 tests · 50 files · all green.**
 
 ---
 
@@ -789,7 +792,7 @@ Contributions welcome. The codebase is intentionally small and surgical — see 
 ```sh
 git clone https://github.com/arthurpanhku/dvalincode
 cd dvalincode && npm install
-npm test                # 323/323 ✅
+npm test                # 343/343 ✅
 npm run typecheck
 ```
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -9,7 +9,7 @@
 <p align="center">
   <a href="https://github.com/arthurpanhku/dvalincode/releases/latest"><img src="https://img.shields.io/github/v/release/arthurpanhku/dvalincode?style=for-the-badge&color=818cf8&label=Release" alt="Release"></a>
   <a href="https://github.com/arthurpanhku/dvalincode/releases"><img src="https://img.shields.io/github/downloads/arthurpanhku/dvalincode/total?style=for-the-badge&color=blue&label=Downloads" alt="Downloads"></a>
-  <a href="#-测试"><img src="https://img.shields.io/badge/Tests-323%20%2F%20323%20%E2%9C%93-success?style=for-the-badge" alt="Tests"></a>
+  <a href="#-测试"><img src="https://img.shields.io/badge/Tests-343%20%2F%20343%20%E2%9C%93-success?style=for-the-badge" alt="Tests"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-green?style=for-the-badge" alt="License"></a>
   <a href="https://scorecard.dev/viewer/?uri=github.com/arthurpanhku/dvalincode"><img src="https://api.scorecard.dev/projects/github.com/arthurpanhku/dvalincode/badge" alt="OpenSSF Scorecard"></a>
   <a href="#-一行安装"><img src="https://img.shields.io/badge/Platforms-macOS%20·%20Windows%20·%20Linux-blue?style=for-the-badge" alt="Platforms"></a>
@@ -43,7 +43,7 @@ permissions:
   security-events: write
 steps:
   - uses: actions/checkout@v5
-  - uses: arthurpanhku/dvalincode@v0.15.0
+  - uses: arthurpanhku/dvalincode@v0.16.1
     with:
       fail-on: high
 ```
@@ -64,6 +64,8 @@ claude mcp add dvalin -- npx -y dvalincode mcp-serve --workspace .
 `dvalin_scan` 只读且确定性 —— 不跑模型、不需要任何凭据、不改文件 —— 所以 agent
 可以每次改完就调一次。对一个真实漏洞样本的实测：约 170ms 返回，payload 约 600 字节。
 同一个 server 还提供 `dvalin_run_task`（委派完整的受管任务）以及会话、审计证据工具。
+
+Claude Code 与 Codex 均已用已发布的包做过端到端验证 —— 是真实发起工具调用，而不只是握手成功。
 [Agent 集成 →](integrations/)
 
 ### 然后让它把找到的问题修掉
@@ -589,7 +591,7 @@ RESTORE → COMPACT → COMMAND → BUILD → RUN → SAVE → RESPOND → DONE
 npm test
 ```
 
-**323 个测试 · 49 个文件 · 全部通过。**
+**343 个测试 · 50 个文件 · 全部通过。**
 
 ---
 
@@ -716,7 +718,7 @@ Linux 与 macOS 命令通过 <code>/bin/sh</code> 执行；Windows 命令通过�
 ```sh
 git clone https://github.com/arthurpanhku/dvalincode
 cd dvalincode && npm install
-npm test                # 323/323 ✅
+npm test                # 343/343 ✅
 npm run typecheck
 ```
 

--- a/docs/DVALIN.md
+++ b/docs/DVALIN.md
@@ -60,7 +60,7 @@ permissions:
   pull-requests: write     # only when comment: 'true'
 steps:
   - uses: actions/checkout@v5
-  - uses: arthurpanhku/dvalincode@v0.15.0
+  - uses: arthurpanhku/dvalincode@v0.16.1
     with:
       fail-on: high        # critical | high | medium | low | none
       scanners: builtin    # add semgrep,trivy,osv-scanner if on PATH

--- a/docs/examples/dvalin-scan.yml
+++ b/docs/examples/dvalin-scan.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5   # pin by commit digest in production
 
-      - uses: arthurpanhku/dvalincode@v0.15.0
+      - uses: arthurpanhku/dvalincode@v0.16.1
         with:
           # Fail the build on high or critical findings. Use 'none' to report
           # without blocking while you work through the backlog.
@@ -30,6 +30,6 @@ jobs:
       # Optional: add the external engines. Dvalin picks up whatever is on PATH.
       #
       # - run: pipx install semgrep
-      # - uses: arthurpanhku/dvalincode@v0.15.0
+      # - uses: arthurpanhku/dvalincode@v0.16.1
       #   with:
       #     scanners: builtin,semgrep,trivy,osv-scanner

--- a/integrations/claude-code/README.md
+++ b/integrations/claude-code/README.md
@@ -9,7 +9,9 @@ skill works with nothing but `npx`.
 claude mcp add dvalin -- npx -y dvalincode mcp-serve --workspace .
 ```
 
-Or in `.mcp.json`:
+That lands in your user config for this project and connects immediately.
+
+Or commit a `.mcp.json` so the whole team gets it:
 
 ```json
 {
@@ -21,6 +23,15 @@ Or in `.mcp.json`:
   }
 }
 ```
+
+**A `.mcp.json` does not connect until you approve it.** `claude mcp list` shows
+it as `⏸ Pending approval (run \`claude\` to approve)` until then. That is
+deliberate on Claude Code's part — a config file arriving with a repository is
+untrusted input, and it should not be able to start a process on your machine
+because you cloned something. Run `claude` once in the project and approve.
+
+If you would rather skip that for your own machine, `--scope local` keeps the
+entry in your user config instead, where it needs no approval.
 
 This exposes four tools:
 
@@ -49,3 +60,23 @@ not to declare code secure because a scan came back clean.
 The skill uses `npx -y dvalincode` when no MCP server is configured, so it works
 with nothing installed. With the MCP server configured it uses `dvalin_scan`
 instead, which is faster since there is no per-call process start.
+
+## Verified
+
+Both clients were checked end to end against the published package, driving a
+real tool call rather than only a handshake:
+
+| Client | Server command | Result |
+|---|---|---|
+| Claude Code 2.1.226 | `npx -y dvalincode mcp-serve` | `mcp__dvalin__dvalin_scan` called, correct findings returned |
+| Claude Code 2.1.226 | `node dist/index.js mcp-serve` | connected |
+| Codex 0.147.0 | `npx -y dvalincode mcp-serve` | `dvalin/dvalin_scan` called, correct findings returned |
+| Codex 0.147.0 | `node dist/index.js mcp-serve` | `dvalin/dvalin_scan` called, correct findings returned |
+
+The fixture was a file containing `eval(req.body.e)`; both clients reported
+`vuln.js` line 2, rule `dvalin/eval`, score 88 grade B — the scanner's own
+numbers, not something either model could infer from reading the file.
+
+Codex configures the same server with `codex mcp add dvalin -- npx -y
+dvalincode mcp-serve --workspace .`, which writes `[mcp_servers.dvalin]` into
+`~/.codex/config.toml`.


### PR DESCRIPTION
## Both clients verified end to end

Claude Code and Codex were installed as CLIs and driven against the **published** package — a real tool call, not only a handshake.

| Client | Server command | Result |
|---|---|---|
| Claude Code 2.1.226 | `npx -y dvalincode mcp-serve` | `mcp__dvalin__dvalin_scan` called, correct findings |
| Claude Code 2.1.226 | `node dist/index.js mcp-serve` | connected |
| Codex 0.147.0 | `npx -y dvalincode mcp-serve` | `dvalin/dvalin_scan` called, correct findings |
| Codex 0.147.0 | `node dist/index.js mcp-serve` | `dvalin/dvalin_scan` called, correct findings |

The two `npx` rows are the ones that matter: they are what the README tells people to run, and they work against what is on npm today.

Proof it was the tool and not the model reading the file, from Claude Code's own `stream-json` event stream:

```
→ mcp__dvalin__dvalin_scan {"cwd":".../mcptest"}
← {"score":88,"grade":"B","metrics":{"critical":0,"high":1,...
```

Both clients reported `vuln.js` line 2, rule `dvalin/eval`, score 88 grade B, and Claude Code also surfaced security severity 7.5 and CWE-94 — the scanner's own numbers, not something derivable from a two-line fixture.

## What the docs had wrong by omission

A committed `.mcp.json` **does not connect until a human approves it**. `claude mcp list` shows `⏸ Pending approval (run claude to approve)`, which reads like a broken setup to anyone following our README — which only showed the `.mcp.json` form and said nothing about this.

That gate is correct behaviour on Claude Code's part: a config file arriving with a repository is untrusted input and should not be able to start a process on your machine because you cloned something. So the doc now explains the gate rather than treating it as a wrinkle, and points at `--scope local` for a personal machine.

## Two stale facts on the front page

- The test badge said **323**; the suite is **343 across 50 files**.
- The Action snippets still pinned **v0.15.0** while **v0.16.1** is current. The old pin resolves, so nothing was broken — it just was not true any more. Updated in both READMEs, `docs/DVALIN.md`, and the example workflow.

## Testing

`npm run check`: 343 tests / 50 files. Repo self-scan clean, exit 0.

## Security and AI Governance

- [x] This change does not expand file, shell, network, model, or approval permissions.
- [x] If it changes agent behavior, prompts, policy, providers, audit logging, or release/build security, I updated the relevant governance evidence in `docs/`.
- [x] If it introduces a new model/provider/tool or new data flow, I completed `docs/governance/AI-CHANGE-IMPACT-ASSESSMENT.md`.

Documentation only.

## Notes on how this was tested

Both CLIs were installed globally on the maintainer's machine with their agreement, after checking the packages' npm maintainers resolve to `@anthropic.com` and `@openai.com` respectively.

Test configuration went into a throwaway directory, and everything added was removed afterwards: `claude mcp remove -s local`, `codex mcp remove`. Verified afterwards that no MCP entry remains in either config, and that the pre-existing `claude.ai Google Drive` connector and every unrelated Codex section survived untouched. `codex mcp add/remove` did reformat `~/.codex/config.toml` — key ordering and `120` to `120.0` — which is its own writer normalising; a byte-exact backup was taken first and the content was checked to be semantically identical.

The two CLIs were left installed, since they are useful to keep.
