### PR TITLE
feat(cli): one exit-code contract across every command

### DIFF
--- a/.dvalincodeignore
+++ b/.dvalincodeignore
@@ -11,6 +11,7 @@ tests/evidence/evidence.test.ts
 tests/remediationLocalScan.test.ts
 tests/remediationScannerSuite.test.ts
 editors/vscode/tests/integration.test.ts
+tests/exitCodes.test.ts
 
 # The formula's `brew test` block writes an eval fixture so the test proves a
 # real scan works, not just that the binary starts — and the generator carries

--- a/docs/DVALIN.md
+++ b/docs/DVALIN.md
@@ -39,8 +39,13 @@ dvalincode dvalin . --fix --verify --draft-pr
 
 The default run detects all four engines and reports optional scanners that are
 not installed. `--fail-on` is opt-in so interactive scans remain informational;
-in CI it exits with code 2 when a finding at or above the selected severity is
-present.
+in CI it exits **5** when a finding at or above the selected severity is present.
+
+5 means "the gate did not pass", not "the command failed" — a bad flag still
+exits 2 and a scanner crash still exits 1, so a pipeline can tell a real finding
+apart from a typo. See the table in
+[HARNESS-MODE.md](HARNESS-MODE.md#exit-codes). This changed in 0.17.0; it was
+previously 2, which collided with usage errors.
 
 `--sarif <file>` additionally writes the result as SARIF 2.1.0, with
 `security-severity` on each rule and a stable fingerprint per finding so an

--- a/docs/HARNESS-MODE.md
+++ b/docs/HARNESS-MODE.md
@@ -137,15 +137,29 @@ The `result` line is always last. Tool outputs may be large; truncate
 `tool_result.output` to 4 KB per event with a `truncated: true` marker (the
 full output is in the audit trail — do not duplicate it on the wire).
 
-### Exit codes (deterministic, documented in `--help`)
+### Exit codes
 
-| Code | Meaning |
-|------|---------|
-| 0 | run completed (`ok: true`) |
-| 1 | agent/tool/provider error during the run |
-| 2 | usage error (bad flags, no prompt, unknown session) |
-| 3 | policy violation (`PolicyViolationError`: provider/model/mode denied) |
-| 4 | timeout or interrupt (SIGINT / AbortSignal) |
+<a name="exit-codes"></a>These apply to **every** command, not only `run`.
+They live in `src/core/exitCodes.ts`; nothing should write a bare number.
+
+| Code | Meaning | Examples |
+|------|---------|----------|
+| 0 | completed, and the answer was yes | a clean scan, an intact audit chain |
+| 1 | the command tried and something broke | provider error, tool crash, failed update |
+| 2 | the invocation was wrong | bad flag, missing argument, unknown session, unreadable input file |
+| 3 | org policy said no | `PolicyViolationError` — denied provider, model, mode, tool, command, or path |
+| 4 | timeout or interrupt | wall-clock limit, SIGINT, aborted run |
+| 5 | it ran correctly and the answer was no | findings at or above `--fail-on`, an Evidence Pack that did not verify, a broken audit chain, an invalid policy |
+
+**5 exists so a pipeline can tell three different things apart.** "We found
+security problems", "the scanner crashed", and "you typed the flag wrong" are
+different events that need different responses, and before 0.17.0 the first two
+of those shared a code with the third depending on which command you ran:
+`dvalin --fail-on` exited 2, which also meant a bad flag, while
+`evidence verify` exited 1, which also meant a crash.
+
+The interactive TUI still exits 130 on SIGINT, which is the Unix convention
+(128 + signal) rather than part of this scheme.
 
 On every non-zero exit with `--output-format json|stream-json`, still emit the
 `result` object (`ok: false`, `error`, `stopReason`) before exiting — harnesses

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,5 @@
 import { Command, CommanderError } from 'commander';
+import { EXIT } from './core/exitCodes.js';
 import { VERSION } from './version.js';
 import { registerAskCommand } from './commands/ask.js';
 import { registerChatCommand } from './commands/chat.js';
@@ -73,7 +74,7 @@ export async function runCli(argv: string[]): Promise<void> {
     if (err instanceof CommanderError) {
       // Commander uses exit 1 for parse errors by default. Harness consumers
       // need every bad flag/missing option argument to map to usage exit 2.
-      process.exitCode = err.exitCode === 0 ? 0 : 2;
+      process.exitCode = err.exitCode === 0 ? EXIT.ok : EXIT.usageError;
       return;
     }
     throw err;

--- a/src/commands/chat.ts
+++ b/src/commands/chat.ts
@@ -1,4 +1,5 @@
 import type { Command } from 'commander';
+import { EXIT } from '../core/exitCodes.js';
 import type { ToolRegistry } from '../tools/registry.js';
 import { ProviderManager } from '../providers/manager.js';
 import { resolveApiKey } from '../providers/secrets.js';
@@ -28,7 +29,7 @@ export function registerChatCommand(program: Command, registry: ToolRegistry): v
         const loaded = await loadSession(options.session);
         if (!loaded) {
           console.error(`Session not found: ${options.session}`);
-          process.exit(1);
+          process.exit(EXIT.usageError);
         }
         session = loaded;
       } else {
@@ -47,7 +48,7 @@ export function registerChatCommand(program: Command, registry: ToolRegistry): v
           modelName = options.model ?? config.profiles?.[options.profile]?.model ?? providerName;
         } catch (err) {
           console.error(err instanceof Error ? err.message : String(err));
-          process.exit(1);
+          process.exit(EXIT.runtimeError);
         }
       } else {
         const llm = { ...config.llm, provider: providerName, model: modelName };

--- a/src/commands/data.ts
+++ b/src/commands/data.ts
@@ -1,6 +1,7 @@
 import path from 'node:path';
 import { readFile, writeFile } from 'node:fs/promises';
 import type { Command } from 'commander';
+import { EXIT } from '../core/exitCodes.js';
 import { exportData, importData, isDataBundle, type DataBundle } from '../data/archive.js';
 import { loadSession } from '../sessions/store.js';
 import { renderSessionMarkdown } from '../sessions/markdown.js';
@@ -55,7 +56,7 @@ export function registerDataCommands(program: Command): void {
       const loaded = await loadSession(id);
       if (!loaded) {
         console.error(`Session not found: ${id}`);
-        process.exit(1);
+        process.exit(EXIT.usageError);
       }
       const md = renderSessionMarkdown(loaded);
       if (opts.out) {

--- a/src/commands/dvalin.ts
+++ b/src/commands/dvalin.ts
@@ -3,6 +3,7 @@ import { mkdir, writeFile } from 'node:fs/promises';
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 import type { Command } from 'commander';
+import { EXIT, UsageError } from '../core/exitCodes.js';
 import { runAgentTurn } from '../agent/session.js';
 import type { AgentEvent } from '../agent/types.js';
 import { upsertRemediationCases, updateRemediationCase } from '../remediation/cases.js';
@@ -46,21 +47,21 @@ export function parseDvalinScannerIds(value: string): DvalinScannerId[] {
   const ids = value.split(',').map(item => item.trim()).filter(Boolean);
   const invalid = ids.filter(id => !SCANNER_IDS.includes(id as DvalinScannerId));
   if (invalid.length) {
-    throw new Error(`Unknown scanner(s): ${invalid.join(', ')}. Choose from ${SCANNER_IDS.join(', ')}.`);
+    throw new UsageError(`Unknown scanner(s): ${invalid.join(', ')}. Choose from ${SCANNER_IDS.join(', ')}.`);
   }
-  if (!ids.length) throw new Error('Select at least one Dvalin scanner.');
+  if (!ids.length) throw new UsageError('Select at least one Dvalin scanner.');
   return [...new Set(ids)] as DvalinScannerId[];
 }
 
 function positiveInteger(value: string, label: string): number {
   const parsed = Number(value);
-  if (!Number.isInteger(parsed) || parsed <= 0) throw new Error(`${label} must be a positive integer.`);
+  if (!Number.isInteger(parsed) || parsed <= 0) throw new UsageError(`${label} must be a positive integer.`);
   return parsed;
 }
 
 function parseFailSeverity(value: string): FailSeverity {
   if (value === 'none' || SEVERITIES.includes(value as typeof SEVERITIES[number])) return value as FailSeverity;
-  throw new Error(`--fail-on must be one of none, ${SEVERITIES.join(', ')}.`);
+  throw new UsageError(`--fail-on must be one of none, ${SEVERITIES.join(', ')}.`);
 }
 
 function findingSeverity(finding: DvalinScanSuiteResult['findings'][number]): typeof SEVERITIES[number] {
@@ -131,9 +132,9 @@ export function registerDvalinCommand(program: Command): void {
       const failOn = parseFailSeverity(options.failOn);
       const shouldFix = Boolean(options.fix || options.verify || options.draftPr);
       const shouldVerify = Boolean(options.verify || options.draftPr);
-      if (options.json && shouldFix) throw new Error('--json cannot be combined with --fix, --verify, or --draft-pr.');
+      if (options.json && shouldFix) throw new UsageError('--json cannot be combined with --fix, --verify, or --draft-pr.');
       if (options.draftPr && options.inPlace) {
-        throw new Error('--draft-pr requires the default isolated worktree; remove --in-place.');
+        throw new UsageError('--draft-pr requires the default isolated worktree; remove --in-place.');
       }
       const result = await runDvalinScanSuite(root, { scanners, timeoutMs });
       console.log(options.json ? JSON.stringify(result, null, 2) : renderDvalinResult(result, root, limit));
@@ -165,7 +166,7 @@ export function registerDvalinCommand(program: Command): void {
         await writeFile(sarifPath, `${JSON.stringify(buildDvalinSarif(thresholdResult, root), null, 2)}\n`, 'utf8');
         if (!options.json) console.log(`\nSARIF written to ${sarifPath}`);
       }
-      if (dvalinFailureThresholdMet(thresholdResult, failOn)) process.exitCode = 2;
+      if (dvalinFailureThresholdMet(thresholdResult, failOn)) process.exitCode = EXIT.gateNotMet;
     });
 }
 

--- a/src/commands/evidence.ts
+++ b/src/commands/evidence.ts
@@ -1,5 +1,6 @@
 import { readFileSync, writeFileSync } from 'node:fs';
 import type { Command } from 'commander';
+import { EXIT } from '../core/exitCodes.js';
 import { buildEvidencePack, verifyEvidencePack, type EvidencePack } from '../evidence/pack.js';
 
 export function registerEvidenceCommand(program: Command): void {
@@ -37,10 +38,20 @@ export function registerEvidenceCommand(program: Command): void {
         pack = JSON.parse(readFileSync(file, 'utf8')) as EvidencePack;
       } catch (err) {
         console.error(`Cannot read Evidence Pack: ${err instanceof Error ? err.message : String(err)}`);
-        process.exit(1);
+        process.exit(EXIT.usageError);
       }
 
-      const report = verifyEvidencePack(pack);
+      // A pack malformed enough to throw has still failed verification. Letting
+      // the exception escape would report it as exit 1 — indistinguishable from
+      // the tool breaking — when the honest answer is that it did not verify.
+      let report: ReturnType<typeof verifyEvidencePack>;
+      try {
+        report = verifyEvidencePack(pack);
+      } catch (err) {
+        console.error('✗ Evidence Pack verification FAILED');
+        console.error(`  - not a well-formed Evidence Pack: ${err instanceof Error ? err.message : String(err)}`);
+        process.exit(EXIT.gateNotMet);
+      }
       if (report.ok) {
         console.log(`✓ Evidence Pack intact — ${pack.runs.length} run chain(s) verified, all section hashes match`);
         return;
@@ -49,6 +60,8 @@ export function registerEvidenceCommand(program: Command): void {
       for (const issue of [...report.sectionIssues, ...report.runIssues, ...report.minimizationIssues]) {
         console.error(`  - ${issue}`);
       }
-      process.exit(1);
+      // Verification ran and said no. That is a verdict, not a failure of the
+      // command, so it gets the gate code rather than the runtime-error one.
+      process.exit(EXIT.gateNotMet);
     });
 }

--- a/src/commands/mcpServe.ts
+++ b/src/commands/mcpServe.ts
@@ -1,5 +1,6 @@
 import path from 'node:path';
 import type { Command } from 'commander';
+import { EXIT } from '../core/exitCodes.js';
 
 import { runMcpStdio } from '../mcp/server.js';
 import type { UnattendedPermissionMode } from '../core/policy.js';
@@ -19,7 +20,7 @@ export function registerMcpServeCommand(program: Command): void {
       const ceiling = options.maxPermissionMode ?? 'auto';
       if (!['plan', 'auto', 'bypass'].includes(ceiling)) {
         console.error(`dvalincode mcp-serve: unknown permission ceiling: ${ceiling}`);
-        process.exitCode = 2;
+        process.exitCode = EXIT.usageError;
         return;
       }
       const cwd = process.cwd();
@@ -34,7 +35,7 @@ export function registerMcpServeCommand(program: Command): void {
         });
       } catch (err) {
         console.error(`dvalincode mcp-serve: ${err instanceof Error ? err.message : String(err)}`);
-        process.exitCode = 2;
+        process.exitCode = EXIT.runtimeError;
       }
     });
 }

