### PR TITLE
Add independent Dvalin security runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 <p align="center">
   <a href="https://github.com/arthurpanhku/dvalincode/releases/latest"><img src="https://img.shields.io/github/v/release/arthurpanhku/dvalincode?style=for-the-badge&color=818cf8&label=Release" alt="Release"></a>
   <a href="https://github.com/arthurpanhku/dvalincode/releases"><img src="https://img.shields.io/github/downloads/arthurpanhku/dvalincode/total?style=for-the-badge&color=blue&label=Downloads" alt="Downloads"></a>
-  <a href="#-tests"><img src="https://img.shields.io/badge/Tests-357%20%2F%20357%20%E2%9C%93-success?style=for-the-badge" alt="Tests"></a>
+  <a href="#-tests"><img src="https://img.shields.io/badge/Tests-365%20%2F%20365%20%E2%9C%93-success?style=for-the-badge" alt="Tests"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-green?style=for-the-badge" alt="License"></a>
   <a href="https://scorecard.dev/viewer/?uri=github.com/arthurpanhku/dvalincode"><img src="https://api.scorecard.dev/projects/github.com/arthurpanhku/dvalincode/badge" alt="OpenSSF Scorecard"></a>
   <a href="#-quick-install"><img src="https://img.shields.io/badge/Platforms-macOS%20·%20Windows%20·%20Linux-blue?style=for-the-badge" alt="Platforms"></a>
@@ -18,23 +18,50 @@
 </p>
 
 <p align="center">
-  <b>Find the security holes in your repo, fix them, and prove the fix — in one command.</b><br>
-  Every fix is diffed, tested, re-scanned, and recorded in a tamper-evident audit log before it can become a PR.
+  <b>Security verification for code written by humans and AI agents.</b><br>
+  <b>Agent writes. Dvalin verifies.</b>
 </p>
+
+Dvalin is the independent security runtime between code generation and merge.
+Humans, coding agents, and CI call the same versioned scan contract; Dvalin
+normalizes scanner evidence, applies a baseline-aware gate, persists the
+security workflow, and independently verifies a repair before publication.
+Its built-in coding capability is a remediation executor—not the trust boundary
+and not an attempt to compete with every general-purpose coding agent.
 
 ---
 
 ## ⏱️ 30 seconds, no install, no API key
 
 ```sh
-npx dvalincode dvalin .
+npx dvalincode security scan .
+# After installing the package: dvalin scan .
 ```
 
 That is the whole thing. It runs the built-in rules for injection, hardcoded
 secrets, XSS, `eval`, and unsafe shell use against the current directory and
 prints what it found. No account, no model, no config, no code leaves your
-machine. Add `--scanners builtin,semgrep,trivy,osv-scanner` to pull in whichever
-of those engines you already have on `PATH`.
+machine. The default policy runs only Dvalin Built-in, so the first scan always
+works. Add optional engines explicitly, or inspect their fixed install commands:
+
+```sh
+dvalin scanners list
+dvalin scanners install semgrep       # review the command
+dvalin scanners install semgrep --yes # execute it under Dvalin policy
+```
+
+For an incremental “no new high-risk findings” gate, commit the policy and
+baseline with the repository:
+
+```sh
+dvalin init
+dvalin baseline
+dvalin scan
+```
+
+This creates `dvalin.security.json` and `.dvalin/baseline.json`. Suppressions
+require a reason and may have an owner and expiry date. Scan output is a
+versioned envelope with a deterministic gate result and a resumable workflow ID.
 
 ### Or put it on every pull request — nothing to install at all
 
@@ -63,11 +90,13 @@ it. DvalinCode is an MCP server, so any agent that speaks MCP can:
 claude mcp add dvalin -- npx -y dvalincode mcp-serve --workspace .
 ```
 
-`dvalin_scan` is read-only and deterministic — no model runs, no credentials are
-needed, no files are touched — so an agent can call it after every edit. A real
-call against a vulnerable fixture returns in ~170ms with a ~600 byte payload.
-The same server also exposes `dvalin_run_task` for delegating a whole governed
-task, plus the session and audit-evidence tools.
+`dvalin_scan` never runs a model or edits the target workspace. It records a
+small local workflow so an agent can retrieve one finding by fingerprint and
+request an independent re-scan through `dvalin_get_finding` and
+`dvalin_verify_findings`. Responses include MCP `structuredContent`; scanner
+readiness is available through `dvalin_list_scanners`. The same server exposes
+`dvalin_run_task` as an optional implementation helper, plus session and audit
+evidence tools.
 
 Verified end to end with both Claude Code and Codex driving a real tool call
 against the published package, not only completing a handshake.
@@ -171,13 +200,14 @@ If you are the person who has to approve this class of tool, start at
 
 ## 🎯 Core Goal
 
-> **Make AI coding approvable for regulated and security-sensitive teams.**
+> **Make every code-producing human or agent pass the same independent security gate.**
 
-DvalinCode is built as an **approvable agent runtime**, not just another coding
-agent app. The core product is not only "AI writes code"; it is the evidence a
-security, compliance, or platform team needs to safely allow AI coding in
-financial services, healthcare, internal enterprise platforms, and other
-confidential codebases.
+DvalinCode is built as an **agent-compatible security runtime**, not another
+general coding-agent benchmark entry. The core product is scan evidence,
+policy, baseline, deterministic verification, and portable interfaces that a
+human developer, an external agent, or CI can all call. The bundled coding agent
+stays capable enough to implement and test focused remediations reliably; its
+model prose never decides whether the security gate passed.
 
 - **Any model** — every OpenAI-compatible endpoint is a first-class citizen, local models included. Your workflow should never be hostage to one vendor's pricing, rate limits, or quality swings.
 - **Safe by default** — three-tier approvals with diff preview, an undo stack, and sandboxed shell execution. An agent you can trust on full-auto.
@@ -671,7 +701,7 @@ RESTORE → COMPACT → COMMAND → BUILD → RUN → SAVE → RESPOND → DONE
 npm test
 ```
 
-**357 tests · 52 files · all green.**
+**365 tests · 55 files · all green.**
 
 ---
 
@@ -792,7 +822,7 @@ Contributions welcome. The codebase is intentionally small and surgical — see 
 ```sh
 git clone https://github.com/arthurpanhku/dvalincode
 cd dvalincode && npm install
-npm test                # 357/357 ✅
+npm test                # 365/365 ✅
 npm run typecheck
 ```
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -9,7 +9,7 @@
 <p align="center">
   <a href="https://github.com/arthurpanhku/dvalincode/releases/latest"><img src="https://img.shields.io/github/v/release/arthurpanhku/dvalincode?style=for-the-badge&color=818cf8&label=Release" alt="Release"></a>
   <a href="https://github.com/arthurpanhku/dvalincode/releases"><img src="https://img.shields.io/github/downloads/arthurpanhku/dvalincode/total?style=for-the-badge&color=blue&label=Downloads" alt="Downloads"></a>
-  <a href="#-测试"><img src="https://img.shields.io/badge/Tests-357%20%2F%20357%20%E2%9C%93-success?style=for-the-badge" alt="Tests"></a>
+  <a href="#-测试"><img src="https://img.shields.io/badge/Tests-365%20%2F%20365%20%E2%9C%93-success?style=for-the-badge" alt="Tests"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-green?style=for-the-badge" alt="License"></a>
   <a href="https://scorecard.dev/viewer/?uri=github.com/arthurpanhku/dvalincode"><img src="https://api.scorecard.dev/projects/github.com/arthurpanhku/dvalincode/badge" alt="OpenSSF Scorecard"></a>
   <a href="#-一行安装"><img src="https://img.shields.io/badge/Platforms-macOS%20·%20Windows%20·%20Linux-blue?style=for-the-badge" alt="Platforms"></a>
@@ -18,21 +18,45 @@
 </p>
 
 <p align="center">
-  <b>找出仓库里的安全漏洞，修掉它，并且证明确实修好了 —— 一条命令。</b><br>
-  每一处修复都会先出 diff、跑测试、重新扫描，并写入防篡改审计日志，然后才允许变成 PR。
+  <b>为人类和 AI Agent 编写的代码提供独立安全验证。</b><br>
+  <b>Agent writes. Dvalin verifies.</b>
 </p>
+
+Dvalin 是放在“代码生成”和“允许合并”之间的独立安全运行时。人类开发者、Coding
+Agent 和 CI 调用同一套版本化扫描协议；Dvalin 统一扫描证据、执行基线策略、持久化安全
+工作流，并在发布前独立验证修复。内置 Coding 能力只负责可靠地执行聚焦修复，不是安全
+结论的信任边界，也不以打败所有通用 Coding Agent 为目标。
 
 ---
 
 ## ⏱️ 30 秒，免安装，不需要 API Key
 
 ```sh
-npx dvalincode dvalin .
+npx dvalincode security scan .
+# 安装 npm 包后也可直接运行：dvalin scan .
 ```
 
 就这一条。它用内置规则扫描当前目录里的注入、硬编码密钥、XSS、`eval` 和不安全的
 shell 调用，然后把结果打出来。不需要注册、不需要模型、不需要配置，代码不出本机。
-想接入你已经装好的引擎，加上 `--scanners builtin,semgrep,trivy,osv-scanner` 即可。
+默认只启用一定存在的 Dvalin Built-in；可选引擎必须显式启用，其固定安装命令可以先审查：
+
+```sh
+dvalin scanners list
+dvalin scanners install semgrep       # 只显示并审查命令
+dvalin scanners install semgrep --yes # 在 Dvalin 策略约束下执行
+```
+
+要建立“禁止新增高风险问题”的增量门禁，把策略和基线一并提交到仓库：
+
+```sh
+dvalin init
+dvalin baseline
+dvalin scan
+```
+
+这会创建 `dvalin.security.json` 和 `.dvalin/baseline.json`。每条 suppression 都必须
+写原因，还可以设置 owner 和过期时间。扫描输出是版本化 envelope，包含确定性 gate
+结果和可恢复的 workflow ID。
 
 ### 或者挂到每个 PR 上 —— 完全不用装任何东西
 
@@ -61,9 +85,11 @@ server，任何支持 MCP 的 agent 都能接：
 claude mcp add dvalin -- npx -y dvalincode mcp-serve --workspace .
 ```
 
-`dvalin_scan` 只读且确定性 —— 不跑模型、不需要任何凭据、不改文件 —— 所以 agent
-可以每次改完就调一次。对一个真实漏洞样本的实测：约 170ms 返回，payload 约 600 字节。
-同一个 server 还提供 `dvalin_run_task`（委派完整的受管任务）以及会话、审计证据工具。
+`dvalin_scan` 不跑模型，也不会修改目标 workspace；它只持久化一份精简的本地安全
+workflow。Agent 可以用 fingerprint 精确读取单条发现，再通过 `dvalin_get_finding` 和
+`dvalin_verify_findings` 请求独立复扫。响应包含 MCP `structuredContent`，并可通过
+`dvalin_list_scanners` 查询组件是否就绪。同一 server 也提供可选的 `dvalin_run_task`
+实现助手，以及 session 和审计证据工具。
 
 Claude Code 与 Codex 均已用已发布的包做过端到端验证 —— 是真实发起工具调用，而不只是握手成功。
 [Agent 集成 →](integrations/)
@@ -157,11 +183,12 @@ dvalincode report verify    # 重新推导上次运行审计日志的哈希链
 
 ## 🎯 核心目标
 
-> **让高合规与安全敏感团队也能批准 AI 编码。**
+> **让每一个写代码的人类或 Agent，都通过同一套独立安全门禁。**
 
-DvalinCode 的定位是 **可审批的 Agent 运行时（runtime）**，而不只是又一个
-编码 Agent 应用。核心产品不只是“AI 能写代码”，而是金融、医疗、政企、内部平台
-等高保密代码库在引入 AI 编码前所需要的安全、合规和审计证据。
+DvalinCode 的定位是 **Agent 可调用的安全运行时**，而不是又一个通用 Coding Agent
+榜单参赛者。核心产品是扫描证据、策略、基线、确定性验证，以及能被人类、外部 Agent
+和 CI 共同调用的便携接口。自带 Coding Agent 只需保持可靠完成聚焦修复和测试的能力；
+模型的文字声明永远不能决定安全 gate 是否通过。
 
 - **模型自由** —— 任何 OpenAI 兼容端点都是一等公民，包括本地模型。你的工作流不应被任何一家厂商的定价、限流或质量波动绑架。
 - **默认安全** —— 三档审批 + diff 预审、撤销栈、沙箱化 shell 执行。一个敢放心开全自动的 Agent。
@@ -591,7 +618,7 @@ RESTORE → COMPACT → COMMAND → BUILD → RUN → SAVE → RESPOND → DONE
 npm test
 ```
 
-**357 个测试 · 52 个文件 · 全部通过。**
+**365 个测试 · 55 个文件 · 全部通过。**
 
 ---
 
@@ -718,7 +745,7 @@ Linux 与 macOS 命令通过 <code>/bin/sh</code> 执行；Windows 命令通过�
 ```sh
 git clone https://github.com/arthurpanhku/dvalincode
 cd dvalincode && npm install
-npm test                # 357/357 ✅
+npm test                # 365/365 ✅
 npm run typecheck
 ```
 

