### PR TITLE
feat(cli): add tools --json so an agent can discover how to call things

### DIFF
--- a/docs/HARNESS-MODE.md
+++ b/docs/HARNESS-MODE.md
@@ -176,6 +176,37 @@ same `runId` as the `result` line.
 
 ---
 
+## `tools --json` — what is callable, and how
+
+Capability discovery. `--json` reports every tool with the JSON Schema needed
+to build its input:
+
+```sh
+dvalincode tools --json
+```
+
+```json
+{ "tools": [
+  { "name": "list_files", "access": "read", "description": "...",
+    "parameters": { "type": "object", "properties": { "pattern": { "type": "string" } },
+                    "required": ["pattern"] },
+    "requiresYes": false } ] }
+```
+
+`parameters` is produced by the same helper the agent loop and the runner use,
+so a caller reading it gets exactly the schema the model is given. If those
+forked, an agent would build inputs the model would never produce.
+
+`requiresYes` is true for `write` and `execute` tools — the ones `run-tool`
+refuses without `--yes`, reporting `permission_denied`.
+
+Together with `run-tool --json` this closes the loop: discover a tool, read its
+schema, build an input, call it, and read a structured result — without parsing
+prose at any step.
+
+The text output is unchanged in shape, but its columns are now sized from the
+longest name rather than a fixed width, which a long tool name used to overflow.
+
 ## `run-tool --json` — one tool, machine-readable
 
 `dvalincode run` drives a whole governed turn. When a caller wants a single

--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -6,7 +6,7 @@ import { minimizedDescriptor } from '../audit/minimize.js';
 import { policyHash, type LoadedPolicy } from '../core/policy.js';
 import type { ChatMessage, TokenUsage } from '../providers/types.js';
 import type { ProviderAdapter } from '../providers/types.js';
-import type { ToolRegistry } from '../tools/registry.js';
+import { toolParametersSchema, type ToolRegistry } from '../tools/registry.js';
 import type { DvalinContext } from '../core/context.js';
 
 /** Per-run audit configuration for the agent loop. */