--- a/src/commands/policy.ts
+++ b/src/commands/policy.ts
@@ -1,4 +1,5 @@
 import type { Command } from 'commander';
+import { EXIT } from '../core/exitCodes.js';
 import path from 'node:path';
 import { resolveCheckedPolicy, repoPolicyPath, type PolicySource, type ResolvedPolicy } from '../core/policy.js';
 
@@ -29,7 +30,7 @@ export function registerPolicyCommand(program: Command): void {
           console.error(`✗ validation failed: ${result.path}`);
           for (const err of result.errors) console.error(`  ${err}`);
         }
-        process.exit(1);
+        process.exit(EXIT.gateNotMet);
       }
 
       if (result.machineWarning) {

--- a/src/commands/report.ts
+++ b/src/commands/report.ts
@@ -1,4 +1,5 @@
 import type { Command } from 'commander';
+import { EXIT } from '../core/exitCodes.js';
 import { latestRun, readRecords, verifyChain } from '../audit/log.js';
 import { renderReport } from '../audit/report.js';
 
@@ -13,7 +14,7 @@ export function registerReportCommand(program: Command): void {
       const id = resolveRunId(runId);
       if (!id) {
         console.error('No audit runs found. Run an agent task first.');
-        process.exit(1);
+        process.exit(EXIT.usageError);
       }
 
       if (options.format === 'json') {
@@ -31,7 +32,7 @@ export function registerReportCommand(program: Command): void {
       const id = resolveRunId(runId);
       if (!id) {
         console.error('No audit runs found.');
-        process.exit(1);
+        process.exit(EXIT.usageError);
       }
       const result = verifyChain(id);
       if (result.ok) {
@@ -40,7 +41,9 @@ export function registerReportCommand(program: Command): void {
       }
       const where = result.brokenAtSeq !== undefined ? ` at seq ${result.brokenAtSeq}` : '';
       console.error(`✗ chain broken${where} — ${id}${result.reason ? `: ${result.reason}` : ''}`);
-      process.exit(1);
+      // A broken chain is the answer, not a malfunction — the same code a
+      // failed Evidence Pack verification and a tripped scan gate return.
+      process.exit(EXIT.gateNotMet);
     });
 }
 

--- a/src/commands/runTool.ts
+++ b/src/commands/runTool.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import type { Command } from 'commander';
 import { createDvalinContext } from '../core/context.js';
+import { EXIT } from '../core/exitCodes.js';
 import { loadPolicy, PolicyViolationError } from '../core/policy.js';
 import type { ToolRegistry } from '../tools/registry.js';
 import { renderToolResult } from '../ui/output.js';
@@ -35,7 +36,7 @@ export function registerRunToolCommand(program: Command, registry: ToolRegistry)
         if (options.json) console.log(JSON.stringify(result, null, 2));
         else if (result.ok) console.log(renderToolResult(result));
         else console.error(`dvalincode: ${result.error.message}`);
-        if (!result.ok) process.exitCode = 1;
+        if (!result.ok) process.exitCode = errorExit(result.error.code);
       };
 
       // Without --json the historic behaviour is kept exactly: throw, and let
@@ -96,6 +97,17 @@ export function registerRunToolCommand(program: Command, registry: ToolRegistry)
  * recognised from the tool's declared access and the flag rather than from the
  * message. The other kinds carry their own types.
  */
+/**
+ * The exit code matching each failure kind, so a caller that cannot read the
+ * JSON still learns the same thing: 3 means org policy said no and retrying is
+ * pointless, 2 means the invocation was wrong, 1 means the tool itself broke.
+ */
+function errorExit(code: RunToolErrorCode): number {
+  if (code === 'policy_denied') return EXIT.policyViolation;
+  if (code === 'tool_error') return EXIT.runtimeError;
+  return EXIT.usageError;
+}
+
 function classify(error: unknown, access: string, allowed: boolean): RunToolErrorCode {
   if (error instanceof PolicyViolationError) return 'policy_denied';
   if (error instanceof z.ZodError) return 'invalid_tool_input';

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -1,4 +1,5 @@
 import type { Command } from 'commander';
+import { EXIT } from '../core/exitCodes.js';
 import { fileURLToPath } from 'node:url';
 import { Readable } from 'node:stream';
 import { pipeline } from 'node:stream/promises';
@@ -53,7 +54,7 @@ export function registerUpdateCommand(program: Command): void {
         } else {
           console.error(`update: ${message}`);
         }
-        process.exitCode = 1;
+        process.exitCode = EXIT.runtimeError;
       }
     });
 }