--- a/docs/SECURITY-RUNTIME.md
+++ b/docs/SECURITY-RUNTIME.md
@@ -1,0 +1,119 @@
+# Dvalin security runtime
+
+Dvalin is an independent security verifier for code written by humans and AI
+agents. The product boundary is not “which model writes the best code”; it is
+the stable contract between code production and merge:
+
+> Agent writes. Dvalin verifies.
+
+## Architecture
+
+```mermaid
+flowchart LR
+  H["Human developer"] --> C["Code change"]
+  A["Coding agent"] --> C
+  C --> S["Dvalin scan contract"]
+  S --> F["Normalized findings"]
+  F --> G["Baseline + policy gate"]
+  G -->|pass| E["Evidence / CI / merge"]
+  G -->|needs work| R["External agent or Dvalin remediation"]
+  R --> V["Independent re-scan + check exits"]
+  V --> G
+```
+
+The generic DvalinCode Agent Loop remains responsible for a single model turn
+(`RESTORE → COMPACT → COMMAND → BUILD → RUN → SAVE → RESPOND`). Security
+orchestration is a separate persisted state machine. This keeps model control
+flow generic while making security transitions deterministic and resumable.
+
+## Security workflow states
+
+The version 1 workflow supports:
+
+`created → scanning → ready/needs_work/passed → external_handoff/internal_fix → verifying → passed/needs_work → evidence_ready → publication_pending → published`
+
+Blocked work can resume at scanning or verification. Workflows live under
+`~/.dvalincode/security/workflows/` (or `DVALINCODE_HOME`) and contain compact
+finding snapshots, not source snippets or prompts.
+
+## Repository contract
+
+Run:
+
+```sh
+dvalin init
+dvalin baseline
+dvalin scan
+```
+
+`dvalin.security.json` is a versioned repository policy:
+
+```json
+{
+  "version": 1,
+  "scanners": ["builtin"],
+  "gate": { "severity": "high", "mode": "new" },
+  "baseline": ".dvalin/baseline.json",
+  "checks": ["test"],
+  "suppressions": []
+}
+```
+
+Unconfigured repositories remain compatible: the built-in scanner runs and the
+gate is non-blocking. Initializing opts the repository into a high-severity,
+new-findings gate. A suppression needs a fingerprint or rule, a reason, and may
+also carry a path, owner, and expiry date. Expired suppressions are reported and
+no longer hide findings.
+
+Finding fingerprints are stable over path spelling normalization. Verification
+also uses a conservative target fingerprint (scanner + rule + file), so moving
+the same vulnerability within a file does not make it appear fixed.
+
+## Interfaces
+
+- Human CLI: `dvalin scan`, `baseline`, `verify`, `doctor`, and `scanners`.
+- Compatibility CLI: `dvalincode security ...`; the earlier
+  `dvalincode dvalin ...` repair command remains available.
+- Agent MCP: `dvalin_scan`, `dvalin_get_finding`,
+  `dvalin_verify_findings`, `dvalin_list_scanners`, and optional governed coding
+  and evidence tools. Structured tools return MCP `structuredContent`.
+- CI: the GitHub Action produces SARIF; a GitLab example is in
+  `docs/examples/gitlab-ci.yml`.
+- Editors: the VS Code extension and Dvalin workspace remain presentation
+  layers over the same scanner suite.
+
+## Verification boundary
+
+Scanner results and actual process exit codes decide the gate. In automated
+remediation, focused checks must run through `run_check`; Dvalin reads their
+exit codes from the tamper-evident audit trail and then independently re-runs
+the original scanners. The model's `DVALIN_VERIFICATION_PASSED` marker remains
+only as a compatibility fallback for API callers that do not provide audit
+evidence—it is not used by the automated publication path.
+
+`dvalin verify <workflow-id>` runs the checks selected in
+`dvalin.security.json` and reports `scan-and-checks` assurance. The MCP
+verification tool reports `scan-only` because the calling agent owns its check
+execution; the governed automated-remediation path separately requires recorded
+`run_check` evidence before publication.
+
+## Scanner installation
+
+Dvalin Built-in always exists. Optional engines are detected from `PATH`.
+`dvalin scanners install <id>` prints a fixed, reviewable command and does not
+execute it. Adding `--yes` runs the fixed executable/argument vector under the
+resolved Dvalin command and egress policy. Scanner discovery never triggers an
+installation by itself. The Dvalin status UI uses the same fixed plan: its
+download icon shows a native confirmation containing the exact command, calls a
+workspace-restricted local endpoint, verifies the executable on `PATH`, and does
+not require a configured model.
+
+## Honest limits
+
+- A passing scan is not proof that a program is secure.
+- The health score is a triage heuristic, not a certification.
+- Business-logic flaws may require threat modeling and human review.
+- External scanners may access their own registries and advisory databases;
+  availability and errors are included in the result.
+- Dvalin can orchestrate a repair, but publication stays explicit and it never
+  auto-merges a change.

--- a/docs/examples/gitlab-ci.yml
+++ b/docs/examples/gitlab-ci.yml
@@ -1,0 +1,12 @@
+stages:
+  - security
+
+dvalin-security:
+  stage: security
+  image: node:22-bookworm-slim
+  script:
+    - npx -y dvalincode security scan . --fail-on high --sarif dvalin.sarif --no-workflow
+  artifacts:
+    when: always
+    paths:
+      - dvalin.sarif

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -5,6 +5,8 @@ Ways to reach DvalinCode from something other than its own CLI.
 | Path | What it is |
 |---|---|
 | [`claude-code/`](claude-code/) | A Claude Code skill that runs a Dvalin scan and reads the result. |
+| [`agents/`](agents/) | Portable security-gate instructions for coding agents. |
+| [`mcp/`](mcp/) | A generic stdio MCP server configuration. |
 | [`../editors/vscode/`](../editors/vscode/) | The VS Code extension — findings in the Problems panel. |
 | [`../action.yml`](../action.yml) | The GitHub Action — findings on the pull request diff. |
 | `dvalincode mcp-serve` | The MCP server, for any agent that speaks MCP. See the repository README. |

--- a/integrations/agents/README.md
+++ b/integrations/agents/README.md
@@ -1,0 +1,11 @@
+# Coding-agent security gate
+
+Copy [`dvalin-security.md`](dvalin-security.md) into the instruction mechanism
+used by your coding agent (for example an `AGENTS.md`, custom-agent body, rule,
+or repository instruction file). Configure the generic MCP server from
+[`../mcp/dvalin.mcp.json`](../mcp/dvalin.mcp.json), adapting the surrounding
+configuration key to your client.
+
+The instructions deliberately keep implementation and verification separate:
+the coding agent may change code, but only Dvalin's structured gate result can
+declare that the security verification passed.

--- a/integrations/agents/dvalin-security.md
+++ b/integrations/agents/dvalin-security.md
@@ -1,0 +1,18 @@
+# Dvalin security gate
+
+After changing code that handles input, authentication, authorization, secrets,
+queries, commands, templates, dependencies, or deployment configuration:
+
+1. Call `dvalin_scan` with `scanners: ["builtin"]` at minimum.
+2. Treat every result as evidence to validate, not as infallible truth.
+3. For a reported issue, call `dvalin_get_finding` with its workflow ID and
+   fingerprint before editing. Read the relevant source and data flow.
+4. Make the smallest behavior-preserving fix and add a focused regression test.
+5. Run the project's focused checks.
+6. Call `dvalin_verify_findings` with the original workflow ID.
+7. Report success only if the returned structured gate has `passed: true`.
+
+Never claim that a clean scan proves the code is secure. Never suppress or
+exclude a finding merely to make the gate pass. If an optional engine is absent,
+report it; do not install software unless the user explicitly authorizes the
+reviewed command.

--- a/integrations/claude-code/README.md
+++ b/integrations/claude-code/README.md
@@ -33,11 +33,14 @@ because you cloned something. Run `claude` once in the project and approve.
 If you would rather skip that for your own machine, `--scope local` keeps the
 entry in your user config instead, where it needs no approval.
 
-This exposes four tools:
+This exposes seven tools:
 
 | Tool | Needs a model? | Notes |
 |---|---|---|
-| `dvalin_scan` | no | Read-only, deterministic, no credentials. Safe to call after every edit. |
+| `dvalin_scan` | no | Does not edit the workspace; returns structured findings and persists a compact workflow. |
+| `dvalin_get_finding` | no | Reads one finding by workflow ID and fingerprint. |
+| `dvalin_verify_findings` | no | Re-scans and applies the deterministic verification gate. |
+| `dvalin_list_scanners` | no | Reports scanner readiness and fixed install commands. |
 | `dvalin_run_task` | yes | Delegates a whole governed coding task; needs DvalinCode's provider configured. |
 | `dvalin_get_session` | no | Session summary and its audit anchor. |
 | `dvalin_get_evidence` | no | The Markdown audit trail for a run. |

--- a/integrations/claude-code/skills/dvalin-security-scan/SKILL.md
+++ b/integrations/claude-code/skills/dvalin-security-scan/SKILL.md
@@ -5,16 +5,16 @@ description: Scan code for injection, hardcoded secrets, XSS, dynamic code execu
 
 # Dvalin security scan
 
-A deterministic scanner. No model runs, nothing is sent anywhere, and it never
-edits files — so it is safe to call as often as you like, including on code you
-just wrote yourself.
+A deterministic scanner. No model runs and it never edits the target workspace;
+it persists only a compact local workflow so findings can be resumed and
+independently verified.
 
 ## Running it
 
 If a `dvalin` MCP server is configured, call `dvalin_scan`. Otherwise:
 
 ```sh
-npx -y dvalincode dvalin . --scanners builtin --json
+npx -y dvalincode security scan . --scanners builtin --json
 ```
 
 Scan the whole workspace — the scanner takes a directory, not a file. `builtin`

