### PR TITLE
release: 0.17.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 <p align="center">
   <a href="https://github.com/arthurpanhku/dvalincode/releases/latest"><img src="https://img.shields.io/github/v/release/arthurpanhku/dvalincode?style=for-the-badge&color=818cf8&label=Release" alt="Release"></a>
   <a href="https://github.com/arthurpanhku/dvalincode/releases"><img src="https://img.shields.io/github/downloads/arthurpanhku/dvalincode/total?style=for-the-badge&color=blue&label=Downloads" alt="Downloads"></a>
-  <a href="#-tests"><img src="https://img.shields.io/badge/Tests-343%20%2F%20343%20%E2%9C%93-success?style=for-the-badge" alt="Tests"></a>
+  <a href="#-tests"><img src="https://img.shields.io/badge/Tests-357%20%2F%20357%20%E2%9C%93-success?style=for-the-badge" alt="Tests"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-green?style=for-the-badge" alt="License"></a>
   <a href="https://scorecard.dev/viewer/?uri=github.com/arthurpanhku/dvalincode"><img src="https://api.scorecard.dev/projects/github.com/arthurpanhku/dvalincode/badge" alt="OpenSSF Scorecard"></a>
   <a href="#-quick-install"><img src="https://img.shields.io/badge/Platforms-macOS%20·%20Windows%20·%20Linux-blue?style=for-the-badge" alt="Platforms"></a>
@@ -45,7 +45,7 @@ permissions:
   security-events: write
 steps:
   - uses: actions/checkout@v5
-  - uses: arthurpanhku/dvalincode@v0.16.1
+  - uses: arthurpanhku/dvalincode@v0.17.0
     with:
       fail-on: high
 ```
@@ -671,7 +671,7 @@ RESTORE → COMPACT → COMMAND → BUILD → RUN → SAVE → RESPOND → DONE
 npm test
 ```
 
-**343 tests · 50 files · all green.**
+**357 tests · 52 files · all green.**
 
 ---
 
@@ -792,7 +792,7 @@ Contributions welcome. The codebase is intentionally small and surgical — see 
 ```sh
 git clone https://github.com/arthurpanhku/dvalincode
 cd dvalincode && npm install
-npm test                # 343/343 ✅
+npm test                # 357/357 ✅
 npm run typecheck
 ```
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -9,7 +9,7 @@
 <p align="center">
   <a href="https://github.com/arthurpanhku/dvalincode/releases/latest"><img src="https://img.shields.io/github/v/release/arthurpanhku/dvalincode?style=for-the-badge&color=818cf8&label=Release" alt="Release"></a>
   <a href="https://github.com/arthurpanhku/dvalincode/releases"><img src="https://img.shields.io/github/downloads/arthurpanhku/dvalincode/total?style=for-the-badge&color=blue&label=Downloads" alt="Downloads"></a>
-  <a href="#-测试"><img src="https://img.shields.io/badge/Tests-343%20%2F%20343%20%E2%9C%93-success?style=for-the-badge" alt="Tests"></a>
+  <a href="#-测试"><img src="https://img.shields.io/badge/Tests-357%20%2F%20357%20%E2%9C%93-success?style=for-the-badge" alt="Tests"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-green?style=for-the-badge" alt="License"></a>
   <a href="https://scorecard.dev/viewer/?uri=github.com/arthurpanhku/dvalincode"><img src="https://api.scorecard.dev/projects/github.com/arthurpanhku/dvalincode/badge" alt="OpenSSF Scorecard"></a>
   <a href="#-一行安装"><img src="https://img.shields.io/badge/Platforms-macOS%20·%20Windows%20·%20Linux-blue?style=for-the-badge" alt="Platforms"></a>
@@ -43,7 +43,7 @@ permissions:
   security-events: write
 steps:
   - uses: actions/checkout@v5
-  - uses: arthurpanhku/dvalincode@v0.16.1
+  - uses: arthurpanhku/dvalincode@v0.17.0
     with:
       fail-on: high
 ```
@@ -591,7 +591,7 @@ RESTORE → COMPACT → COMMAND → BUILD → RUN → SAVE → RESPOND → DONE
 npm test
 ```
 
-**343 个测试 · 50 个文件 · 全部通过。**
+**357 个测试 · 52 个文件 · 全部通过。**
 
 ---
 
@@ -718,7 +718,7 @@ Linux 与 macOS 命令通过 <code>/bin/sh</code> 执行；Windows 命令通过�
 ```sh
 git clone https://github.com/arthurpanhku/dvalincode
 cd dvalincode && npm install
-npm test                # 343/343 ✅
+npm test                # 357/357 ✅
 npm run typecheck
 ```
 