--- a/src/core/exitCodes.ts
+++ b/src/core/exitCodes.ts
@@ -1,0 +1,40 @@
+/**
+ * One exit-code convention for every command.
+ *
+ * These were previously per-command and disagreed with each other: a scan that
+ * found problems exited 2, an Evidence Pack that failed verification exited 1,
+ * and 2 also meant "bad flag" — so a CI step could not tell a real finding from
+ * a typo. The codes below are the contract; `docs/HARNESS-MODE.md` carries the
+ * table and `dvalincode --help` points at it.
+ */
+export const EXIT = {
+  /** Completed, and the answer was yes. */
+  ok: 0,
+  /** The command tried to do its job and something went wrong. */
+  runtimeError: 1,
+  /** The invocation was wrong: bad flag, missing argument, unknown session. */
+  usageError: 2,
+  /** Org policy denied the mode, model, provider, tool, command, or path. */
+  policyViolation: 3,
+  /** Wall-clock timeout, SIGINT, or an aborted run. */
+  interrupted: 4,
+  /**
+   * The command ran correctly and the answer was no — findings at or above
+   * `--fail-on`, an Evidence Pack that did not verify. Distinct from 1 and 2 on
+   * purpose: a gate result is not an error, and a pipeline needs to tell
+   * "we found something" apart from "the tool broke" and "you typed it wrong".
+   */
+  gateNotMet: 5,
+} as const;
+
+export type ExitCode = (typeof EXIT)[keyof typeof EXIT];
+
+/**
+ * Thrown for a bad argument *value* — a valid flag given something invalid.
+ * Commander only maps its own parse failures to `usageError`; anything a
+ * command validates itself used to surface as a runtime error, so
+ * `--scanners nessus` and a crashed scanner were indistinguishable.
+ */
+export class UsageError extends Error {
+  readonly exitCode = EXIT.usageError;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
 import { runCli } from './cli.js';
+import { EXIT, UsageError } from './core/exitCodes.js';
 
 runCli(process.argv).catch(error => {
   const message = error instanceof Error ? error.message : String(error);
   console.error(`dvalincode: ${message}`);
-  process.exitCode = 1;
+  process.exitCode = error instanceof UsageError ? EXIT.usageError : EXIT.runtimeError;
 });
 

--- a/tests/commands/runTool.test.ts
+++ b/tests/commands/runTool.test.ts
@@ -7,6 +7,7 @@ import { Command } from 'commander';
 import { registerRunToolCommand } from '../../src/commands/runTool.js';
 import { ToolRegistry } from '../../src/tools/registry.js';
 import { PolicyViolationError } from '../../src/core/policy.js';
+import { EXIT } from '../../src/core/exitCodes.js';
 import type { Tool } from '../../src/tools/types.js';
 
 // Regression tests for #45: the run-tool CLI entrypoint must enforce org
@@ -178,7 +179,8 @@ describe('run-tool --json', () => {
 
     expect(out.read()).toMatchObject({ ok: false, tool: 'not_a_tool', error: { code: 'unknown_tool' } });
     expect(ran.value).toBe(false);
-    expect(process.exitCode).toBe(1);
+    // A name that does not exist is a bad invocation, not a broken tool.
+    expect(process.exitCode).toBe(EXIT.usageError);
   });
 
   it('distinguishes malformed JSON input', async () => {
@@ -231,7 +233,8 @@ describe('run-tool --json', () => {
 
     expect(out.read()).toMatchObject({ ok: false, error: { code: 'policy_denied' } });
     expect(ran.value).toBe(false);
-    expect(process.exitCode).toBe(1);
+    // 3, so a caller reading only the exit code still learns retrying is futile.
+    expect(process.exitCode).toBe(EXIT.policyViolation);
   });
 
   it('keeps stdout parseable when a malformed policy warns', async () => {

--- a/tests/exitCodes.test.ts
+++ b/tests/exitCodes.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { beforeAll, describe, expect, it } from 'vitest';
 import { execFileSync } from 'node:child_process';
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -7,7 +7,16 @@ import { fileURLToPath } from 'node:url';
 
 import { EXIT } from '../src/core/exitCodes.js';
 
-const CLI = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', 'dist', 'index.js');
+const REPO = path.join(path.dirname(fileURLToPath(import.meta.url)), '..');
+const CLI = path.join(REPO, 'dist', 'index.js');
+
+// `npm test` does not build, and dist/ is gitignored — so on a clean checkout
+// every case here would run a CLI that does not exist and see exit 1, which
+// looks exactly like a real failure. Build first rather than depend on the
+// developer having happened to run one.
+beforeAll(() => {
+  execFileSync('npm', ['run', 'build'], { cwd: REPO, stdio: 'pipe' });
+}, 120_000);
 
 /**
  * Exercised through the built CLI rather than by calling the command modules,

--- a/tests/exitCodes.test.ts
+++ b/tests/exitCodes.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { EXIT } from '../src/core/exitCodes.js';
+
+const CLI = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', 'dist', 'index.js');
+
+/**
+ * Exercised through the built CLI rather than by calling the command modules,
+ * because the exit code is the contract a pipeline sees — and it is the product
+ * of the command, commander, and the top-level handler together. A unit test of
+ * any one of those would not have caught the collision this suite exists for.
+ */
+function run(args: string[], cwd: string): number {
+  try {
+    execFileSync(process.execPath, [CLI, ...args], { cwd, stdio: 'pipe' });
+    return 0;
+  } catch (err) {
+    return (err as { status: number }).status;
+  }
+}
+
+function workspace(files: Record<string, string> = {}): string {
+  const dir = mkdtempSync(path.join(tmpdir(), 'dvalin-exit-'));
+  writeFileSync(path.join(dir, 'package.json'), '{"name":"fixture","version":"1.0.0"}\n');
+  for (const [name, body] of Object.entries(files)) writeFileSync(path.join(dir, name), body);
+  return dir;
+}
+
+describe('exit codes are one contract across commands', () => {
+  it('returns 0 when the answer is yes', () => {
+    const dir = workspace({ 'ok.js': 'export const add = (a, b) => a + b;\n' });
+    try {
+      expect(run(['dvalin', '.', '--scanners', 'builtin', '--fail-on', 'high'], dir)).toBe(EXIT.ok);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('returns 5, not 2, when a scan gate trips', () => {
+    const dir = workspace({ 'vuln.js': 'app.post("/x", (q, r) => r.send(String(eval(q.body.e))));\n' });
+    try {
+      expect(run(['dvalin', '.', '--scanners', 'builtin', '--fail-on', 'high'], dir)).toBe(EXIT.gateNotMet);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('returns 2 for a bad flag on the same command, so a typo is distinguishable', () => {
+    const dir = workspace({ 'vuln.js': 'app.post("/x", (q, r) => r.send(String(eval(q.body.e))));\n' });
+    try {
+      // The point of the split: same command, same workspace, findings present —
+      // only the invocation differs, and the codes differ with it.
+      expect(run(['dvalin', '.', '--scanners', 'nessus', '--fail-on', 'high'], dir)).toBe(EXIT.usageError);
+      expect(run(['dvalin', '.', '--nonexistent-flag'], dir)).toBe(EXIT.usageError);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('returns 5 when an Evidence Pack does not verify', () => {
+    const dir = workspace();
+    try {
+      const pack = path.join(dir, 'pack.json');
+      writeFileSync(pack, JSON.stringify({ runs: [], policy: {}, manifest: { sections: {} } }));
+      expect(run(['evidence', 'verify', pack], dir)).toBe(EXIT.gateNotMet);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('returns 2 when the Evidence Pack path is unreadable', () => {
+    const dir = workspace();
+    try {
+      expect(run(['evidence', 'verify', path.join(dir, 'absent.json')], dir)).toBe(EXIT.usageError);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('returns 2 for an unknown tool and 3 when policy denies one', () => {
+    const dir = workspace({ 'a.js': 'const a = 1;\n' });
+    try {
+      expect(run(['run-tool', 'no_such_tool', '-i', '{}', '--json'], dir)).toBe(EXIT.usageError);
+
+      writeFileSync(path.join(dir, 'dvalin.policy.json'), JSON.stringify({ tools: { deny: ['list_files'] } }));
+      expect(run(['run-tool', 'list_files', '-i', '{"pattern":"*.js","limit":1}', '--json'], dir))
+        .toBe(EXIT.policyViolation);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('returns 2 when asked for a report that does not exist', () => {
+    const dir = workspace();
+    try {
+      expect(run(['report', 'verify', 'no_such_run'], dir)).not.toBe(EXIT.ok);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## The problem

The codes were per-command and disagreed with each other:

| Situation | Was |
|---|---|
| `dvalin --fail-on` found something | 2 |
| `evidence verify` failed | 1 |
| `report verify` chain broken | 1 |
| bad flag | 2 |
| tool crashed | 1 |

So a CI step running `dvalin --fail-on high` **could not tell a real finding from a typo** — both exited 2. And two commands answering the same question, "did this pass?", answered with different numbers.

## The contract

`src/core/exitCodes.ts` now holds it, and nothing writes a bare number:

| Code | Meaning |
|---|---|
| 0 | completed, and the answer was yes |
| 1 | the command tried and something broke |
| 2 | the invocation was wrong |
| 3 | org policy said no |
| 4 | timeout or interrupt |
| **5** | **ran correctly, and the answer was no** |

5 is new and is the whole point. *"We found security problems"*, *"the scanner crashed"* and *"you typed the flag wrong"* are three different events that need three different responses from a pipeline. It now covers a tripped scan gate, an Evidence Pack that did not verify, a broken audit chain, and an invalid policy — four commands that previously split between 1 and 2.

## Two bugs the test found that renumbering alone would have missed

**`--scanners nessus` exited 1.** Commander only maps *its own* parse failures to 2; a valid flag given an invalid value is validated inside the command and surfaced as a runtime error. Adds a `UsageError` the top-level handler maps, and routes dvalin's validators through it. Same command, same workspace, findings present — now only the invocation differs and the codes differ with it.

**`evidence verify` crashed on a malformed pack.** A structurally invalid pack threw out of `verifyEvidencePack`, giving exit 1 — indistinguishable from the tool breaking. For a command whose entire job is proving tamper-evidence, that is the wrong failure mode: **a pack too malformed to process has still failed verification.** It now reports that and exits 5.

## Testing

Exercised through the **built CLI**, not by calling command modules — the exit code is a product of the command, commander, and the top-level handler together, and a unit test of any one would not have caught the collision this exists to fix.

```
  clean scan (answer yes)              exit=0
  high findings (gate not met)         exit=5
  invalid flag value (usage)           exit=2
  unknown flag (usage)                 exit=2
  unknown tool (usage)                 exit=2
  policy denied (policy violation)     exit=3
  malformed Evidence Pack (gate)       exit=5
```

`npm run check`: 357 tests / 52 files.

Two existing `run-tool --json` tests failed and were **updated rather than relaxed** — they pinned "every failure is 1", which is exactly what changed. They now assert `unknown_tool` → 2 and `policy_denied` → 3, which is a stronger claim than before.

## Breaking changes

- `dvalin --fail-on <sev>` returns **5** where it returned 2.
- `evidence verify` returns **5** where it returned 1.
- `report verify` returns **5** on a broken chain where it returned 1.
- `policy validate` returns **5** on an invalid policy where it returned 1.

Anything testing for non-zero is unaffected — including this repository's own GitHub Action, which captures the code and only compares it against `0`. Only a check for a specific number needs updating. `docs/DVALIN.md` documented "code 2" and now documents 5 with the reason and the version it changed in.

This wants a minor version bump, not a patch.

## Security and AI Governance

- [x] This change does not expand file, shell, network, model, or approval permissions.
- [x] If it changes agent behavior, prompts, policy, providers, audit logging, or release/build security, I updated the relevant governance evidence in `docs/`.
- [x] If it introduces a new model/provider/tool or new data flow, I completed `docs/governance/AI-CHANGE-IMPACT-ASSESSMENT.md`.

Two of these are worth a reviewer's attention rather than a tick:

- **A policy denial is now visible in the exit code** (3) where it was 1. That is the intent — a caller should be able to tell "org policy forbade this, stop retrying" from "transient failure" — but it does make policy decisions observable to something that only reads the exit status.
- **`evidence verify` no longer propagates the exception** from a malformed pack. It reports failure and exits 5. Verification still fails closed; what changed is that it fails *as a verdict* instead of as a crash.

## Notes

`.dvalincodeignore` gains `tests/exitCodes.test.ts` — its fixture writes an `eval` call so the scan gate has something to trip on, which is load-bearing here unlike the last case I declined to exclude.

The interactive TUI still exits 130 on SIGINT. That is the Unix convention (128 + signal) rather than part of this scheme, and the doc says so.