--- a/integrations/mcp/dvalin.mcp.json
+++ b/integrations/mcp/dvalin.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "dvalin": {
+      "command": "npx",
+      "args": ["-y", "dvalincode", "mcp-serve", "--workspace", "."]
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "zod": "^4.1.13"
       },
       "bin": {
+        "dvalin": "dist/dvalinIndex.js",
         "dvalincode": "dist/index.js"
       },
       "devDependencies": {
@@ -3634,9 +3635,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.5.0.tgz",
+      "integrity": "sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -4192,9 +4193,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.15",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {
@@ -4384,9 +4385,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
-      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "dev": true,
       "funding": [
         {
@@ -4404,7 +4405,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dvalincode",
   "version": "0.17.0",
-  "description": "A local-first, provider-neutral CLI foundation for agentic coding workflows.",
+  "description": "Independent security verification for code written by humans and AI agents.",
   "type": "module",
   "license": "MIT",
   "repository": {
@@ -10,7 +10,8 @@
   },
   "mcpName": "io.github.arthurpanhku/dvalincode",
   "bin": {
-    "dvalincode": "dist/index.js"
+    "dvalincode": "dist/index.js",
+    "dvalin": "dist/dvalinIndex.js"
   },
   "files": [
     "dist",
@@ -54,7 +55,10 @@
     "agent",
     "developer-tools",
     "typescript",
-    "coding-assistant"
+    "coding-assistant",
+    "devsecops",
+    "security",
+    "code-scanning"
   ],
   "engines": {
     "node": ">=20"

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -20,6 +20,7 @@ import { registerUpdateCommand } from './commands/update.js';
 import { registerDvalinCommand } from './commands/dvalin.js';
 import { registerRunCommand } from './commands/run.js';
 import { registerMcpServeCommand } from './commands/mcpServe.js';
+import { registerSecurityCommand } from './commands/security.js';
 import { createDefaultToolRegistry } from './tools/registry.js';
 
 export function buildProgram(): Command {
@@ -33,6 +34,7 @@ export function buildProgram(): Command {
 
   registerScanCommand(program);
   registerDvalinCommand(program);
+  registerSecurityCommand(program);
   registerToolsCommand(program, registry);
   registerRunToolCommand(program, registry);
   registerAskCommand(program, registry);

--- a/src/commands/dvalin.ts
+++ b/src/commands/dvalin.ts
@@ -20,6 +20,7 @@ import {
   buildDraftPrPrompt,
   evaluateVerificationGate,
   extractDraftPrUrl,
+  verificationEvidenceFromAudit,
 } from '../remediation/automate.js';
 
 const execFileAsync = promisify(execFile);
@@ -238,6 +239,9 @@ async function runAutomatedRemediation(input: {
     after,
     agentOutput: verificationTurn.result.output,
     hasChanges: Boolean(status.trim()),
+    checkEvidence: verificationTurn.result.runId
+      ? verificationEvidenceFromAudit(verificationTurn.result.runId)
+      : [],
   });
   if (!gate.passed) {
     throw new Error(`Dvalin verification gate failed: ${gate.reasons.join('; ')}`);

--- a/src/commands/security.ts
+++ b/src/commands/security.ts
@@ -1,0 +1,331 @@
+import { access, mkdir, writeFile } from 'node:fs/promises';
+import { constants } from 'node:fs';
+import path from 'node:path';
+import type { Command } from 'commander';
+import { EXIT, UsageError } from '../core/exitCodes.js';
+import { loadPolicy } from '../core/policy.js';
+import { createDvalinContext } from '../core/context.js';
+import { resolveWorkspaceRoot } from '../core/workspace.js';
+import { parseDvalinScannerIds, renderDvalinResult } from './dvalin.js';
+import {
+  DVALIN_SCANNER_IDS,
+  dvalinScannerInstallPlan,
+  installDvalinScanner,
+  listDvalinScanners,
+  runDvalinScanSuite,
+  type DvalinScannerId,
+  type DvalinScanSuiteResult,
+} from '../remediation/scannerSuite.js';
+import { buildDvalinSarif } from '../remediation/sarifExport.js';
+import { runCheckTool } from '../tools/runCheck.js';
+import { readSecurityBaseline, writeSecurityBaseline } from '../security/baseline.js';
+import {
+  loadSecurityConfig,
+  resolveSecurityPath,
+  writeInitialSecurityConfig,
+  type DvalinSecurityConfig,
+} from '../security/config.js';
+import {
+  compareWithBaseline,
+  evaluateSecurityGate,
+  type SecurityFindingDelta,
+  type SecurityGateMode,
+  type SecurityScanEnvelope,
+  type SecurityThreshold,
+} from '../security/contracts.js';
+import { applySecuritySuppressions } from '../security/suppressions.js';
+import {
+  createSecurityWorkflow,
+  evaluateWorkflowVerificationGate,
+  loadSecurityWorkflow,
+  verifySecurityWorkflow,
+  type SecurityWorkflow,
+  type SecurityCheckEvidence,
+} from '../security/workflow.js';
+
+type ScanOptions = {
+  config?: string;
+  scanners?: string;
+  timeout: string;
+  limit: string;
+  json?: boolean;
+  sarif?: string;
+  failOn?: string;
+  newOnly?: boolean;
+  workflow: boolean;
+};
+
+type BaselineOptions = { config?: string; scanners?: string; timeout: string; output?: string; json?: boolean };
+
+export type ExecutedSecurityScan = SecurityScanEnvelope & {
+  root: string;
+  config: DvalinSecurityConfig;
+  workflow?: SecurityWorkflow;
+  suppressed: number;
+  expiredSuppressions: number;
+};
+
+export function registerSecurityCommand(program: Command): void {
+  const security = program.command('security').description('Deterministic security verification for human- and agent-written code');
+  registerSecuritySubcommands(security);
+}
+
+/** Shared by `dvalincode security ...` and the focused `dvalin ...` binary. */
+export function registerSecuritySubcommands(parent: Command): void {
+  parent
+    .command('init')
+    .description('Create a versioned Dvalin security policy')
+    .argument('[path]', 'workspace path', '.')
+    .option('--force', 'replace an existing policy')
+    .action(async (inputPath: string, options: { force?: boolean }) => {
+      const root = await resolveWorkspaceRoot(path.resolve(process.cwd(), inputPath));
+      const target = await writeInitialSecurityConfig(root, Boolean(options.force));
+      console.log(`Created ${target}`);
+      console.log('Next: run `dvalin baseline` once, then use `dvalin scan` as a new-findings gate.');
+    });
+
+  parent
+    .command('scan')
+    .description('Scan code, apply suppressions/baseline policy, and evaluate the gate')
+    .argument('[path]', 'workspace path', '.')
+    .option('--config <file>', 'security config path (default: dvalin.security.json)')
+    .option('--scanners <ids>', `override scanner set: ${DVALIN_SCANNER_IDS.join(', ')}`)
+    .option('--timeout <seconds>', 'timeout for each external scanner', '300')
+    .option('--limit <count>', 'maximum findings shown in text output', '20')
+    .option('--json', 'print the versioned result envelope as JSON')
+    .option('--sarif <file>', 'also write SARIF 2.1.0')
+    .option('--fail-on <severity>', 'override gate severity: critical, high, medium, low, none')
+    .option('--new-only', 'evaluate only findings not present in the baseline')
+    .option('--no-workflow', 'do not persist a resumable security workflow')
+    .action(async (inputPath: string, options: ScanOptions) => {
+      const execution = await executeSecurityScan({
+        root: path.resolve(process.cwd(), inputPath),
+        configPath: options.config,
+        scanners: options.scanners ? parseDvalinScannerIds(options.scanners) : undefined,
+        timeoutMs: positiveInteger(options.timeout, '--timeout') * 1000,
+        threshold: options.failOn ? parseThreshold(options.failOn) : undefined,
+        mode: options.newOnly ? 'new' : undefined,
+        saveWorkflow: options.workflow,
+      });
+      const limit = positiveInteger(options.limit, '--limit');
+      if (options.json) {
+        console.log(JSON.stringify({
+          schemaVersion: execution.schemaVersion,
+          scan: execution.scan,
+          delta: execution.delta,
+          gate: execution.gate,
+          workflowId: execution.workflow?.id,
+          suppressed: execution.suppressed,
+          expiredSuppressions: execution.expiredSuppressions,
+        }, null, 2));
+      } else {
+        console.log(renderSecurityExecution(execution, limit));
+      }
+      if (options.sarif) await writeSarif(execution.scan, execution.root, options.sarif, !options.json);
+      if (!execution.gate.passed) process.exitCode = EXIT.gateNotMet;
+    });
+
+  parent
+    .command('baseline')
+    .description('Record the current accepted findings for a new-findings gate')
+    .argument('[path]', 'workspace path', '.')
+    .option('--config <file>', 'security config path (default: dvalin.security.json)')
+    .option('--scanners <ids>', `override scanner set: ${DVALIN_SCANNER_IDS.join(', ')}`)
+    .option('--timeout <seconds>', 'timeout for each external scanner', '300')
+    .option('--output <file>', 'override baseline output path')
+    .option('--json', 'print baseline metadata as JSON')
+    .action(async (inputPath: string, options: BaselineOptions) => {
+      const root = await resolveWorkspaceRoot(path.resolve(process.cwd(), inputPath));
+      const loaded = await loadSecurityConfig(root, options.config);
+      const scanners = options.scanners ? parseDvalinScannerIds(options.scanners) : loaded.config.scanners;
+      const raw = await runDvalinScanSuite(root, { scanners, timeoutMs: positiveInteger(options.timeout, '--timeout') * 1000 });
+      const suppressed = applySecuritySuppressions(raw, loaded.config.suppressions);
+      const output = options.output ?? loaded.config.baseline;
+      const written = await writeSecurityBaseline(root, output, suppressed.result);
+      const body = { path: written.path, scanId: written.baseline.scanId, findings: written.baseline.findings.length, scanners };
+      console.log(options.json ? JSON.stringify(body, null, 2) : `Baseline written to ${written.path} · ${body.findings} accepted finding(s)`);
+    });
+
+  parent
+    .command('verify')
+    .description('Resume a workflow and deterministically re-scan its findings')
+    .argument('<workflow-id>', 'security workflow id returned by scan')
+    .option('--timeout <seconds>', 'timeout for each external scanner', '300')
+    .option('--json', 'print workflow state as JSON')
+    .action(async (workflowId: string, options: { timeout: string; json?: boolean }) => {
+      const workflow = await loadSecurityWorkflow(workflowId);
+      const loaded = await loadSecurityConfig(workflow.root);
+      const result = await runDvalinScanSuite(workflow.root, {
+        scanners: workflow.scanners,
+        timeoutMs: positiveInteger(options.timeout, '--timeout') * 1000,
+      });
+      const gate = evaluateWorkflowVerificationGate(workflow, result);
+      const checks = await runConfiguredChecks(workflow.root, loaded.config.checks);
+      const updated = await verifySecurityWorkflow({ workflow, result, gate, checks });
+      if (options.json) console.log(JSON.stringify(updated, null, 2));
+      else console.log(`Workflow ${updated.id} · ${updated.state} · ${updated.verification?.assurance} · ${updated.latestScan.findings.length} finding(s)`);
+      if (updated.state !== 'passed') process.exitCode = EXIT.gateNotMet;
+    });
+
+  parent
+    .command('doctor')
+    .description('Show security policy, baseline, and scanner readiness')
+    .argument('[path]', 'workspace path', '.')
+    .option('--config <file>', 'security config path')
+    .option('--json', 'print diagnostics as JSON')
+    .action(async (inputPath: string, options: { config?: string; json?: boolean }) => {
+      const root = await resolveWorkspaceRoot(path.resolve(process.cwd(), inputPath));
+      const loaded = await loadSecurityConfig(root, options.config);
+      const baselinePath = resolveSecurityPath(root, loaded.config.baseline);
+      const baselineAvailable = await exists(baselinePath);
+      const scanners = await listDvalinScanners();
+      const body = { root, configPath: loaded.path, config: loaded.config, baseline: { path: baselinePath, available: baselineAvailable }, scanners };
+      if (options.json) console.log(JSON.stringify(body, null, 2));
+      else {
+        console.log(`Dvalin security doctor · ${root}`);
+        console.log(`Policy: ${loaded.path ?? 'defaults (builtin scanner, non-blocking)'}`);
+        console.log(`Baseline: ${baselineAvailable ? 'ready' : 'missing'} · ${baselinePath}`);
+        for (const scanner of scanners) {
+          console.log(`  ${scanner.available ? '✓' : '!'} ${scanner.name}${scanner.available ? '' : ` · ${scanner.installCommand ?? 'install manually'}`}`);
+        }
+      }
+    });
+
+  const scanners = parent.command('scanners').description('Inspect and install optional scanner engines');
+  scanners
+    .command('list')
+    .description('List scanner readiness and install commands')
+    .option('--json', 'print scanner descriptors as JSON')
+    .action(async (options: { json?: boolean }) => {
+      const listed = await listDvalinScanners();
+      console.log(options.json ? JSON.stringify(listed, null, 2) : listed.map(scanner =>
+        `${scanner.available ? '✓' : '!'} ${scanner.id} · ${scanner.available ? 'ready' : scanner.installCommand ?? 'install manually'}`,
+      ).join('\n'));
+    });
+  scanners
+    .command('install')
+    .description('Print a fixed install command; execute it only with --yes')
+    .argument('<scanner>', `one of ${DVALIN_SCANNER_IDS.join(', ')}`)
+    .option('--yes', 'execute the reviewed command under Dvalin policy')
+    .action(async (scanner: string, options: { yes?: boolean }) => {
+      const id = parseDvalinScannerIds(scanner)[0]!;
+      const plan = dvalinScannerInstallPlan(id);
+      if (!plan.command) {
+        console.log(plan.reason);
+        return;
+      }
+      console.log(`Install plan: ${plan.command}`);
+      if (!options.yes) {
+        console.log('Review the command, then rerun with --yes to execute it.');
+        return;
+      }
+      await installDvalinScanner(process.cwd(), id);
+      console.log(`${id} installation command completed.`);
+    });
+}
+
+export async function executeSecurityScan(input: {
+  root: string;
+  configPath?: string;
+  scanners?: DvalinScannerId[];
+  timeoutMs?: number;
+  threshold?: SecurityThreshold;
+  mode?: SecurityGateMode;
+  saveWorkflow?: boolean;
+}): Promise<ExecutedSecurityScan> {
+  const root = await resolveWorkspaceRoot(input.root);
+  const loaded = await loadSecurityConfig(root, input.configPath);
+  const config: DvalinSecurityConfig = {
+    ...loaded.config,
+    scanners: input.scanners ?? loaded.config.scanners,
+    gate: {
+      severity: input.threshold ?? loaded.config.gate.severity,
+      mode: input.mode ?? loaded.config.gate.mode,
+    },
+  };
+  const raw = await runDvalinScanSuite(root, { scanners: config.scanners, timeoutMs: input.timeoutMs });
+  const suppression = applySecuritySuppressions(raw, config.suppressions);
+  let delta: SecurityFindingDelta | undefined;
+  if (config.gate.mode === 'new') {
+    try {
+      delta = compareWithBaseline(suppression.result, await readSecurityBaseline(root, config.baseline));
+    } catch (error) {
+      throw new UsageError(`${error instanceof Error ? error.message : String(error)}. Run \`dvalin baseline\` before using a new-findings gate.`);
+    }
+  }
+  const gate = evaluateSecurityGate({ result: suppression.result, threshold: config.gate.severity, mode: config.gate.mode, delta });
+  const workflow = input.saveWorkflow === false ? undefined : await createSecurityWorkflow({ root, result: suppression.result, gate, delta });
+  return {
+    schemaVersion: 1,
+    scan: suppression.result,
+    delta,
+    gate,
+    root,
+    config,
+    workflow,
+    suppressed: suppression.suppressed.length,
+    expiredSuppressions: suppression.expired.length,
+  };
+}
+
+function renderSecurityExecution(execution: ExecutedSecurityScan, limit: number): string {
+  const lines = [renderDvalinResult(execution.scan, execution.root, limit)];
+  if (execution.delta) {
+    lines.push('', `Baseline delta · ${execution.delta.new.length} new · ${execution.delta.existing.length} existing · ${execution.delta.resolved.length} resolved`);
+  }
+  if (execution.suppressed) lines.push(`Suppressed: ${execution.suppressed}`);
+  if (execution.expiredSuppressions) lines.push(`Expired suppressions: ${execution.expiredSuppressions}`);
+  lines.push(`Gate: ${execution.gate.passed ? 'PASS' : 'FAIL'} · ${execution.gate.mode} findings · threshold ${execution.gate.threshold}`);
+  if (execution.workflow) lines.push(`Workflow: ${execution.workflow.id}`);
+  return lines.join('\n');
+}
+
+function parseThreshold(value: string): SecurityThreshold {
+  if (['critical', 'high', 'medium', 'low', 'none'].includes(value)) return value as SecurityThreshold;
+  throw new UsageError('--fail-on must be one of critical, high, medium, low, none.');
+}
+
+function positiveInteger(value: string, label: string): number {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) throw new UsageError(`${label} must be a positive integer.`);
+  return parsed;
+}
+
+async function writeSarif(result: DvalinScanSuiteResult, root: string, file: string, announce: boolean): Promise<void> {
+  const target = path.resolve(process.cwd(), file);
+  await mkdir(path.dirname(target), { recursive: true });
+  await writeFile(target, `${JSON.stringify(buildDvalinSarif(result, root), null, 2)}\n`, 'utf8');
+  if (announce) console.log(`SARIF written to ${target}`);
+}
+
+async function runConfiguredChecks(
+  cwd: string,
+  checks: DvalinSecurityConfig['checks'],
+): Promise<SecurityCheckEvidence[]> {
+  const context = createDvalinContext({ cwd, approvalMode: 'full-auto', policy: loadPolicy(cwd).policy });
+  const evidence: SecurityCheckEvidence[] = [];
+  for (const kind of checks) {
+    try {
+      const result = await runCheckTool.run({ kind, args: [], timeoutMs: 120_000 }, context);
+      const exitCode = typeof result.metadata?.exitCode === 'number' ? result.metadata.exitCode : null;
+      evidence.push({
+        kind,
+        command: typeof result.metadata?.command === 'string' ? result.metadata.command : kind,
+        exitCode,
+        passed: result.metadata?.skipped !== true && exitCode === 0,
+      });
+    } catch {
+      evidence.push({ kind, command: kind, exitCode: null, passed: false });
+    }
+  }
+  return evidence;
+}
+
+async function exists(file: string): Promise<boolean> {
+  try {
+    await access(file, constants.R_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/src/dvalinCli.ts
+++ b/src/dvalinCli.ts
@@ -1,0 +1,34 @@
+import { Command, CommanderError } from 'commander';
+import { registerSecuritySubcommands } from './commands/security.js';
+import { registerMcpServeCommand } from './commands/mcpServe.js';
+import { EXIT } from './core/exitCodes.js';
+import { VERSION } from './version.js';
+
+export function buildDvalinProgram(): Command {
+  const program = new Command()
+    .name('dvalin')
+    .description('Independent security verification for human- and agent-written code')
+    .version(VERSION);
+  registerSecuritySubcommands(program);
+  registerMcpServeCommand(program);
+  return program;
+}
+
+export async function runDvalinCli(argv: string[]): Promise<void> {
+  const program = buildDvalinProgram();
+  applyExitOverride(program);
+  try {
+    await program.parseAsync(argv);
+  } catch (error) {
+    if (error instanceof CommanderError) {
+      process.exitCode = error.exitCode === 0 ? EXIT.ok : EXIT.usageError;
+      return;
+    }
+    throw error;
+  }
+}
+
+function applyExitOverride(command: Command): void {
+  command.exitOverride();
+  for (const child of command.commands) applyExitOverride(child);
+}

--- a/src/dvalinIndex.ts
+++ b/src/dvalinIndex.ts
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+import { runDvalinCli } from './dvalinCli.js';
+import { EXIT, UsageError } from './core/exitCodes.js';
+
+runDvalinCli(process.argv).catch(error => {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(`dvalin: ${message}`);
+  process.exitCode = error instanceof UsageError ? EXIT.usageError : EXIT.runtimeError;
+});

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -14,10 +14,20 @@ import {
 } from '../harness/run.js';
 import type { UnattendedPermissionMode } from '../core/policy.js';
 import {
+  listDvalinScanners,
   runDvalinScanSuite,
+  type DvalinScannerDescriptor,
   type DvalinScannerId,
   type DvalinScanSuiteResult,
 } from '../remediation/scannerSuite.js';
+import { evaluateSecurityGate, findingFingerprint, type SecurityThreshold } from '../security/contracts.js';
+import {
+  createSecurityWorkflow,
+  evaluateWorkflowVerificationGate,
+  getWorkflowFinding,
+  loadSecurityWorkflow,
+  verifySecurityWorkflow,
+} from '../security/workflow.js';
 import { readJournal, type JournalTurnEnd } from '../sessions/journal.js';
 import { loadSession, type Session } from '../sessions/store.js';
 import { VERSION } from '../version.js';
@@ -32,7 +42,7 @@ import { VERSION } from '../version.js';
  * support for revisions this server has never implemented, and the client then
  * assumes features that are not there.
  */
-const SUPPORTED_PROTOCOL_VERSIONS = ['2025-06-18', '2025-03-26', '2024-11-05'] as const;
+const SUPPORTED_PROTOCOL_VERSIONS = ['2025-11-25', '2025-06-18', '2025-03-26', '2024-11-05'] as const;
 const LATEST_PROTOCOL_VERSION = SUPPORTED_PROTOCOL_VERSIONS[0];
 
 const SCANNER_IDS: DvalinScannerId[] = ['builtin', 'semgrep', 'trivy', 'osv-scanner'];
@@ -66,6 +76,10 @@ export type McpServerDependencies = {
   loadSession: (id: string) => Promise<Session | null>;
   renderReport: (runId: string) => string;
   latestRun: () => string | null;
+  createWorkflow: typeof createSecurityWorkflow;
+  loadWorkflow: typeof loadSecurityWorkflow;
+  verifyWorkflow: typeof verifySecurityWorkflow;
+  listScanners: () => Promise<DvalinScannerDescriptor[]>;
 };
 
 export type DvalinMcpServer = {
@@ -77,7 +91,7 @@ const MCP_TOOLS = [
     name: 'dvalin_scan',
     description:
       'Scan a workspace for injection, hardcoded secrets, XSS, dynamic code execution, and unsafe shell use. '
-      + 'Deterministic and read-only: it runs no model, needs no credentials, and never edits files — safe to call '
+      + 'Deterministic and workspace-read-only: it runs no model, needs no credentials, and never edits project files — safe to call '
       + 'after writing code. Returns findings with file, line, severity, and rule reference.',
     inputSchema: {
       type: 'object',
@@ -90,6 +104,11 @@ const MCP_TOOLS = [
         },
         limit: { type: 'integer', minimum: 1, description: `Maximum findings returned (default ${DEFAULT_FINDING_LIMIT}).` },
         timeout_seconds: { type: 'number', exclusiveMinimum: 0 },
+        fail_on: {
+          type: 'string',
+          enum: ['critical', 'high', 'medium', 'low', 'none'],
+          description: 'Workflow gate threshold (default: high).',
+        },
         include_remediation_prompts: {
           type: 'boolean',
           description: 'Include the per-finding repair prompt. Verbose; off by default.',
@@ -97,7 +116,8 @@ const MCP_TOOLS = [
       },
       additionalProperties: false,
     },
-    annotations: { readOnlyHint: true },
+    annotations: stateAnnotations(true),
+    outputSchema: objectOutputSchema(),
   },
   {
     name: 'dvalin_run_task',
@@ -115,7 +135,8 @@ const MCP_TOOLS = [
       required: ['prompt'],
       additionalProperties: false,
     },
-    annotations: { readOnlyHint: false },
+    annotations: writeAnnotations(),
+    outputSchema: objectOutputSchema(),
   },
   {
     name: 'dvalin_get_session',
@@ -126,7 +147,8 @@ const MCP_TOOLS = [
       required: ['session_id'],
       additionalProperties: false,
     },
-    annotations: { readOnlyHint: true },
+    annotations: readAnnotations(),
+    outputSchema: objectOutputSchema(),
   },
   {
     name: 'dvalin_get_evidence',
@@ -136,7 +158,44 @@ const MCP_TOOLS = [
       properties: { run_id: { type: 'string' } },
       additionalProperties: false,
     },
-    annotations: { readOnlyHint: true },
+    annotations: readAnnotations(),
+  },
+  {
+    name: 'dvalin_get_finding',
+    description: 'Read one compact finding from a persisted security workflow by fingerprint.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        workflow_id: { type: 'string' },
+        fingerprint: { type: 'string' },
+      },
+      required: ['workflow_id', 'fingerprint'],
+      additionalProperties: false,
+    },
+    annotations: readAnnotations(),
+    outputSchema: objectOutputSchema(),
+  },
+  {
+    name: 'dvalin_verify_findings',
+    description: 'Re-scan a persisted workflow and deterministically verify that blocked targets are gone and no new severe findings were introduced.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        workflow_id: { type: 'string' },
+        timeout_seconds: { type: 'number', exclusiveMinimum: 0 },
+      },
+      required: ['workflow_id'],
+      additionalProperties: false,
+    },
+    annotations: stateAnnotations(true),
+    outputSchema: objectOutputSchema(),
+  },
+  {
+    name: 'dvalin_list_scanners',
+    description: 'List built-in and optional scanner engines, availability, and reviewable install commands.',
+    inputSchema: { type: 'object', properties: {}, additionalProperties: false },
+    annotations: readAnnotations(),
+    outputSchema: objectOutputSchema(),
   },
 ] as const;
 
@@ -150,6 +209,10 @@ export async function createMcpServer(
     loadSession,
     renderReport: runId => renderReport(runId),
     latestRun: () => latestRun(),
+    createWorkflow: createSecurityWorkflow,
+    loadWorkflow: loadSecurityWorkflow,
+    verifyWorkflow: verifySecurityWorkflow,
+    listScanners: listDvalinScanners,
     ...overrides,
   };
   const serverCwd = await realpath(path.resolve(options.cwd));
@@ -227,7 +290,7 @@ async function callTool(
     allowedWorkspaces: string[];
     maxPermissionMode: UnattendedPermissionMode;
   },
-): Promise<{ content: Array<{ type: 'text'; text: string }>; isError?: boolean }> {
+): Promise<{ content: Array<{ type: 'text'; text: string }>; structuredContent?: Record<string, unknown>; isError?: boolean }> {
   if (name === 'dvalin_scan') {
     const cwd = args.cwd === undefined ? context.serverCwd : requireString(args.cwd, 'cwd');
     const resolvedCwd = await resolveAllowedWorkspace(cwd, context.allowedWorkspaces);
@@ -235,15 +298,19 @@ async function callTool(
     const limit = optionalPositiveNumber(args.limit, 'limit', true) ?? DEFAULT_FINDING_LIMIT;
     const timeoutSeconds = optionalPositiveNumber(args.timeout_seconds, 'timeout_seconds', false);
     const includePrompts = args.include_remediation_prompts === true;
+    const threshold = optionalSecurityThreshold(args.fail_on) ?? 'high';
 
     const result = await context.deps.runScan(resolvedCwd, {
       scanners,
       timeoutMs: timeoutSeconds === undefined ? undefined : timeoutSeconds * 1000,
     });
+    const gate = evaluateSecurityGate({ result, threshold, mode: 'all' });
+    const workflow = await context.deps.createWorkflow({ root: resolvedCwd, result, gate });
 
     // Trimmed by default: the per-finding repair prompt and source snippet are
     // ~1KB each, and a caller that wants context can read the file itself.
     const findings = result.findings.slice(0, limit).map(finding => ({
+      fingerprint: findingFingerprint(finding),
       ruleId: finding.ruleId,
       ruleName: finding.ruleName,
       severity: finding.severity,
@@ -257,7 +324,10 @@ async function callTool(
       ...(includePrompts ? { prompt: finding.prompt } : {}),
     }));
 
-    return toolResult(JSON.stringify({
+    const body = {
+      schemaVersion: 1,
+      scanId: result.id,
+      workflowId: workflow.id,
       score: result.score,
       grade: result.grade,
       metrics: result.metrics,
@@ -270,7 +340,9 @@ async function callTool(
         findings: scanner.findings,
         ...(scanner.error ? { error: scanner.error } : {}),
       })),
-    }));
+      gate,
+    };
+    return toolResult(JSON.stringify(body), false, body);
   }
 
   if (name === 'dvalin_run_task') {
@@ -295,7 +367,7 @@ async function callTool(
       unattended: true,
       origin: 'mcp-serve',
     });
-    return toolResult(JSON.stringify(execution.result), execution.exitCode !== 0);
+    return toolResult(JSON.stringify(execution.result), execution.exitCode !== 0, execution.result as unknown as Record<string, unknown>);
   }
 
   if (name === 'dvalin_get_session') {
@@ -307,14 +379,15 @@ async function callTool(
       (entry): entry is JournalTurnEnd & { seq: number; ts: string } =>
         entry.type === 'turn_end' && !!(entry.runId || entry.auditHead),
     );
-    return toolResult(JSON.stringify({
+    const body = {
       sessionId: session.id,
       cwd: session.cwd,
       summary: session.summary ?? '',
       messageCount: session.messages.length,
       runId: latest?.runId,
       auditHead: latest?.auditHead,
-    }));
+    };
+    return toolResult(JSON.stringify(body), false, body);
   }
 
   if (name === 'dvalin_get_evidence') {
@@ -322,6 +395,50 @@ async function callTool(
     const runId = requestedRunId ?? context.deps.latestRun();
     if (!runId) throw new Error('No audit runs found.');
     return toolResult(context.deps.renderReport(runId));
+  }
+
+  if (name === 'dvalin_get_finding') {
+    const workflowId = requireString(args.workflow_id, 'workflow_id');
+    const fingerprint = requireString(args.fingerprint, 'fingerprint');
+    const workflow = await context.deps.loadWorkflow(workflowId);
+    await resolveAllowedWorkspace(workflow.root, context.allowedWorkspaces);
+    const finding = getWorkflowFinding(workflow, fingerprint);
+    if (!finding) throw new Error(`Finding not found in workflow ${workflowId}: ${fingerprint}`);
+    const body = { schemaVersion: 1, workflowId, finding };
+    return toolResult(JSON.stringify(body), false, body);
+  }
+
+  if (name === 'dvalin_verify_findings') {
+    const workflowId = requireString(args.workflow_id, 'workflow_id');
+    const timeoutSeconds = optionalPositiveNumber(args.timeout_seconds, 'timeout_seconds', false);
+    const workflow = await context.deps.loadWorkflow(workflowId);
+    const cwd = await resolveAllowedWorkspace(workflow.root, context.allowedWorkspaces);
+    const result = await context.deps.runScan(cwd, {
+      scanners: workflow.scanners,
+      timeoutMs: timeoutSeconds === undefined ? undefined : timeoutSeconds * 1000,
+    });
+    const gate = evaluateWorkflowVerificationGate(workflow, result);
+    const updated = await context.deps.verifyWorkflow({ workflow, result, gate });
+    const body = {
+      schemaVersion: 1,
+      workflowId: updated.id,
+      state: updated.state,
+      assurance: updated.verification?.assurance,
+      gate,
+      scanId: result.id,
+      score: result.score,
+      grade: result.grade,
+      findings: result.findings.length,
+    };
+    // A failing security gate is a successful tool execution with a negative
+    // domain result, not an MCP transport/tool error.
+    return toolResult(JSON.stringify(body), false, body);
+  }
+
+  if (name === 'dvalin_list_scanners') {
+    const scanners = await context.deps.listScanners();
+    const body = { schemaVersion: 1, scanners };
+    return toolResult(JSON.stringify(body), false, body);
   }
 
   throw new Error(`Unknown tool: ${name}`);
@@ -361,8 +478,32 @@ function rpcError(id: JsonRpcId, code: number, message: string): JsonRpcResponse
   return { jsonrpc: '2.0', id, error: { code, message } };
 }
 
-function toolResult(text: string, isError = false): { content: Array<{ type: 'text'; text: string }>; isError?: boolean } {
-  return { content: [{ type: 'text', text }], ...(isError ? { isError: true } : {}) };
+function toolResult(
+  text: string,
+  isError = false,
+  structuredContent?: Record<string, unknown>,
+): { content: Array<{ type: 'text'; text: string }>; structuredContent?: Record<string, unknown>; isError?: boolean } {
+  return {
+    content: [{ type: 'text', text }],
+    ...(structuredContent ? { structuredContent } : {}),
+    ...(isError ? { isError: true } : {}),
+  };
+}
+
+function objectOutputSchema(): Record<string, unknown> {
+  return { type: 'object', additionalProperties: true };
+}
+
+function readAnnotations(openWorld = false): Record<string, boolean> {
+  return { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: openWorld };
+}
+
+function writeAnnotations(): Record<string, boolean> {
+  return { readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: true };
+}
+
+function stateAnnotations(openWorld = false): Record<string, boolean> {
+  return { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: openWorld };
 }
 
 function asRecord(value: unknown): Record<string, unknown> | null {
@@ -383,6 +524,12 @@ function optionalPermissionMode(value: unknown): UnattendedPermissionMode | unde
   if (value === undefined) return undefined;
   if (value === 'plan' || value === 'auto' || value === 'bypass') return value;
   throw new Error('permission_mode must be plan, auto, or bypass');
+}
+
+function optionalSecurityThreshold(value: unknown): SecurityThreshold | undefined {
+  if (value === undefined) return undefined;
+  if (value === 'critical' || value === 'high' || value === 'medium' || value === 'low' || value === 'none') return value;
+  throw new Error('fail_on must be critical, high, medium, low, or none');
 }
 
 /**

--- a/src/remediation/automate.ts
+++ b/src/remediation/automate.ts
@@ -1,5 +1,7 @@
 import type { DvalinScanSuiteResult } from './scannerSuite.js';
 import type { RemediationFinding } from './sarif.js';
+import { readRecords } from '../audit/log.js';
+import type { SecurityCheckEvidence } from '../security/workflow.js';
 
 export const VERIFICATION_MARKER = 'DVALIN_VERIFICATION_PASSED';
 
@@ -43,7 +45,7 @@ export function buildAutomatedVerificationPrompt(findings: RemediationFinding[],
     '',
     'Hard verification requirements:',
     '1. Inspect git status and the complete diff. Fail on unrelated changes, test weakening, scanner suppression, generated artifacts, or secrets.',
-    '2. Run focused tests covering every changed area. Then run the project typecheck/build/test command that is proportionate to the change.',
+    '2. Use the run_check tool for focused tests covering every changed area. Then use run_check for the project typecheck/build/test command that is proportionate to the change.',
     '3. Run the Dvalin security suite again and confirm the original finding class is gone without introducing a new high/critical finding.',
     '4. If any required command fails, evidence is missing, or a finding remains, explain the failure and end with DVALIN_VERIFICATION_FAILED.',
     `5. Only when every requirement passes, end the response with the exact standalone line ${VERIFICATION_MARKER}.`,
@@ -64,12 +66,32 @@ export function buildDraftPrPrompt(findings: RemediationFinding[]): string {
 
 export type VerificationGate = { passed: boolean; reasons: string[] };
 
+/** Extract process exit codes from the tamper-evident audit trail, not model prose. */
+export function verificationEvidenceFromAudit(runId: string, auditDir?: string): SecurityCheckEvidence[] {
+  const records = readRecords(runId, auditDir);
+  const evidence: SecurityCheckEvidence[] = [];
+  for (let index = 0; index < records.length; index++) {
+    const record = records[index]!;
+    if (record.type !== 'tool_call' || record.tool !== 'run_check') continue;
+    const execution = records.slice(index + 1).find(candidate => candidate.type === 'tool_call' || candidate.type === 'shell_exec');
+    if (!execution || execution.type !== 'shell_exec') continue;
+    evidence.push({
+      kind: record.argsSummary,
+      command: execution.command,
+      exitCode: execution.exitCode,
+      passed: record.status === 'ok' && execution.exitCode === 0,
+    });
+  }
+  return evidence;
+}
+
 export function evaluateVerificationGate(input: {
   originals: RemediationFinding[];
   baseline?: RemediationFinding[];
   after: DvalinScanSuiteResult;
   agentOutput: string;
   hasChanges: boolean;
+  checkEvidence?: SecurityCheckEvidence[];
 }): VerificationGate {
   const reasons: string[] = [];
   const originalKeys = new Set(input.originals.map(findingKey));
@@ -82,8 +104,16 @@ export function evaluateVerificationGate(input: {
   if (newSevere.length) reasons.push(`${newSevere.length} new high/critical finding target(s) appeared`);
   if (!input.hasChanges) reasons.push('the remediation worktree has no code changes');
 
-  const markerPattern = new RegExp(`(?:^|\\n)${VERIFICATION_MARKER}(?:\\n|$)`);
-  if (!markerPattern.test(input.agentOutput.trim())) reasons.push('focused tests/build were not reported as passing');
+  if (input.checkEvidence) {
+    if (!input.checkEvidence.length) reasons.push('no run_check execution evidence was recorded');
+    const failedChecks = input.checkEvidence.filter(check => !check.passed);
+    if (failedChecks.length) reasons.push(`${failedChecks.length} recorded check(s) failed`);
+  } else {
+    // Compatibility for programmatic callers that have not supplied audit
+    // evidence. The automated remediation path always supplies it.
+    const markerPattern = new RegExp(`(?:^|\\n)${VERIFICATION_MARKER}(?:\\n|$)`);
+    if (!markerPattern.test(input.agentOutput.trim())) reasons.push('focused tests/build were not reported as passing');
+  }
   return { passed: reasons.length === 0, reasons };
 }
 

--- a/src/remediation/scannerSuite.ts
+++ b/src/remediation/scannerSuite.ts
@@ -10,6 +10,8 @@ import { parseSarifForRemediation, type RemediationFinding } from './sarif.js';
 
 export type DvalinScannerId = 'builtin' | 'semgrep' | 'trivy' | 'osv-scanner';
 
+export const DVALIN_SCANNER_IDS: DvalinScannerId[] = ['builtin', 'semgrep', 'trivy', 'osv-scanner'];
+
 export type DvalinScannerDescriptor = {
   id: DvalinScannerId;
   name: string;
@@ -18,6 +20,13 @@ export type DvalinScannerDescriptor = {
   available: boolean;
   installCommand?: string;
   homepage: string;
+};
+
+export type DvalinScannerInstallPlan = {
+  scanner: DvalinScannerId;
+  supported: boolean;
+  command?: string;
+  reason?: string;
 };
 
 export type DvalinScannerRun = DvalinScannerDescriptor & {
@@ -125,6 +134,45 @@ export async function listDvalinScanners(): Promise<DvalinScannerDescriptor[]> {
     available: Boolean(await findExecutable(scanner.command)),
   })));
   return [BUILTIN, ...external];
+}
+
+/**
+ * Return a reviewable install plan. Dvalin never downloads or executes an
+ * installer merely because a scan discovered that an optional engine is absent.
+ */
+export function dvalinScannerInstallPlan(id: DvalinScannerId): DvalinScannerInstallPlan {
+  if (id === 'builtin') {
+    return { scanner: id, supported: true, reason: 'Dvalin Built-in ships with the CLI; no installation is required.' };
+  }
+  const scanner = EXTERNAL_SCANNERS.find(candidate => candidate.descriptor.id === id);
+  if (!scanner) return { scanner: id, supported: false, reason: `Unknown scanner: ${id}` };
+  if (!scanner.descriptor.installCommand) {
+    return { scanner: id, supported: false, reason: `No managed install command is available for ${scanner.descriptor.name}.` };
+  }
+  return { scanner: id, supported: true, command: scanner.descriptor.installCommand };
+}
+
+/** Execute a previously reviewed, fixed installer argv under the resolved policy. */
+export async function installDvalinScanner(cwd: string, id: DvalinScannerId): Promise<void> {
+  const launch = scannerInstaller(id);
+  if (!launch) {
+    if (id === 'builtin') return;
+    throw new Error(`No managed installer is available for ${id}.`);
+  }
+  const policy = loadPolicy(cwd).policy;
+  const commandLine = buildShellScript(launch.command, launch.args);
+  const decision = checkCommand(policy, commandLine);
+  if (!decision.allowed) throw new Error(`Scanner installation blocked by policy: ${decision.rule}`);
+  const result = await runGovernedExecutable({
+    ...launch,
+    cwd,
+    timeoutMs: 600_000,
+    policy,
+    toolName: 'install_security_scanner',
+    preferSandboxWhenUnrestricted: false,
+    skipNetworkSandboxWhenPolicyAllows: true,
+  });
+  if (result.exitCode !== 0) throw new Error(result.output.trim() || `${launch.command} exited ${result.exitCode}`);
 }
 
 export async function runDvalinScanSuite(
@@ -308,4 +356,11 @@ async function findExecutable(command: string): Promise<string | undefined> {
 function compactError(error: unknown): string {
   const message = error instanceof Error ? error.message : String(error);
   return message.replace(/\s+/g, ' ').trim().slice(0, 500);
+}
+
+function scannerInstaller(id: DvalinScannerId): { command: string; args: string[] } | null {
+  if (id === 'semgrep') return { command: 'python3', args: ['-m', 'pip', 'install', 'semgrep'] };
+  if (id === 'trivy') return { command: 'brew', args: ['install', 'trivy'] };
+  if (id === 'osv-scanner') return { command: 'brew', args: ['install', 'osv-scanner'] };
+  return null;
 }

--- a/src/security/baseline.ts
+++ b/src/security/baseline.ts
@@ -1,0 +1,29 @@
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { UsageError } from '../core/exitCodes.js';
+import type { DvalinScanSuiteResult } from '../remediation/scannerSuite.js';
+import { createBaseline, isSecurityBaseline, type SecurityBaseline } from './contracts.js';
+import { resolveSecurityPath } from './config.js';
+
+export async function readSecurityBaseline(root: string, file: string): Promise<SecurityBaseline> {
+  const target = resolveSecurityPath(root, file);
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(await readFile(target, 'utf8')) as unknown;
+  } catch (error) {
+    throw new UsageError(`Cannot read security baseline ${target}: ${error instanceof Error ? error.message : String(error)}`);
+  }
+  if (!isSecurityBaseline(parsed)) throw new UsageError(`Invalid or unsupported security baseline: ${target}`);
+  return parsed;
+}
+
+export async function writeSecurityBaseline(root: string, file: string, result: DvalinScanSuiteResult): Promise<{
+  path: string;
+  baseline: SecurityBaseline;
+}> {
+  const target = resolveSecurityPath(root, file);
+  const baseline = createBaseline(result);
+  await mkdir(path.dirname(target), { recursive: true });
+  await writeFile(target, `${JSON.stringify(baseline, null, 2)}\n`, 'utf8');
+  return { path: target, baseline };
+}

--- a/src/security/config.ts
+++ b/src/security/config.ts
@@ -1,0 +1,152 @@
+import { access, readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { constants } from 'node:fs';
+import { UsageError } from '../core/exitCodes.js';
+import type { DvalinScannerId } from '../remediation/scannerSuite.js';
+import type { SecurityGateMode, SecurityThreshold } from './contracts.js';
+
+export const SECURITY_CONFIG_FILE = 'dvalin.security.json';
+export const DEFAULT_BASELINE_FILE = '.dvalin/baseline.json';
+
+export type SecuritySuppression = {
+  fingerprint?: string;
+  ruleId?: string;
+  path?: string;
+  reason: string;
+  owner?: string;
+  expiresAt?: string;
+};
+
+export type DvalinSecurityConfig = {
+  version: 1;
+  scanners: DvalinScannerId[];
+  gate: {
+    severity: SecurityThreshold;
+    mode: SecurityGateMode;
+  };
+  baseline: string;
+  checks: Array<'test' | 'typecheck' | 'build' | 'lint'>;
+  suppressions: SecuritySuppression[];
+};
+
+export const DEFAULT_SECURITY_CONFIG: DvalinSecurityConfig = {
+  version: 1,
+  scanners: ['builtin'],
+  gate: { severity: 'none', mode: 'all' },
+  baseline: DEFAULT_BASELINE_FILE,
+  checks: ['test'],
+  suppressions: [],
+};
+
+export const INITIALIZED_SECURITY_CONFIG: DvalinSecurityConfig = {
+  ...DEFAULT_SECURITY_CONFIG,
+  gate: { severity: 'high', mode: 'new' },
+};
+
+export async function loadSecurityConfig(root: string, explicitPath?: string): Promise<{
+  config: DvalinSecurityConfig;
+  path?: string;
+}> {
+  const candidate = explicitPath ? path.resolve(root, explicitPath) : path.join(root, SECURITY_CONFIG_FILE);
+  try {
+    await access(candidate, constants.R_OK);
+  } catch {
+    if (explicitPath) throw new UsageError(`Security config not found: ${candidate}`);
+    return { config: structuredClone(DEFAULT_SECURITY_CONFIG) };
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(await readFile(candidate, 'utf8')) as unknown;
+  } catch (error) {
+    throw new UsageError(`Invalid security config ${candidate}: ${error instanceof Error ? error.message : String(error)}`);
+  }
+  return { config: parseSecurityConfig(parsed, candidate), path: candidate };
+}
+
+export async function writeInitialSecurityConfig(root: string, force = false): Promise<string> {
+  const target = path.join(root, SECURITY_CONFIG_FILE);
+  if (!force) {
+    try {
+      await access(target, constants.F_OK);
+      throw new UsageError(`${SECURITY_CONFIG_FILE} already exists. Use --force to replace it.`);
+    } catch (error) {
+      if (error instanceof UsageError) throw error;
+    }
+  }
+  await writeFile(target, `${JSON.stringify(INITIALIZED_SECURITY_CONFIG, null, 2)}\n`, 'utf8');
+  return target;
+}
+
+export function parseSecurityConfig(value: unknown, source = SECURITY_CONFIG_FILE): DvalinSecurityConfig {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) throw new UsageError(`${source} must contain a JSON object.`);
+  const input = value as Record<string, unknown>;
+  if (input.version !== 1) throw new UsageError(`${source}: version must be 1.`);
+  const scanners = parseScanners(input.scanners, source);
+  const gateInput = asRecord(input.gate);
+  const severity = gateInput?.severity ?? DEFAULT_SECURITY_CONFIG.gate.severity;
+  const mode = gateInput?.mode ?? DEFAULT_SECURITY_CONFIG.gate.mode;
+  if (!['critical', 'high', 'medium', 'low', 'none'].includes(String(severity))) {
+    throw new UsageError(`${source}: gate.severity must be critical, high, medium, low, or none.`);
+  }
+  if (mode !== 'all' && mode !== 'new') throw new UsageError(`${source}: gate.mode must be all or new.`);
+  const baseline = input.baseline ?? DEFAULT_SECURITY_CONFIG.baseline;
+  if (typeof baseline !== 'string' || !baseline.trim()) throw new UsageError(`${source}: baseline must be a path string.`);
+  const checks = input.checks ?? DEFAULT_SECURITY_CONFIG.checks;
+  if (!Array.isArray(checks) || checks.some(check => !['test', 'typecheck', 'build', 'lint'].includes(String(check)))) {
+    throw new UsageError(`${source}: checks must contain only test, typecheck, build, or lint.`);
+  }
+  const suppressions = input.suppressions ?? [];
+  if (!Array.isArray(suppressions)) throw new UsageError(`${source}: suppressions must be an array.`);
+  return {
+    version: 1,
+    scanners,
+    gate: { severity: severity as SecurityThreshold, mode },
+    baseline,
+    checks: [...new Set(checks)] as DvalinSecurityConfig['checks'],
+    suppressions: suppressions.map((suppression, index) => parseSuppression(suppression, `${source}: suppressions[${index}]`)),
+  };
+}
+
+export function resolveSecurityPath(root: string, candidate: string): string {
+  const resolvedRoot = path.resolve(root);
+  const resolved = path.resolve(resolvedRoot, candidate);
+  const relative = path.relative(resolvedRoot, resolved);
+  if (relative.startsWith('..' + path.sep) || relative === '..' || path.isAbsolute(relative)) {
+    throw new UsageError(`Security artifact path must stay inside the workspace: ${candidate}`);
+  }
+  return resolved;
+}
+
+function parseScanners(value: unknown, source: string): DvalinScannerId[] {
+  const scanners = value ?? DEFAULT_SECURITY_CONFIG.scanners;
+  const allowed: DvalinScannerId[] = ['builtin', 'semgrep', 'trivy', 'osv-scanner'];
+  if (!Array.isArray(scanners) || !scanners.length || scanners.some(scanner => !allowed.includes(scanner as DvalinScannerId))) {
+    throw new UsageError(`${source}: scanners must contain one or more of ${allowed.join(', ')}.`);
+  }
+  return [...new Set(scanners)] as DvalinScannerId[];
+}
+
+function parseSuppression(value: unknown, source: string): SecuritySuppression {
+  const input = asRecord(value);
+  if (!input) throw new UsageError(`${source} must be an object.`);
+  if (typeof input.reason !== 'string' || !input.reason.trim()) throw new UsageError(`${source}.reason is required.`);
+  if (!input.fingerprint && !input.ruleId) throw new UsageError(`${source} needs fingerprint or ruleId.`);
+  for (const field of ['fingerprint', 'ruleId', 'path', 'owner', 'expiresAt'] as const) {
+    if (input[field] !== undefined && typeof input[field] !== 'string') throw new UsageError(`${source}.${field} must be a string.`);
+  }
+  if (typeof input.expiresAt === 'string' && !Number.isFinite(Date.parse(input.expiresAt))) {
+    throw new UsageError(`${source}.expiresAt must be an ISO date.`);
+  }
+  return {
+    fingerprint: input.fingerprint as string | undefined,
+    ruleId: input.ruleId as string | undefined,
+    path: input.path as string | undefined,
+    reason: input.reason,
+    owner: input.owner as string | undefined,
+    expiresAt: input.expiresAt as string | undefined,
+  };
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : null;
+}

--- a/src/security/contracts.ts
+++ b/src/security/contracts.ts
@@ -1,0 +1,177 @@
+import { createHash } from 'node:crypto';
+import type { RemediationFinding } from '../remediation/sarif.js';
+import type { DvalinScannerId, DvalinScanSuiteResult } from '../remediation/scannerSuite.js';
+
+export const SECURITY_SCHEMA_VERSION = 1 as const;
+
+export const SECURITY_SEVERITIES = ['critical', 'high', 'medium', 'low'] as const;
+export type SecuritySeverity = typeof SECURITY_SEVERITIES[number];
+export type SecurityThreshold = SecuritySeverity | 'none';
+export type SecurityGateMode = 'all' | 'new';
+
+export type SecurityFindingSnapshot = {
+  fingerprint: string;
+  targetFingerprint: string;
+  findingId: string;
+  source: string;
+  ruleId: string;
+  ruleName?: string;
+  severity: RemediationFinding['severity'];
+  securitySeverity?: string;
+  message: string;
+  path: string;
+  startLine?: number;
+  endLine?: number;
+  helpUri?: string;
+  tags: string[];
+};
+
+export type SecurityBaseline = {
+  schemaVersion: typeof SECURITY_SCHEMA_VERSION;
+  kind: 'dvalin-security-baseline';
+  createdAt: string;
+  scanId: string;
+  scanners: DvalinScannerId[];
+  findings: SecurityFindingSnapshot[];
+};
+
+export type SecurityFindingDelta = {
+  new: SecurityFindingSnapshot[];
+  existing: SecurityFindingSnapshot[];
+  resolved: SecurityFindingSnapshot[];
+};
+
+export type SecurityGateResult = {
+  passed: boolean;
+  mode: SecurityGateMode;
+  threshold: SecurityThreshold;
+  considered: number;
+  blocking: SecurityFindingSnapshot[];
+};
+
+export type SecurityScanEnvelope = {
+  schemaVersion: typeof SECURITY_SCHEMA_VERSION;
+  scan: DvalinScanSuiteResult;
+  delta?: SecurityFindingDelta;
+  gate: SecurityGateResult;
+};
+
+export function severityOfFinding(finding: Pick<RemediationFinding, 'severity' | 'securitySeverity'>): SecuritySeverity {
+  const score = Number.parseFloat(finding.securitySeverity ?? '');
+  if (score >= 9) return 'critical';
+  if (finding.severity === 'error' || score >= 7) return 'high';
+  if (finding.severity === 'warning' || score >= 4) return 'medium';
+  return 'low';
+}
+
+export function findingFingerprint(finding: Pick<RemediationFinding, 'id' | 'source' | 'ruleId' | 'path' | 'startLine' | 'message'>): string {
+  return digest([
+    finding.source,
+    finding.id,
+    finding.ruleId,
+    normalizePath(finding.path),
+    String(finding.startLine ?? 0),
+    finding.message.trim().replace(/\s+/g, ' '),
+  ]);
+}
+
+/** A conservative verification key: a moved instance of the same rule in the same file still remains a target. */
+export function findingTargetFingerprint(finding: Pick<RemediationFinding, 'source' | 'ruleId' | 'path'>): string {
+  return digest([finding.source, finding.ruleId, normalizePath(finding.path)]);
+}
+
+export function snapshotFinding(finding: RemediationFinding): SecurityFindingSnapshot {
+  return {
+    fingerprint: findingFingerprint(finding),
+    targetFingerprint: findingTargetFingerprint(finding),
+    findingId: finding.id,
+    source: finding.source,
+    ruleId: finding.ruleId,
+    ruleName: finding.ruleName,
+    severity: finding.severity,
+    securitySeverity: finding.securitySeverity,
+    message: finding.message,
+    path: normalizePath(finding.path),
+    startLine: finding.startLine,
+    endLine: finding.endLine,
+    helpUri: finding.helpUri,
+    tags: [...finding.tags],
+  };
+}
+
+export function createBaseline(result: DvalinScanSuiteResult): SecurityBaseline {
+  return {
+    schemaVersion: SECURITY_SCHEMA_VERSION,
+    kind: 'dvalin-security-baseline',
+    createdAt: new Date().toISOString(),
+    scanId: result.id,
+    scanners: result.scanners.map(scanner => scanner.id),
+    findings: result.findings.map(snapshotFinding),
+  };
+}
+
+export function compareWithBaseline(result: DvalinScanSuiteResult, baseline: SecurityBaseline): SecurityFindingDelta {
+  const current = result.findings.map(snapshotFinding);
+  const baselineByFingerprint = new Map(baseline.findings.map(finding => [finding.fingerprint, finding]));
+  const currentFingerprints = new Set(current.map(finding => finding.fingerprint));
+  return {
+    new: current.filter(finding => !baselineByFingerprint.has(finding.fingerprint)),
+    existing: current.filter(finding => baselineByFingerprint.has(finding.fingerprint)),
+    resolved: baseline.findings.filter(finding => !currentFingerprints.has(finding.fingerprint)),
+  };
+}
+
+export function evaluateSecurityGate(input: {
+  result: DvalinScanSuiteResult;
+  threshold: SecurityThreshold;
+  mode: SecurityGateMode;
+  delta?: SecurityFindingDelta;
+}): SecurityGateResult {
+  const considered = input.mode === 'new'
+    ? input.delta?.new ?? input.result.findings.map(snapshotFinding)
+    : input.result.findings.map(snapshotFinding);
+  const thresholdIndex = input.threshold === 'none' ? -1 : SECURITY_SEVERITIES.indexOf(input.threshold);
+  const blocking = thresholdIndex === -1
+    ? []
+    : considered.filter(finding => SECURITY_SEVERITIES.indexOf(severityOfFinding(finding)) <= thresholdIndex);
+  return {
+    passed: blocking.length === 0,
+    mode: input.mode,
+    threshold: input.threshold,
+    considered: considered.length,
+    blocking,
+  };
+}
+
+export function isSecurityBaseline(value: unknown): value is SecurityBaseline {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const record = value as Record<string, unknown>;
+  return record.schemaVersion === SECURITY_SCHEMA_VERSION
+    && record.kind === 'dvalin-security-baseline'
+    && typeof record.createdAt === 'string'
+    && typeof record.scanId === 'string'
+    && Array.isArray(record.scanners)
+    && Array.isArray(record.findings)
+    && record.findings.every(isFindingSnapshot);
+}
+
+function isFindingSnapshot(value: unknown): value is SecurityFindingSnapshot {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const record = value as Record<string, unknown>;
+  return typeof record.fingerprint === 'string'
+    && typeof record.targetFingerprint === 'string'
+    && typeof record.findingId === 'string'
+    && typeof record.source === 'string'
+    && typeof record.ruleId === 'string'
+    && typeof record.message === 'string'
+    && typeof record.path === 'string'
+    && Array.isArray(record.tags);
+}
+
+function digest(parts: string[]): string {
+  return createHash('sha256').update(parts.join('\0')).digest('hex');
+}
+
+function normalizePath(filePath: string): string {
+  return filePath.replace(/\\/g, '/').replace(/^\.\//, '');
+}

--- a/src/security/suppressions.ts
+++ b/src/security/suppressions.ts
@@ -1,0 +1,70 @@
+import type { RemediationFinding } from '../remediation/sarif.js';
+import type { DvalinScanSuiteResult } from '../remediation/scannerSuite.js';
+import type { SecuritySuppression } from './config.js';
+import { findingFingerprint } from './contracts.js';
+
+export type SuppressionResult = {
+  result: DvalinScanSuiteResult;
+  suppressed: Array<{ finding: RemediationFinding; suppression: SecuritySuppression }>;
+  expired: SecuritySuppression[];
+};
+
+export function applySecuritySuppressions(
+  result: DvalinScanSuiteResult,
+  suppressions: SecuritySuppression[],
+  now = new Date(),
+): SuppressionResult {
+  const expired = suppressions.filter(suppression => suppression.expiresAt && Date.parse(suppression.expiresAt) <= now.getTime());
+  const active = suppressions.filter(suppression => !expired.includes(suppression));
+  const suppressed: SuppressionResult['suppressed'] = [];
+  const findings = result.findings.filter(finding => {
+    const fingerprint = findingFingerprint(finding);
+    const match = active.find(suppression =>
+      (suppression.fingerprint === fingerprint || (!suppression.fingerprint && suppression.ruleId === finding.ruleId))
+      && (!suppression.path || normalizePath(suppression.path) === normalizePath(finding.path))
+    );
+    if (!match) return true;
+    suppressed.push({ finding, suppression: match });
+    return false;
+  });
+  return {
+    result: { ...result, findings, metrics: metricsFor(findings), score: scoreFor(findings), grade: gradeFor(scoreFor(findings)) },
+    suppressed,
+    expired,
+  };
+}
+
+function metricsFor(findings: RemediationFinding[]): DvalinScanSuiteResult['metrics'] {
+  const metrics: DvalinScanSuiteResult['metrics'] = { critical: 0, high: 0, medium: 0, low: 0, files: 0, rules: 0 };
+  const files = new Set<string>();
+  const rules = new Set<string>();
+  for (const finding of findings) {
+    const score = Number.parseFloat(finding.securitySeverity ?? '');
+    if (score >= 9) metrics.critical++;
+    else if (finding.severity === 'error' || score >= 7) metrics.high++;
+    else if (finding.severity === 'warning' || score >= 4) metrics.medium++;
+    else metrics.low++;
+    files.add(finding.path);
+    rules.add(`${finding.source}:${finding.ruleId}`);
+  }
+  metrics.files = files.size;
+  metrics.rules = rules.size;
+  return metrics;
+}
+
+function scoreFor(findings: RemediationFinding[]): number {
+  const metrics = metricsFor(findings);
+  return Math.max(0, 100 - metrics.critical * 22 - metrics.high * 12 - metrics.medium * 5 - metrics.low);
+}
+
+function gradeFor(score: number): DvalinScanSuiteResult['grade'] {
+  if (score >= 90) return 'A';
+  if (score >= 80) return 'B';
+  if (score >= 70) return 'C';
+  if (score >= 60) return 'D';
+  return 'F';
+}
+
+function normalizePath(filePath: string): string {
+  return filePath.replace(/\\/g, '/').replace(/^\.\//, '');
+}

--- a/src/security/workflow.ts
+++ b/src/security/workflow.ts
@@ -1,0 +1,306 @@
+import { createHash, randomUUID } from 'node:crypto';
+import { mkdir, readFile, rename, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { dvalinHome } from '../memory/store.js';
+import {
+  DVALIN_SCANNER_IDS,
+  type DvalinScannerId,
+  type DvalinScanMetrics,
+  type DvalinScanSuiteResult,
+} from '../remediation/scannerSuite.js';
+import { UsageError } from '../core/exitCodes.js';
+import {
+  SECURITY_SCHEMA_VERSION,
+  SECURITY_SEVERITIES,
+  severityOfFinding,
+  snapshotFinding,
+  type SecurityFindingDelta,
+  type SecurityFindingSnapshot,
+  type SecurityGateResult,
+} from './contracts.js';
+
+export type SecurityWorkflowState =
+  | 'created'
+  | 'scanning'
+  | 'ready'
+  | 'external_handoff'
+  | 'internal_fix'
+  | 'verifying'
+  | 'passed'
+  | 'needs_work'
+  | 'blocked'
+  | 'evidence_ready'
+  | 'publication_pending'
+  | 'published';
+
+const SECURITY_WORKFLOW_STATES: SecurityWorkflowState[] = [
+  'created', 'scanning', 'ready', 'external_handoff', 'internal_fix', 'verifying',
+  'passed', 'needs_work', 'blocked', 'evidence_ready', 'publication_pending', 'published',
+];
+
+export type SecurityCheckEvidence = {
+  kind: string;
+  command: string;
+  exitCode: number | null;
+  passed: boolean;
+};
+
+export type SecurityWorkflowScan = {
+  id: string;
+  completedAt: string;
+  score: number;
+  grade: DvalinScanSuiteResult['grade'];
+  metrics: DvalinScanMetrics;
+  findings: SecurityFindingSnapshot[];
+};
+
+export type SecurityWorkflow = {
+  schemaVersion: typeof SECURITY_SCHEMA_VERSION;
+  kind: 'dvalin-security-workflow';
+  id: string;
+  projectId: string;
+  root: string;
+  state: SecurityWorkflowState;
+  scanners: DvalinScannerId[];
+  createdAt: string;
+  updatedAt: string;
+  initialScan: SecurityWorkflowScan;
+  latestScan: SecurityWorkflowScan;
+  delta?: SecurityFindingDelta;
+  gate: SecurityGateResult;
+  verification?: {
+    assurance: 'scan-only' | 'scan-and-checks';
+    checks: SecurityCheckEvidence[];
+    verifiedAt: string;
+  };
+  history: Array<{ state: SecurityWorkflowState; at: string; note?: string }>;
+};
+
+const TRANSITIONS: Record<SecurityWorkflowState, SecurityWorkflowState[]> = {
+  created: ['scanning', 'blocked'],
+  scanning: ['ready', 'passed', 'needs_work', 'blocked'],
+  ready: ['external_handoff', 'internal_fix', 'verifying', 'needs_work', 'blocked'],
+  external_handoff: ['verifying', 'blocked'],
+  internal_fix: ['verifying', 'blocked'],
+  verifying: ['passed', 'needs_work', 'blocked'],
+  passed: ['evidence_ready', 'publication_pending', 'published', 'verifying'],
+  needs_work: ['external_handoff', 'internal_fix', 'verifying', 'blocked'],
+  blocked: ['scanning', 'verifying'],
+  evidence_ready: ['publication_pending', 'published', 'verifying'],
+  publication_pending: ['published', 'blocked'],
+  published: ['verifying'],
+};
+
+export async function createSecurityWorkflow(input: {
+  root: string;
+  result: DvalinScanSuiteResult;
+  gate: SecurityGateResult;
+  delta?: SecurityFindingDelta;
+}): Promise<SecurityWorkflow> {
+  const now = new Date().toISOString();
+  const root = path.resolve(input.root);
+  const initialScan = workflowScan(input.result);
+  const state: SecurityWorkflowState = input.gate.passed ? 'passed' : 'needs_work';
+  const workflow: SecurityWorkflow = {
+    schemaVersion: SECURITY_SCHEMA_VERSION,
+    kind: 'dvalin-security-workflow',
+    id: `security-${now.replace(/[:.]/g, '-')}-${randomUUID().slice(0, 8)}`,
+    projectId: createHash('sha256').update(root).digest('hex').slice(0, 16),
+    root,
+    state,
+    scanners: input.result.scanners.map(scanner => scanner.id),
+    createdAt: now,
+    updatedAt: now,
+    initialScan,
+    latestScan: initialScan,
+    delta: input.delta,
+    gate: input.gate,
+    history: [
+      { state: 'created', at: now },
+      { state: 'scanning', at: now },
+      { state, at: now, note: input.gate.passed ? 'Security gate passed.' : 'Security gate needs remediation.' },
+    ],
+  };
+  await persistSecurityWorkflow(workflow);
+  return workflow;
+}
+
+export async function loadSecurityWorkflow(id: string): Promise<SecurityWorkflow> {
+  assertWorkflowId(id);
+  let value: unknown;
+  try {
+    value = JSON.parse(await readFile(workflowPath(id), 'utf8')) as unknown;
+  } catch (error) {
+    throw new UsageError(`Cannot read security workflow ${id}: ${error instanceof Error ? error.message : String(error)}`);
+  }
+  if (!isSecurityWorkflow(value) || value.id !== id) throw new UsageError(`Invalid or unsupported security workflow: ${id}`);
+  return value;
+}
+
+export async function transitionSecurityWorkflow(
+  workflow: SecurityWorkflow,
+  next: SecurityWorkflowState,
+  note?: string,
+): Promise<SecurityWorkflow> {
+  if (workflow.state !== next && !TRANSITIONS[workflow.state].includes(next)) {
+    throw new UsageError(`Invalid security workflow transition: ${workflow.state} -> ${next}`);
+  }
+  const at = new Date().toISOString();
+  const updated: SecurityWorkflow = {
+    ...workflow,
+    state: next,
+    updatedAt: at,
+    history: [...workflow.history, { state: next, at, ...(note ? { note } : {}) }],
+  };
+  await persistSecurityWorkflow(updated);
+  return updated;
+}
+
+export async function verifySecurityWorkflow(input: {
+  workflow: SecurityWorkflow;
+  result: DvalinScanSuiteResult;
+  gate: SecurityGateResult;
+  checks?: SecurityCheckEvidence[];
+}): Promise<SecurityWorkflow> {
+  let workflow = input.workflow;
+  if (workflow.state !== 'verifying') workflow = await transitionSecurityWorkflow(workflow, 'verifying');
+  const checks = input.checks ?? [];
+  const checksPassed = checks.every(check => check.passed);
+  const passed = input.gate.passed && checksPassed;
+  const at = new Date().toISOString();
+  const next: SecurityWorkflowState = passed ? 'passed' : 'needs_work';
+  const updated: SecurityWorkflow = {
+    ...workflow,
+    state: next,
+    updatedAt: at,
+    latestScan: workflowScan(input.result),
+    gate: input.gate,
+    verification: {
+      assurance: checks.length ? 'scan-and-checks' : 'scan-only',
+      checks,
+      verifiedAt: at,
+    },
+    history: [
+      ...workflow.history,
+      { state: next, at, note: passed ? 'Deterministic verification passed.' : 'Deterministic verification failed.' },
+    ],
+  };
+  await persistSecurityWorkflow(updated);
+  return updated;
+}
+
+export function getWorkflowFinding(workflow: SecurityWorkflow, fingerprint: string): SecurityFindingSnapshot | undefined {
+  return workflow.latestScan.findings.find(finding => finding.fingerprint === fingerprint)
+    ?? workflow.initialScan.findings.find(finding => finding.fingerprint === fingerprint);
+}
+
+/** Re-check the original blocked targets and reject newly introduced severe findings. */
+export function evaluateWorkflowVerificationGate(
+  workflow: SecurityWorkflow,
+  result: DvalinScanSuiteResult,
+): SecurityGateResult {
+  if (workflow.gate.threshold === 'none') {
+    return { passed: true, mode: workflow.gate.mode, threshold: 'none', considered: result.findings.length, blocking: [] };
+  }
+  const current = result.findings.map(snapshotFinding);
+  const originalTargets = new Set(workflow.gate.blocking.map(finding => finding.targetFingerprint));
+  const initialFingerprints = new Set(workflow.initialScan.findings.map(finding => finding.fingerprint));
+  const thresholdIndex = SECURITY_SEVERITIES.indexOf(workflow.gate.threshold);
+  const blocking = current.filter(finding => {
+    if (originalTargets.has(finding.targetFingerprint)) return true;
+    return !initialFingerprints.has(finding.fingerprint)
+      && SECURITY_SEVERITIES.indexOf(severityOfFinding(finding)) <= thresholdIndex;
+  });
+  return {
+    passed: blocking.length === 0,
+    mode: workflow.gate.mode,
+    threshold: workflow.gate.threshold,
+    considered: current.length,
+    blocking,
+  };
+}
+
+function workflowScan(result: DvalinScanSuiteResult): SecurityWorkflowScan {
+  return {
+    id: result.id,
+    completedAt: result.completedAt,
+    score: result.score,
+    grade: result.grade,
+    metrics: { ...result.metrics },
+    findings: result.findings.map(snapshotFinding),
+  };
+}
+
+async function persistSecurityWorkflow(workflow: SecurityWorkflow): Promise<void> {
+  const directory = workflowDirectory();
+  await mkdir(directory, { recursive: true });
+  const target = workflowPath(workflow.id);
+  const temporary = `${target}.${process.pid}.${randomUUID().slice(0, 8)}.tmp`;
+  await writeFile(temporary, `${JSON.stringify(workflow, null, 2)}\n`, { encoding: 'utf8', mode: 0o600 });
+  await rename(temporary, target);
+}
+
+function workflowDirectory(): string {
+  return path.join(dvalinHome(), 'security', 'workflows');
+}
+
+function workflowPath(id: string): string {
+  assertWorkflowId(id);
+  return path.join(workflowDirectory(), `${id}.json`);
+}
+
+function assertWorkflowId(id: string): void {
+  if (!/^security-[A-Za-z0-9-]+$/.test(id)) throw new UsageError(`Invalid security workflow id: ${id}`);
+}
+
+function isSecurityWorkflow(value: unknown): value is SecurityWorkflow {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const record = value as Record<string, unknown>;
+  return record.schemaVersion === SECURITY_SCHEMA_VERSION
+    && record.kind === 'dvalin-security-workflow'
+    && typeof record.id === 'string'
+    && typeof record.projectId === 'string'
+    && typeof record.root === 'string'
+    && SECURITY_WORKFLOW_STATES.includes(record.state as SecurityWorkflowState)
+    && Array.isArray(record.scanners)
+    && record.scanners.length > 0
+    && record.scanners.every(scanner => DVALIN_SCANNER_IDS.includes(scanner as DvalinScannerId))
+    && Array.isArray(record.history)
+    && record.history.every(entry => {
+      if (!entry || typeof entry !== 'object' || Array.isArray(entry)) return false;
+      const history = entry as Record<string, unknown>;
+      return SECURITY_WORKFLOW_STATES.includes(history.state as SecurityWorkflowState) && typeof history.at === 'string';
+    })
+    && isWorkflowScan(record.initialScan)
+    && isWorkflowScan(record.latestScan)
+    && isWorkflowGate(record.gate);
+}
+
+function isWorkflowScan(value: unknown): value is SecurityWorkflowScan {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const scan = value as Record<string, unknown>;
+  return typeof scan.id === 'string'
+    && typeof scan.completedAt === 'string'
+    && typeof scan.score === 'number'
+    && ['A', 'B', 'C', 'D', 'F'].includes(String(scan.grade))
+    && !!scan.metrics
+    && Array.isArray(scan.findings)
+    && scan.findings.every(finding => {
+      if (!finding || typeof finding !== 'object' || Array.isArray(finding)) return false;
+      const snapshot = finding as Record<string, unknown>;
+      return typeof snapshot.fingerprint === 'string'
+        && typeof snapshot.targetFingerprint === 'string'
+        && typeof snapshot.ruleId === 'string'
+        && typeof snapshot.path === 'string';
+    });
+}
+
+function isWorkflowGate(value: unknown): value is SecurityGateResult {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const gate = value as Record<string, unknown>;
+  return typeof gate.passed === 'boolean'
+    && (gate.mode === 'all' || gate.mode === 'new')
+    && ['critical', 'high', 'medium', 'low', 'none'].includes(String(gate.threshold))
+    && typeof gate.considered === 'number'
+    && Array.isArray(gate.blocking);
+}

--- a/src/server/routes/remediation.ts
+++ b/src/server/routes/remediation.ts
@@ -3,7 +3,13 @@ import { listRemediationCases, updateRemediationCase, upsertRemediationCases } f
 import { runLocalSecurityScan } from '../../remediation/localScan.js';
 import { parseSarifForRemediation } from '../../remediation/sarif.js';
 import { createRemediationWorktree } from '../../remediation/worktree.js';
-import { listDvalinScanners, runDvalinScanSuite, type DvalinScannerId } from '../../remediation/scannerSuite.js';
+import {
+  dvalinScannerInstallPlan,
+  installDvalinScanner,
+  listDvalinScanners,
+  runDvalinScanSuite,
+  type DvalinScannerId,
+} from '../../remediation/scannerSuite.js';
 import { allowWorkspaceRoot, resolveAllowedCwd } from '../security.js';
 import { consumeScannerWorkspaceGrant, issueScannerWorkspaceGrant } from '../scannerWorkspaceGrants.js';
 
@@ -11,6 +17,29 @@ export const remediationRouter = Router();
 
 remediationRouter.get('/scanners', async (_req, res) => {
   res.json(await listDvalinScanners());
+});
+
+remediationRouter.post('/scanners/install', async (req, res) => {
+  const body = req.body as { cwd?: string; scanner?: DvalinScannerId; command?: string; confirmed?: boolean };
+  const allowed = new Set<DvalinScannerId>(['semgrep', 'trivy', 'osv-scanner']);
+  if (!body.scanner || !allowed.has(body.scanner)) {
+    res.status(400).json({ error: 'scanner must be semgrep, trivy, or osv-scanner' });
+    return;
+  }
+  const plan = dvalinScannerInstallPlan(body.scanner);
+  if (!plan.command || body.confirmed !== true || body.command !== plan.command) {
+    res.status(400).json({ error: 'The fixed scanner install command must be explicitly confirmed.' });
+    return;
+  }
+  try {
+    const cwd = await resolveAllowedCwd(body.cwd);
+    await installDvalinScanner(cwd, body.scanner);
+    const scanner = (await listDvalinScanners()).find(candidate => candidate.id === body.scanner);
+    if (!scanner?.available) throw new Error(`${body.scanner} completed installation but is not available on PATH.`);
+    res.json(scanner);
+  } catch (error) {
+    res.status(400).json({ error: error instanceof Error ? error.message : 'Could not install scanner' });
+  }
 });
 
 remediationRouter.post('/suite/authorize', async (req, res) => {

--- a/tests/dvalinCommand.test.ts
+++ b/tests/dvalinCommand.test.ts
@@ -1,4 +1,8 @@
 import { describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { AuditSink } from '../src/audit/log.js';
 import {
   dvalinFailureThresholdMet,
   parseDvalinScannerIds,
@@ -10,6 +14,7 @@ import {
   evaluateVerificationGate,
   extractDraftPrUrl,
   VERIFICATION_MARKER,
+  verificationEvidenceFromAudit,
 } from '../src/remediation/automate.js';
 
 const result: DvalinScanSuiteResult = {
@@ -60,6 +65,26 @@ describe('dvalin command helpers', () => {
     });
     expect(failed.passed).toBe(false);
     expect(failed.reasons).toHaveLength(2);
+  });
+
+  it('uses recorded run_check exit codes as deterministic test evidence', () => {
+    const directory = mkdtempSync(path.join(tmpdir(), 'dvalin-check-evidence-'));
+    try {
+      const sink = new AuditSink('check-run', directory);
+      sink.append({ type: 'tool_call', tool: 'run_check', argsSummary: 'kind=test', status: 'ok', durationMs: 5 });
+      sink.append({ type: 'shell_exec', command: 'npm', exitCode: 0, sandbox: 'none' });
+      const evidence = verificationEvidenceFromAudit('check-run', directory);
+      expect(evidence).toEqual([{ kind: 'kind=test', command: 'npm', exitCode: 0, passed: true }]);
+      expect(evaluateVerificationGate({
+        originals: result.findings,
+        after: { ...result, findings: [], metrics: { critical: 0, high: 0, medium: 0, low: 0, files: 0, rules: 0 } },
+        agentOutput: 'Model text does not decide the gate.',
+        hasChanges: true,
+        checkEvidence: evidence,
+      }).passed).toBe(true);
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
   });
 
   it('does not classify untouched baseline findings outside the fix cap as new', () => {

--- a/tests/mcp/scanTool.test.ts
+++ b/tests/mcp/scanTool.test.ts
@@ -8,6 +8,7 @@ import type { DvalinScanSuiteResult } from '../../src/remediation/scannerSuite.j
 
 const cleanups: Array<() => void> = [];
 afterEach(() => {
+  delete process.env.DVALINCODE_HOME;
   while (cleanups.length) cleanups.pop()!();
 });
 
@@ -24,6 +25,10 @@ function call(id: number, args: Record<string, unknown> = {}): string {
     method: 'tools/call',
     params: { name: 'dvalin_scan', arguments: args },
   });
+}
+
+function callTool(id: number, name: string, args: Record<string, unknown> = {}): string {
+  return JSON.stringify({ jsonrpc: '2.0', id, method: 'tools/call', params: { name, arguments: args } });
 }
 
 function finding(overrides: Record<string, unknown> = {}) {
@@ -69,6 +74,7 @@ function scanResult(findings: ReturnType<typeof finding>[]): DvalinScanSuiteResu
 }
 
 async function serverWith(runScan: ReturnType<typeof vi.fn>, cwd = tempDir()) {
+  process.env.DVALINCODE_HOME = path.join(cwd, '.test-dvalin-home');
   return { cwd, server: await createMcpServer({ cwd, workspaces: [cwd], maxPermissionMode: 'auto' }, { runScan }) };
 }
 
@@ -89,11 +95,15 @@ describe('dvalin_scan', () => {
     const { server } = await serverWith(runScan);
     const body = payload(await server.handleLine(call(1)));
     expect(body.score).toBe(88);
+    expect(body.scanId).toBe('scan-1');
+    expect(body.workflowId).toMatch(/^security-/);
     expect(body.findings[0].ruleId).toBe('dvalin/eval');
     expect(body.findings[0].startLine).toBe(3);
     expect(body.findings[0].helpUri).toContain('cwe.mitre.org');
     expect(body.findings[0]).not.toHaveProperty('prompt');
     expect(body.findings[0]).not.toHaveProperty('snippet');
+    const response: any = await server.handleLine(call(2));
+    expect(response.result.structuredContent.scanId).toBe('scan-1');
   });
 
   it('includes the repair prompt only when asked', async () => {
@@ -154,5 +164,24 @@ describe('dvalin_scan', () => {
     const { cwd, server } = await serverWith(runScan);
     await server.handleLine(call(1));
     expect(runScan.mock.calls[0]![0]).toContain(path.basename(cwd));
+  });
+
+  it('lets an agent read one finding and request deterministic re-verification', async () => {
+    const runScan = vi.fn()
+      .mockResolvedValueOnce(scanResult([finding()]))
+      .mockResolvedValueOnce(scanResult([]));
+    const { server } = await serverWith(runScan);
+    const scanned = payload(await server.handleLine(call(1, { fail_on: 'high' })));
+
+    const findingResponse: any = await server.handleLine(callTool(2, 'dvalin_get_finding', {
+      workflow_id: scanned.workflowId,
+      fingerprint: scanned.findings[0].fingerprint,
+    }));
+    expect(findingResponse.result.structuredContent.finding.ruleId).toBe('dvalin/eval');
+
+    const verifyResponse: any = await server.handleLine(callTool(3, 'dvalin_verify_findings', {
+      workflow_id: scanned.workflowId,
+    }));
+    expect(verifyResponse.result.structuredContent).toMatchObject({ state: 'passed', assurance: 'scan-only' });
   });
 });

--- a/tests/mcp/server.test.ts
+++ b/tests/mcp/server.test.ts
@@ -37,20 +37,25 @@ describe('task-level stdio MCP server', () => {
 
     const listed = await server.handleLine(request(2, 'tools/list'));
     const tools = (listed as any).result.tools;
-    // dvalin_scan leads deliberately: it is the only tool a caller can use with
-    // no model, no credentials, and no configuration.
+    // The security workflow leads; general coding remains available as an
+    // implementation helper rather than the product's trust boundary.
     expect(tools.map((tool: any) => tool.name)).toEqual([
       'dvalin_scan', 'dvalin_run_task', 'dvalin_get_session', 'dvalin_get_evidence',
+      'dvalin_get_finding', 'dvalin_verify_findings', 'dvalin_list_scanners',
     ]);
     const readOnly = Object.fromEntries(
       tools.map((tool: any) => [tool.name, tool.annotations.readOnlyHint]),
     );
     expect(readOnly).toEqual({
-      dvalin_scan: true,
+      dvalin_scan: false,
       dvalin_run_task: false,
       dvalin_get_session: true,
       dvalin_get_evidence: true,
+      dvalin_get_finding: true,
+      dvalin_verify_findings: false,
+      dvalin_list_scanners: true,
     });
+    expect(tools.filter((tool: any) => tool.name !== 'dvalin_get_evidence').every((tool: any) => tool.outputSchema?.type === 'object')).toBe(true);
   });
 
   it('returns JSON-RPC parse and method-not-found errors', async () => {
@@ -167,20 +172,20 @@ describe('task-level stdio MCP server', () => {
 // implemented, and the client then relies on features that are absent.
 describe('protocol version negotiation', () => {
   it('returns each revision this server actually speaks', () => {
-    for (const version of ['2024-11-05', '2025-03-26', '2025-06-18']) {
+    for (const version of ['2024-11-05', '2025-03-26', '2025-06-18', '2025-11-25']) {
       expect(negotiateProtocolVersion(version)).toBe(version);
     }
   });
 
   it('falls back to its own latest for a version it does not speak', () => {
-    expect(negotiateProtocolVersion('2099-01-01')).toBe('2025-06-18');
-    expect(negotiateProtocolVersion('1.0.0')).toBe('2025-06-18');
+    expect(negotiateProtocolVersion('2099-01-01')).toBe('2025-11-25');
+    expect(negotiateProtocolVersion('1.0.0')).toBe('2025-11-25');
   });
 
   it('falls back when the client omits or malforms the field', () => {
-    expect(negotiateProtocolVersion(undefined)).toBe('2025-06-18');
-    expect(negotiateProtocolVersion(null)).toBe('2025-06-18');
-    expect(negotiateProtocolVersion(20241105)).toBe('2025-06-18');
+    expect(negotiateProtocolVersion(undefined)).toBe('2025-11-25');
+    expect(negotiateProtocolVersion(null)).toBe('2025-11-25');
+    expect(negotiateProtocolVersion(20241105)).toBe('2025-11-25');
   });
 
   it('never echoes an unsupported version through initialize', async () => {
@@ -189,6 +194,6 @@ describe('protocol version negotiation', () => {
     const response = await server.handleLine(
       request(1, 'initialize', { protocolVersion: '2099-01-01' }),
     );
-    expect((response as any).result.protocolVersion).toBe('2025-06-18');
+    expect((response as any).result.protocolVersion).toBe('2025-11-25');
   });
 });

--- a/tests/remediationScannerSuite.test.ts
+++ b/tests/remediationScannerSuite.test.ts
@@ -2,7 +2,7 @@ import { chmod, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { listDvalinScanners, runDvalinScanSuite } from '../src/remediation/scannerSuite.js';
+import { dvalinScannerInstallPlan, listDvalinScanners, runDvalinScanSuite } from '../src/remediation/scannerSuite.js';
 import { consumeScannerWorkspaceGrant, issueScannerWorkspaceGrant } from '../src/server/scannerWorkspaceGrants.js';
 
 describe.sequential('Dvalin scanner suite', () => {
@@ -47,6 +47,13 @@ describe.sequential('Dvalin scanner suite', () => {
     expect(result.scanners).toHaveLength(3);
     expect(result.scanners.every(scanner => scanner.status === 'missing')).toBe(true);
     expect(result.findings).toEqual([]);
+  });
+
+  it('returns a reviewable install plan without executing it', () => {
+    expect(dvalinScannerInstallPlan('builtin')).toMatchObject({ supported: true, reason: expect.stringContaining('no installation') });
+    expect(dvalinScannerInstallPlan('semgrep')).toEqual({
+      scanner: 'semgrep', supported: true, command: 'python3 -m pip install semgrep',
+    });
   });
 
   it('uses an explicit Semgrep community ruleset with metrics disabled', async () => {

--- a/tests/securityConfig.test.ts
+++ b/tests/securityConfig.test.ts
@@ -1,0 +1,25 @@
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { loadSecurityConfig, resolveSecurityPath, writeInitialSecurityConfig } from '../src/security/config.js';
+
+const cleanups: string[] = [];
+afterEach(async () => {
+  for (const directory of cleanups.splice(0)) await rm(directory, { recursive: true, force: true });
+});
+
+describe('security configuration', () => {
+  it('initializes a strict new-findings policy while unconfigured projects remain non-blocking', async () => {
+    const root = await mkdtemp(path.join(tmpdir(), 'dvalin-security-config-'));
+    cleanups.push(root);
+    expect((await loadSecurityConfig(root)).config.gate).toEqual({ severity: 'none', mode: 'all' });
+    const file = await writeInitialSecurityConfig(root);
+    expect(JSON.parse(await readFile(file, 'utf8'))).toMatchObject({ version: 1, scanners: ['builtin'], gate: { severity: 'high', mode: 'new' } });
+    expect((await loadSecurityConfig(root)).config.gate).toEqual({ severity: 'high', mode: 'new' });
+  });
+
+  it('rejects artifact paths that escape the workspace', () => {
+    expect(() => resolveSecurityPath('/repo', '../outside.json')).toThrow('must stay inside');
+  });
+});

--- a/tests/securityContracts.test.ts
+++ b/tests/securityContracts.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import type { DvalinScanSuiteResult } from '../src/remediation/scannerSuite.js';
+import { compareWithBaseline, createBaseline, evaluateSecurityGate, findingFingerprint } from '../src/security/contracts.js';
+
+function result(findings: DvalinScanSuiteResult['findings']): DvalinScanSuiteResult {
+  return {
+    id: 'scan-test', source: 'Dvalin Security Suite', startedAt: '2026-01-01T00:00:00Z', completedAt: '2026-01-01T00:00:01Z',
+    score: 88, grade: 'B', totalResults: findings.length, skippedResults: 0,
+    metrics: { critical: 0, high: findings.length, medium: 0, low: 0, files: findings.length, rules: findings.length },
+    scanners: [{ id: 'builtin', name: 'Built-in', category: 'secrets', description: '', available: true, homepage: '', status: 'completed', findings: findings.length, durationMs: 1 }],
+    findings,
+  };
+}
+
+const finding: DvalinScanSuiteResult['findings'][number] = {
+  id: 'one', source: 'Dvalin Local Scan', ruleId: 'dvalin/secret', ruleName: 'Secret', severity: 'error',
+  securitySeverity: '8.0', message: 'Secret found', path: 'src/app.ts', startLine: 4, tags: [], prompt: 'Fix it',
+};
+
+describe('versioned security contracts', () => {
+  it('creates stable fingerprints and new/existing/resolved deltas', () => {
+    expect(findingFingerprint(finding)).toBe(findingFingerprint({ ...finding, path: './src/app.ts' }));
+    const baseline = createBaseline(result([finding]));
+    const added = { ...finding, id: 'two', ruleId: 'dvalin/eval', message: 'Eval found', startLine: 10 };
+    const delta = compareWithBaseline(result([finding, added]), baseline);
+    expect(delta.existing).toHaveLength(1);
+    expect(delta.new).toHaveLength(1);
+    expect(delta.resolved).toHaveLength(0);
+  });
+
+  it('blocks only new findings when configured as a new-only gate', () => {
+    const baseline = createBaseline(result([finding]));
+    const added = { ...finding, id: 'two', path: 'src/new.ts' };
+    const current = result([finding, added]);
+    const delta = compareWithBaseline(current, baseline);
+    const gate = evaluateSecurityGate({ result: current, threshold: 'high', mode: 'new', delta });
+    expect(gate.passed).toBe(false);
+    expect(gate.considered).toBe(1);
+    expect(gate.blocking[0]?.path).toBe('src/new.ts');
+  });
+});

--- a/tests/securityWorkflow.test.ts
+++ b/tests/securityWorkflow.test.ts
@@ -1,0 +1,53 @@
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { DvalinScanSuiteResult } from '../src/remediation/scannerSuite.js';
+import { evaluateSecurityGate } from '../src/security/contracts.js';
+import { createSecurityWorkflow, evaluateWorkflowVerificationGate, loadSecurityWorkflow, verifySecurityWorkflow } from '../src/security/workflow.js';
+
+let home: string;
+let originalHome: string | undefined;
+
+beforeEach(async () => {
+  home = await mkdtemp(path.join(tmpdir(), 'dvalin-security-workflow-'));
+  originalHome = process.env.DVALINCODE_HOME;
+  process.env.DVALINCODE_HOME = home;
+});
+
+afterEach(async () => {
+  if (originalHome === undefined) delete process.env.DVALINCODE_HOME;
+  else process.env.DVALINCODE_HOME = originalHome;
+  await rm(home, { recursive: true, force: true });
+});
+
+const finding: DvalinScanSuiteResult['findings'][number] = {
+  id: 'one', source: 'Dvalin Local Scan', ruleId: 'dvalin/eval', ruleName: 'Eval', severity: 'error', securitySeverity: '8.0',
+  message: 'Eval found', path: 'src/app.ts', startLine: 4, tags: [], prompt: 'Fix it',
+};
+
+function result(findings = [finding]): DvalinScanSuiteResult {
+  return {
+    id: `scan-${findings.length}`, source: 'Dvalin Security Suite', startedAt: '2026-01-01T00:00:00Z', completedAt: '2026-01-01T00:00:01Z',
+    score: findings.length ? 88 : 100, grade: findings.length ? 'B' : 'A', totalResults: findings.length, skippedResults: 0,
+    metrics: { critical: 0, high: findings.length, medium: 0, low: 0, files: findings.length, rules: findings.length },
+    scanners: [{ id: 'builtin', name: 'Built-in', category: 'secrets', description: '', available: true, homepage: '', status: 'completed', findings: findings.length, durationMs: 1 }],
+    findings,
+  };
+}
+
+describe.sequential('persistent security workflow', () => {
+  it('resumes by id and passes only after a deterministic re-scan clears the target', async () => {
+    const initial = result();
+    const gate = evaluateSecurityGate({ result: initial, threshold: 'high', mode: 'all' });
+    const created = await createSecurityWorkflow({ root: home, result: initial, gate });
+    expect(created.state).toBe('needs_work');
+    expect((await loadSecurityWorkflow(created.id)).initialScan.findings).toHaveLength(1);
+
+    const after = result([]);
+    const verificationGate = evaluateWorkflowVerificationGate(created, after);
+    const verified = await verifySecurityWorkflow({ workflow: created, result: after, gate: verificationGate });
+    expect(verified.state).toBe('passed');
+    expect(verified.verification?.assurance).toBe('scan-only');
+  });
+});

--- a/web/src/components/DvalinWorkspace.tsx
+++ b/web/src/components/DvalinWorkspace.tsx
@@ -9,6 +9,7 @@ import {
   createRemediationWorktree,
   fetchDvalinScanners,
   importSarifReport,
+  installDvalinScanner,
   runDvalinSecuritySuite,
   saveRemediationCases,
   updateRemediationCase,
@@ -206,15 +207,23 @@ export function DvalinWorkspace({ cwd, connected, sending, modelConfigured, onSe
     }
   };
 
-  const requestScannerInstall = (scanner: DvalinScanner) => {
-    if (!scanner.installCommand) return;
+  const requestScannerInstall = async (scanner: DvalinScanner) => {
+    if (!cwd || !scanner.installCommand) return;
+    const confirmed = window.confirm(`Install ${scanner.name} by running this fixed command?\n\n${scanner.installCommand}`);
+    if (!confirmed) return;
     setInstallRequested(scanner.id);
-    onSend([
-      `Install ${scanner.name} so Dvalin can expand its ${scanner.category} coverage.`,
-      `Use this project-provided install command: ${scanner.installCommand}`,
-      'First confirm the command is compatible with this operating system and package manager. If it is not, use the equivalent official installation method and explain the substitution.',
-      'After installation, verify the executable and version are available on PATH. Do not change project source code or start a security scan in this step.',
-    ].join('\n'));
+    setScannerBusy(true);
+    setError(null);
+    try {
+      const installed = await installDvalinScanner(cwd, scanner.id, scanner.installCommand);
+      setScanners(current => current.map(candidate => candidate.id === installed.id ? installed : candidate));
+      setSelectedScanners(previous => new Set(previous).add(installed.id));
+    } catch (error) {
+      setError(error instanceof Error ? error.message : `Could not install ${scanner.name}`);
+    } finally {
+      setInstallRequested(null);
+      setScannerBusy(false);
+    }
   };
 
   const importSarif = async (file: File) => {
@@ -355,7 +364,7 @@ export function DvalinWorkspace({ cwd, connected, sending, modelConfigured, onSe
                       <div className="flex items-center gap-1.5"><span className="truncate text-[11px] font-medium">{scanner.name}</span>{scanner.id === 'builtin' && <span className="rounded bg-emerald-500/10 px-1 py-0.5 text-[7px] font-semibold uppercase text-success-fg">core</span>}</div>
                       <div className="mt-0.5 truncate text-[9px] text-muted-fg">{scanner.description}</div>
                     </div>
-                    {scanner.available ? <span className={`text-[8px] font-semibold uppercase ${run?.status === 'error' ? 'text-danger-fg' : selected ? 'text-success-fg' : 'text-muted-fg'}`}>{run?.status === 'error' ? 'error' : selected ? run?.status ?? 'enabled' : 'off'}</span> : scanner.installCommand ? <button onClick={() => requestScannerInstall(scanner)} disabled={sending || !modelConfigured} className="group flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-lg border border-amber-500/30 bg-amber-500/10 text-warn-fg hover:bg-amber-500/20 disabled:opacity-40" title={modelConfigured ? `Install ${scanner.name}: ${scanner.installCommand}` : `Configure a model to run: ${scanner.installCommand}`} aria-label={`Install ${scanner.name}`}><Download size={12} className={installRequested === scanner.id && sending ? 'animate-bounce' : ''} /></button> : null}
+                    {scanner.available ? <span className={`text-[8px] font-semibold uppercase ${run?.status === 'error' ? 'text-danger-fg' : selected ? 'text-success-fg' : 'text-muted-fg'}`}>{run?.status === 'error' ? 'error' : selected ? run?.status ?? 'enabled' : 'off'}</span> : scanner.installCommand ? <button onClick={() => void requestScannerInstall(scanner)} disabled={scannerBusy} className="group flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-lg border border-amber-500/30 bg-amber-500/10 text-warn-fg hover:bg-amber-500/20 disabled:opacity-40" title={`Install ${scanner.name}: ${scanner.installCommand}`} aria-label={`Install ${scanner.name}`}><Download size={12} className={installRequested === scanner.id ? 'animate-bounce' : ''} /></button> : null}
                   </div>
                   {!scanner.available && scanner.installCommand && <div className="mt-2 flex items-center gap-1.5 border-t border-border/70 pt-2 text-[8px] text-muted-fg"><Terminal size={9} className="flex-shrink-0" /><code className="truncate">{scanner.installCommand}</code></div>}
                 </div>;

--- a/web/src/lib/client.ts
+++ b/web/src/lib/client.ts
@@ -288,6 +288,23 @@ export async function fetchDvalinScanners(): Promise<DvalinScanner[]> {
   return data as DvalinScanner[];
 }
 
+export async function installDvalinScanner(
+  cwd: string,
+  scanner: DvalinScannerId,
+  command: string,
+): Promise<DvalinScanner> {
+  const res = await fetch('/api/remediation/scanners/install', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ cwd, scanner, command, confirmed: true }),
+  });
+  if (!res.ok) {
+    const err = (await res.json().catch(() => ({}))) as { error?: string };
+    throw new Error(err.error ?? `Could not install scanner (HTTP ${res.status})`);
+  }
+  return res.json() as Promise<DvalinScanner>;
+}
+
 export async function runDvalinSecuritySuite(cwd: string, scanners: DvalinScannerId[]): Promise<DvalinScanResult> {
   const authorization = await fetch('/api/remediation/suite/authorize', {
     method: 'POST',


### PR DESCRIPTION
## Summary

- reposition Dvalin as an independent security verifier for human- and agent-written code: **Agent writes. Dvalin verifies.**
- add a versioned security contract with repository policy, baselines, suppressions, deterministic gates, and a persistent workflow state machine outside the generic Agent Loop
- add the focused `dvalin` CLI plus compatibility commands for scan, init, baseline, verify, doctor, and scanner management
- upgrade MCP to structured security workflows with finding lookup, verification, and scanner discovery tools
- make the Dvalin UI install optional scanners through an explicitly confirmed, fixed command without requiring a model
- use recorded `run_check` exit codes and an independent re-scan for automated remediation verification
- add Agent/MCP/GitLab integration templates and update English and Chinese documentation
- update vulnerable production transitive dependencies permitted by existing version ranges

## Why

Dvalin needs a stable trust boundary that works whether code is produced by a human, DvalinCode, or an external coding agent. Security status must come from deterministic scanner/check evidence rather than model prose, while the bundled coding agent remains an optional remediation executor.

## Validation

- `npm run check` — 365/365 tests passed across 55 files
- `npm run build`
- `npm run web:build`
- `npm run site:build`
- `npm audit --omit=dev --audit-level=high` — 0 production vulnerabilities
- CLI smoke tests against this repository and a freshly initialized temporary workspace

## Notes

A clean scan remains a triage signal rather than proof that a program is secure. Publication remains explicit and Dvalin never auto-merges a repair.