--- a/docs/DVALIN.md
+++ b/docs/DVALIN.md
@@ -65,7 +65,7 @@ permissions:
   pull-requests: write     # only when comment: 'true'
 steps:
   - uses: actions/checkout@v5
-  - uses: arthurpanhku/dvalincode@v0.16.1
+  - uses: arthurpanhku/dvalincode@v0.17.0
     with:
       fail-on: high        # critical | high | medium | low | none
       scanners: builtin    # add semgrep,trivy,osv-scanner if on PATH

--- a/docs/examples/dvalin-scan.yml
+++ b/docs/examples/dvalin-scan.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5   # pin by commit digest in production
 
-      - uses: arthurpanhku/dvalincode@v0.16.1
+      - uses: arthurpanhku/dvalincode@v0.17.0
         with:
           # Fail the build on high or critical findings. Use 'none' to report
           # without blocking while you work through the backlog.
@@ -30,6 +30,6 @@ jobs:
       # Optional: add the external engines. Dvalin picks up whatever is on PATH.
       #
       # - run: pipx install semgrep
-      # - uses: arthurpanhku/dvalincode@v0.16.1
+      # - uses: arthurpanhku/dvalincode@v0.17.0
       #   with:
       #     scanners: builtin,semgrep,trivy,osv-scanner

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dvalincode",
-  "version": "0.16.1",
+  "version": "0.17.0",
   "description": "A local-first, provider-neutral CLI foundation for agentic coding workflows.",
   "type": "module",
   "license": "MIT",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/arthurpanhku/dvalincode",
     "source": "github"
   },
-  "version": "0.16.1",
+  "version": "0.17.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "dvalincode",
-      "version": "0.16.1",
+      "version": "0.17.0",
       "transport": {
         "type": "stdio"
       },

--- a/src/version.ts
+++ b/src/version.ts
@@ -5,4 +5,4 @@
  * Everything that reports a version — the CLI `--version`, the trust report, and
  * the self-update check — imports from here so the copies can never drift.
  */
-export const VERSION = '0.16.1';
+export const VERSION = '0.17.0';


### PR DESCRIPTION
## Minor, not patch

Four commands changed their exit codes:

| Command | Was | Now |
|---|---|---|
| `dvalin --fail-on <sev>` | 2 | **5** |
| `evidence verify` | 1 | **5** |
| `report verify` (broken chain) | 1 | **5** |
| `policy validate` (invalid) | 1 | **5** |

5 means *ran correctly, and the answer was no*. Anything checking for non-zero is unaffected — including this repository's own Action, which only compares against `0`. Only a check for a specific number needs updating.

## What is in 0.17.0

- **`dvalin_scan` over MCP** — read-only, deterministic, no credentials, so an agent can call it after every edit. Verified end to end in Claude Code and Codex against the published package.
- **`tools --json` and `run-tool --json`** — an agent can now discover a tool, read its schema, call it, and read a structured result without parsing prose at any step.
- **One exit-code contract** across every command.
- **VS Code extension** — findings in the Problems panel with a governed fix action.
- **Homebrew tap** — `brew install`, which also sidesteps Gatekeeper without a Developer ID.
- **MCP protocol version negotiation** — the server no longer claims to speak revisions it has not implemented.
- **Listed in the MCP registry** as `io.github.arthurpanhku/dvalincode`.

## Release readiness

All four values the pre-flight guard compares against the tag are at 0.17.0 — `package.json`, `src/version.ts`, and `server.json` twice — plus `mcpName` matching the listing and the description within the registry's 100-character limit. Those guards exist because each one cost a failed release to discover.

The Action pin moves to `v0.17.0` in both READMEs, `docs/DVALIN.md`, and the example workflow.

Test counts corrected to the measured **357 / 52**. I had written 359 before running the suite; the badge now matches what `npm test` prints.

## Testing

`npm run check` green, built CLI reports `0.17.0`, repo self-scan clean (exit 0).

## Security and AI Governance

- [x] This change does not expand file, shell, network, model, or approval permissions.
- [x] If it changes agent behavior, prompts, policy, providers, audit logging, or release/build security, I updated the relevant governance evidence in `docs/`.
- [x] If it introduces a new model/provider/tool or new data flow, I completed `docs/governance/AI-CHANGE-IMPACT-ASSESSMENT.md`.

Version numbers and documentation.

## Notes

To release: merge, then `git tag v0.17.0 && git push origin v0.17.0`. The tag drives binaries, Evidence Pack, provenance, the GitHub Release, npm, the Homebrew formula PR, and the registry listing.

Every one of those six jobs has now run successfully at least once, so this should be the first release with no first-run surprises — but the npm and registry jobs are the ones to watch, since they are the two that fail after everything else has already shipped.