@@ -146,7 +146,7 @@ export class AgentLoop {
           const toolDefs = this.registry.list().map(tool => ({
             name: tool.name,
             description: tool.description,
-            parameters: tool.parametersSchema ?? tool.inputSchema.toJSONSchema?.() ?? {},
+            parameters: toolParametersSchema(tool),
           }));
           if (estimateRequestTokens(messages, this.systemPrompt, toolDefs) > triggerTokens) {
             state = TurnState.COMPACT;

--- a/src/agent/runner.ts
+++ b/src/agent/runner.ts
@@ -1,5 +1,5 @@
 import type { ChatMessage, ChatResponse, TokenUsage, ToolCall, ToolDef, ProviderAdapter } from '../providers/types.js';
-import { truncateToolOutput, type ToolRegistry } from '../tools/registry.js';
+import { toolParametersSchema, truncateToolOutput, type ToolRegistry } from '../tools/registry.js';
 import type { DvalinContext } from '../core/context.js';
 import type { TurnConfig, UndoEntry, AgentEventHandler } from './types.js';
 import type { ReverseOp } from '../tools/types.js';
@@ -405,7 +405,7 @@ export class AgentRunner {
     return this.registry.list().map(tool => ({
       name: tool.name,
       description: tool.description,
-      parameters: tool.parametersSchema ?? tool.inputSchema.toJSONSchema?.() ?? {},
+      parameters: toolParametersSchema(tool),
     }));
   }
 

--- a/src/commands/tools.ts
+++ b/src/commands/tools.ts
@@ -1,14 +1,45 @@
 import type { Command } from 'commander';
-import type { ToolRegistry } from '../tools/registry.js';
+import { toolParametersSchema, type ToolRegistry } from '../tools/registry.js';
+
+/** One tool as `dvalincode tools --json` reports it. */
+export type ToolListEntry = {
+  name: string;
+  access: string;
+  description: string;
+  /** JSON Schema for `run-tool -i`. The same schema the model is given. */
+  parameters: Record<string, unknown>;
+  /** True when the tool needs `run-tool --yes` to run at all. */
+  requiresYes: boolean;
+};
 
 export function registerToolsCommand(program: Command, registry: ToolRegistry): void {
   program
     .command('tools')
     .description('List available tools')
-    .action(() => {
-      for (const tool of registry.list()) {
-        console.log(`${tool.name.padEnd(14)} ${tool.access.padEnd(7)} ${tool.description}`);
+    .option('--json', 'print the tool list as JSON, including each input schema')
+    .action((options: { json?: boolean }) => {
+      const tools = registry.list();
+      if (options.json) {
+        console.log(JSON.stringify({ tools: tools.map(toEntry) }, null, 2));
+        return;
+      }
+      // Width from the longest name rather than a fixed 14: `list_remediation_cases`
+      // overflowed it and pushed the rest of that row out of alignment, which
+      // silently breaks anything parsing these columns by position.
+      const nameWidth = Math.max(...tools.map(tool => tool.name.length), 4);
+      const accessWidth = Math.max(...tools.map(tool => tool.access.length), 6);
+      for (const tool of tools) {
+        console.log(`${tool.name.padEnd(nameWidth)}  ${tool.access.padEnd(accessWidth)}  ${tool.description}`);
       }
     });
 }
 
+function toEntry(tool: ReturnType<ToolRegistry['list']>[number]): ToolListEntry {
+  return {
+    name: tool.name,
+    access: tool.access,
+    description: tool.description,
+    parameters: toolParametersSchema(tool),
+    requiresYes: tool.access === 'write' || tool.access === 'execute',
+  };
+}

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -28,6 +28,18 @@ import { deleteFileTool } from './deleteFile.js';
 import { gitStatusTool } from './gitStatus.js';
 import type { Tool, ToolResult } from './types.js';
 
+/**
+ * The JSON Schema a caller needs to build a valid input for this tool.
+ *
+ * Prefer the pre-computed schema — MCP-backed tools carry their own server's
+ * native one — and fall back to deriving it from the zod type. Shared so the
+ * agent loop, the runner, and `dvalincode tools --json` cannot drift: an agent
+ * that reads the CLI's schema must get exactly what the model is given.
+ */
+export function toolParametersSchema(tool: Tool<unknown>): Record<string, unknown> {
+  return tool.parametersSchema ?? tool.inputSchema.toJSONSchema?.() ?? {};
+}
+
 export type TruncatedToolOutput = {
   output: string;
   truncated: boolean;

--- a/tests/commands/tools.test.ts
+++ b/tests/commands/tools.test.ts
@@ -1,0 +1,108 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { z } from 'zod';
+import { Command } from 'commander';
+import { registerToolsCommand } from '../../src/commands/tools.js';
+import { ToolRegistry, toolParametersSchema } from '../../src/tools/registry.js';
+import type { Tool, ToolAccess } from '../../src/tools/types.js';
+
+function tool(name: string, access: ToolAccess, overrides: Partial<Tool<any>> = {}): Tool<any> {
+  return {
+    name,
+    description: `${name} description`,
+    access,
+    inputSchema: z.object({ pattern: z.string() }),
+    async run() {
+      return { title: 'ok', output: '' };
+    },
+    ...overrides,
+  } as Tool<any>;
+}
+
+function invoke(registry: ToolRegistry, args: string[] = []): string {
+  let captured = '';
+  const spy = vi.spyOn(console, 'log').mockImplementation(line => {
+    captured += `${String(line)}\n`;
+  });
+  const program = new Command();
+  program.exitOverride();
+  registerToolsCommand(program, registry);
+  program.parse(['node', 'dvalincode', 'tools', ...args]);
+  spy.mockRestore();
+  return captured;
+}
+
+afterEach(() => vi.restoreAllMocks());
+
+describe('tools --json', () => {
+  it('reports each tool with the schema needed to call it', () => {
+    const registry = new ToolRegistry();
+    registry.register(tool('list_files', 'read'));
+    const body = JSON.parse(invoke(registry, ['--json']));
+
+    expect(body.tools).toHaveLength(1);
+    expect(body.tools[0]).toMatchObject({
+      name: 'list_files',
+      access: 'read',
+      description: 'list_files description',
+      requiresYes: false,
+    });
+    expect(body.tools[0].parameters.properties).toHaveProperty('pattern');
+  });
+
+  it('gives the caller the same schema the model is given', () => {
+    const registry = new ToolRegistry();
+    const listFiles = tool('list_files', 'read');
+    registry.register(listFiles);
+    const body = JSON.parse(invoke(registry, ['--json']));
+    // Both go through toolParametersSchema; if that ever forks, an agent
+    // reading the CLI would build inputs the model would never produce.
+    expect(body.tools[0].parameters).toEqual(toolParametersSchema(listFiles));
+  });
+
+  it('prefers a pre-computed schema, as MCP-backed tools carry', () => {
+    const native = { type: 'object', properties: { q: { type: 'string' } } };
+    const registry = new ToolRegistry();
+    registry.register(tool('mcp_thing', 'read', { parametersSchema: native }));
+    const body = JSON.parse(invoke(registry, ['--json']));
+    expect(body.tools[0].parameters).toEqual(native);
+  });
+
+  it('flags exactly the tools that need --yes', () => {
+    const registry = new ToolRegistry();
+    registry.register(tool('reader', 'read'));
+    registry.register(tool('writer', 'write'));
+    registry.register(tool('runner', 'execute'));
+    const byName = Object.fromEntries(
+      JSON.parse(invoke(registry, ['--json'])).tools.map((t: any) => [t.name, t.requiresYes]),
+    );
+    expect(byName).toEqual({ reader: false, writer: true, runner: true });
+  });
+
+  it('emits valid JSON for an empty registry rather than nothing', () => {
+    expect(JSON.parse(invoke(new ToolRegistry(), ['--json']))).toEqual({ tools: [] });
+  });
+});
+
+describe('tools (text)', () => {
+  it('keeps columns aligned when one name is far longer than the rest', () => {
+    const registry = new ToolRegistry();
+    registry.register(tool('git_diff', 'read'));
+    registry.register(tool('list_remediation_cases', 'read'));
+    const lines = invoke(registry).trim().split('\n');
+
+    // The access column must start at the same offset on every row; a fixed
+    // pad width used to break precisely on the long name.
+    const offsets = lines.map(line => line.indexOf('read'));
+    expect(new Set(offsets).size).toBe(1);
+    expect(offsets[0]).toBeGreaterThan('list_remediation_cases'.length);
+  });
+
+  it('still prints one row per tool with its description', () => {
+    const registry = new ToolRegistry();
+    registry.register(tool('git_diff', 'read'));
+    const lines = invoke(registry).trim().split('\n');
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toContain('git_diff');
+    expect(lines[0]).toContain('git_diff description');
+  });
+});


### PR DESCRIPTION
## Why

`tools` is the capability-discovery entry point — the first thing an agent asks — and it was the one place an agent could not start from:

```
delete_file    write   Delete a file inside the workspace...
list_remediation_cases read    List local remediation cases...
```

Prose, and columns that stop lining up as soon as a name exceeds 14 characters.

## What it returns

```json
{ "tools": [
  { "name": "list_files", "access": "read", "description": "...",
    "parameters": { "type": "object",
                    "properties": { "pattern": { "type": "string" } },
                    "required": ["pattern"] },
    "requiresYes": false } ] }
```

`requiresYes` is true for `write` and `execute` — the tools `run-tool` refuses without `--yes`, reporting `permission_denied`.

## The schema is the same one the model sees

`parameters` comes from a new shared `toolParametersSchema()`. That expression was already duplicated in `loop.ts` and `runner.ts`; a third copy here would have been the one that drifted.

Drift matters more than usual for this particular value: the point of publishing the schema is that a caller reading the CLI builds inputs the model would also produce. If the CLI's copy fell behind, an agent would construct inputs that the agent loop rejects, and the CLI would be lying about the contract. There is a test asserting the two agree.

## Verified by doing the thing it exists for

A script with no other knowledge of the tool: read `tools --json`, construct an input purely from `required` and the declared property types, call `run-tool`, check the result.

```
发现工具: list_files | requiresYes: false
参数: pattern:string, limit:integer
必填: [ 'pattern', 'limit' ]
→ 构造出的输入: {"pattern":"*.js","limit":1}
→ 调用结果: ✅ ok=true  Listed 1 file
```

Discover → schema → input → call → structured result, with no prose parsed at any step.

## Text output

Column widths now come from the longest name instead of a fixed 14. `list_remediation_cases` overflowed that and pushed the rest of its row out of line, which silently breaks anything reading the columns by position.

**The regression test for it was confirmed to fail against the old padding before being kept** — a formatting test that cannot fail is worse than none.

## Testing

7 new tests: the JSON shape; that `parameters` equals `toolParametersSchema` for the same tool; that a pre-computed schema wins (MCP-backed tools carry their server's own); `requiresYes` across all three access levels; valid JSON for an empty registry; column alignment with a long name; and that the text rows still carry name and description.

`npm run check`: 350 tests / 51 files. Repo self-scan clean.

## Security and AI Governance

- [x] This change does not expand file, shell, network, model, or approval permissions.
- [x] If it changes agent behavior, prompts, policy, providers, audit logging, or release/build security, I updated the relevant governance evidence in `docs/`.
- [x] If it introduces a new model/provider/tool or new data flow, I completed `docs/governance/AI-CHANGE-IMPACT-ASSESSMENT.md`.

Read-only listing of what is already registered. The refactor is behaviour-preserving — `loop.ts` and `runner.ts` now call a function containing the expression they had inline.

One thing a reviewer might weigh: this publishes tool input schemas to anyone who can run the CLI. They are not secret — the model receives them every turn, and the tool names were already listed — but the schemas are now easier to enumerate.

## Notes

Third of the three gaps from the CLI review. The last one is unaddressed: **exit codes are inconsistent across commands** — `dvalin --fail-on` uses 2, `run` documents 0/1/3/4, `run-tool` uses 1 for everything, and no single place states the convention.

Also, while editing `loop.ts` and `runner.ts` I truncated both files with a bad in-place rewrite (`open(p,'w')` evaluates before the read, so it wrote an empty file). Caught by the typecheck immediately, restored from HEAD, and redone. Mentioning it because the diff for those two files should be exactly two lines each — an import and a call — and it is worth confirming that is all it is.
