### PR TITLE
Add Codex Security SARIF interoperability and competitive strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 <p align="center">
   <a href="https://github.com/arthurpanhku/dvalincode/releases/latest"><img src="https://img.shields.io/github/v/release/arthurpanhku/dvalincode?style=for-the-badge&color=818cf8&label=Release" alt="Release"></a>
   <a href="https://github.com/arthurpanhku/dvalincode/releases"><img src="https://img.shields.io/github/downloads/arthurpanhku/dvalincode/total?style=for-the-badge&color=blue&label=Downloads" alt="Downloads"></a>
-  <a href="#-tests"><img src="https://img.shields.io/badge/Tests-365%20%2F%20365%20%E2%9C%93-success?style=for-the-badge" alt="Tests"></a>
+  <a href="#-tests"><img src="https://img.shields.io/badge/Tests-372%20%2F%20372%20%E2%9C%93-success?style=for-the-badge" alt="Tests"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-green?style=for-the-badge" alt="License"></a>
   <a href="https://scorecard.dev/viewer/?uri=github.com/arthurpanhku/dvalincode"><img src="https://api.scorecard.dev/projects/github.com/arthurpanhku/dvalincode/badge" alt="OpenSSF Scorecard"></a>
   <a href="#-quick-install"><img src="https://img.shields.io/badge/Platforms-macOS%20·%20Windows%20·%20Linux-blue?style=for-the-badge" alt="Platforms"></a>
@@ -18,16 +18,27 @@
 </p>
 
 <p align="center">
-  <b>Security verification for code written by humans and AI agents.</b><br>
-  <b>Agent writes. Dvalin verifies.</b>
+  <b>Open security engineering for code written by humans and AI agents.</b><br>
+  <b>Discover. Repair. Verify.</b>
 </p>
 
 Dvalin is the independent security runtime between code generation and merge.
-Humans, coding agents, and CI call the same versioned scan contract; Dvalin
-normalizes scanner evidence, applies a baseline-aware gate, persists the
-security workflow, and independently verifies a repair before publication.
-Its built-in coding capability is a remediation executor—not the trust boundary
-and not an attempt to compete with every general-purpose coding agent.
+Humans, coding agents, and CI call the same versioned contract for discovery,
+remediation, and verification; Dvalin normalizes scanner evidence, applies a
+baseline-aware gate, persists the security workflow, and independently verifies
+a repair before publication. Its built-in coding capability is a remediation
+executor—not the trust boundary and not an attempt to compete with every
+general-purpose coding agent.
+
+Dvalin can run independently, compete in overlapping application-security
+workflows, or interoperate with specialist systems such as Codex Security.
+Codex Security's portable SARIF export can become local Dvalin remediation cases
+and pass through the same release gate as every other human or agent. Dvalin
+differentiates through a no-account deterministic baseline, an open multi-engine
+scanner fleet, agent-neutral interfaces, local operation, and policy-bound audit
+evidence. We adopt strong workflow ideas where they improve user outcomes while
+keeping both products optional. See the
+[security-agent strategy](docs/SECURITY-AGENT-STRATEGY.md).
 
 ---
 
@@ -101,6 +112,28 @@ evidence tools.
 Verified end to end with both Claude Code and Codex driving a real tool call
 against the published package, not only completing a handshake.
 [Agent integrations →](integrations/)
+
+### Or interoperate with Codex Security
+
+[Codex Security](https://github.com/openai/codex-security) can export a completed,
+sealed scan as SARIF. Import that portable projection without coupling Dvalin to
+Codex Security's private state directory:
+
+```sh
+DVALIN_CODEX_SCAN_DIR=/tmp/codex-security-results
+npx @openai/codex-security scan . --output-dir "$DVALIN_CODEX_SCAN_DIR"
+npx @openai/codex-security export "$DVALIN_CODEX_SCAN_DIR" \
+  --export-format sarif --source-root "$PWD" --output /tmp/codex-security.sarif
+
+dvalin import /tmp/codex-security.sarif .
+dvalin scan . --fail-on high
+```
+
+The import creates stable Dvalin remediation cases; `--no-persist` validates the
+handoff without changing the backlog. Keep Codex Security's original manifest,
+findings, and coverage artifacts together—Dvalin imports the SARIF finding
+projection but does not rewrite its sealed bundle or reinterpret its coverage.
+[Integration guide →](integrations/codex-security/)
 
 ### Then let it fix what it found
 
@@ -701,7 +734,7 @@ RESTORE → COMPACT → COMMAND → BUILD → RUN → SAVE → RESPOND → DONE
 npm test
 ```
 
-**365 tests · 55 files · all green.**
+**372 tests · 56 files · all green.**
 
 ---
 
@@ -822,7 +855,7 @@ Contributions welcome. The codebase is intentionally small and surgical — see 
 ```sh
 git clone https://github.com/arthurpanhku/dvalincode
 cd dvalincode && npm install
-npm test                # 365/365 ✅
+npm test                # 372/372 ✅
 npm run typecheck
 ```
 
@@ -858,6 +891,10 @@ ecosystem:
   similar coding agents clarified user expectations around terminal agents,
   plan/build modes, permission prompts, project-local context, sandboxing,
   session lifecycle, MCP integration, and diff-first editing workflows.
+- [OpenAI Codex Security](https://github.com/openai/codex-security) and its
+  public documentation informed Dvalin's specialist security-agent research and
+  portable SARIF handoff. Dvalin remains an independent, competing security
+  runtime.
 - The `AGENTS.md` project-instruction convention, common in coding-agent tools,
   informed DvalinCode's project-local instruction loading behavior.
 - CodeQL, GitHub Code Scanning, Semgrep, SARIF, OpenSSF Scorecard, and ISO/IEC
@@ -875,31 +912,20 @@ Full source references: [docs/REFERENCES.md](docs/REFERENCES.md)
 
 ---
 
-## ⭐ Star Growth
-
-<p align="center">
-  <a href="https://www.star-history.com/#arthurpanhku/dvalincode&Date">
-    <picture>
-      <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=arthurpanhku/dvalincode&type=Date&theme=dark">
-      <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=arthurpanhku/dvalincode&type=Date">
-      <img alt="DvalinCode Star History Chart" src="https://api.star-history.com/svg?repos=arthurpanhku/dvalincode&type=Date">
-    </picture>
-  </a>
-</p>
-
----
-
 ## 💛 Thanks to Our Contributors
 
 <p align="center">
   Every issue, idea, documentation improvement, test, and code contribution helps make DvalinCode better.
 </p>
 
-<p align="center">
-  <a href="https://github.com/arthurpanhku/dvalincode/graphs/contributors">
-    <img src="https://contrib.rocks/image?repo=arthurpanhku/dvalincode" alt="DvalinCode contributors">
-  </a>
-</p>
+| Contributor | GitHub profile |
+| --- | --- |
+| Arthur Pan | [@arthurpanhku](https://github.com/arthurpanhku) |
+| Shivas | [@shivasb42](https://github.com/shivasb42) |
+| Aditya | [@adity982](https://github.com/adity982) |
+| badhope | [@weed33834](https://github.com/weed33834) |
+
+See the [complete contribution history](https://github.com/arthurpanhku/dvalincode/graphs/contributors), including automated dependency and maintenance updates.
 
 <p align="center">
   <sub>Want to join them? Read the <a href="CONTRIBUTING.md">contribution guide</a> and send your first pull request.</sub>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -9,7 +9,7 @@
 <p align="center">
   <a href="https://github.com/arthurpanhku/dvalincode/releases/latest"><img src="https://img.shields.io/github/v/release/arthurpanhku/dvalincode?style=for-the-badge&color=818cf8&label=Release" alt="Release"></a>
   <a href="https://github.com/arthurpanhku/dvalincode/releases"><img src="https://img.shields.io/github/downloads/arthurpanhku/dvalincode/total?style=for-the-badge&color=blue&label=Downloads" alt="Downloads"></a>
-  <a href="#-测试"><img src="https://img.shields.io/badge/Tests-365%20%2F%20365%20%E2%9C%93-success?style=for-the-badge" alt="Tests"></a>
+  <a href="#-测试"><img src="https://img.shields.io/badge/Tests-372%20%2F%20372%20%E2%9C%93-success?style=for-the-badge" alt="Tests"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-green?style=for-the-badge" alt="License"></a>
   <a href="https://scorecard.dev/viewer/?uri=github.com/arthurpanhku/dvalincode"><img src="https://api.scorecard.dev/projects/github.com/arthurpanhku/dvalincode/badge" alt="OpenSSF Scorecard"></a>
   <a href="#-一行安装"><img src="https://img.shields.io/badge/Platforms-macOS%20·%20Windows%20·%20Linux-blue?style=for-the-badge" alt="Platforms"></a>
@@ -18,14 +18,21 @@
 </p>
 
 <p align="center">
-  <b>为人类和 AI Agent 编写的代码提供独立安全验证。</b><br>
-  <b>Agent writes. Dvalin verifies.</b>
+  <b>为人类和 AI Agent 编写的代码提供开放安全工程能力。</b><br>
+  <b>发现。修复。验证。</b>
 </p>
 
 Dvalin 是放在“代码生成”和“允许合并”之间的独立安全运行时。人类开发者、Coding
-Agent 和 CI 调用同一套版本化扫描协议；Dvalin 统一扫描证据、执行基线策略、持久化安全
-工作流，并在发布前独立验证修复。内置 Coding 能力只负责可靠地执行聚焦修复，不是安全
-结论的信任边界，也不以打败所有通用 Coding Agent 为目标。
+Agent 和 CI 调用同一套版本化协议完成发现、修复与验证；Dvalin 统一扫描证据、执行
+基线策略、持久化安全工作流，并在发布前独立验证修复。内置 Coding 能力只负责可靠地
+执行聚焦修复，不是安全结论的信任边界，也不以打败所有通用 Coding Agent 为目标。
+
+Dvalin 既可以独立运行、在重叠的应用安全工作流中参与竞争，也可以和 Codex Security
+等专业系统互操作。Codex Security 导出的可移植 SARIF 可以生成本地 Dvalin
+remediation case，并进入与其他人类或 Agent 一致的发布门禁。Dvalin 的差异化包括：
+无需账号的确定性基础扫描、开放的多引擎 scanner fleet、Agent 中立接口、本地运行，
+以及受策略约束的审计证据。我们会吸收能改善用户结果的优秀工作流设计，但不会让任一
+产品成为另一方的必选依赖。详见[安全 Agent 战略](docs/SECURITY-AGENT-STRATEGY.md)。
 
 ---
 
@@ -93,6 +100,26 @@ workflow。Agent 可以用 fingerprint 精确读取单条发现，再通过 `dva
 
 Claude Code 与 Codex 均已用已发布的包做过端到端验证 —— 是真实发起工具调用，而不只是握手成功。
 [Agent 集成 →](integrations/)
+
+### 或者和 Codex Security 互操作
+
+[Codex Security](https://github.com/openai/codex-security) 可以把已完成且密封的扫描
+导出为 SARIF。Dvalin 只导入这个可移植投影，不耦合 Codex Security 的私有状态目录：
+
+```sh
+DVALIN_CODEX_SCAN_DIR=/tmp/codex-security-results
+npx @openai/codex-security scan . --output-dir "$DVALIN_CODEX_SCAN_DIR"
+npx @openai/codex-security export "$DVALIN_CODEX_SCAN_DIR" \
+  --export-format sarif --source-root "$PWD" --output /tmp/codex-security.sarif
+
+dvalin import /tmp/codex-security.sarif .
+dvalin scan . --fail-on high
+```
+
+导入会生成稳定的 Dvalin remediation case；`--no-persist` 可以只校验交接件而不修改
+backlog。请继续保存 Codex Security 原始的 manifest、findings 和 coverage 工件——Dvalin
+只导入 SARIF finding 投影，不会改写其密封 bundle，也不会重新解释其覆盖率。
+[集成指南 →](integrations/codex-security/)
 
 ### 然后让它把找到的问题修掉
 
@@ -618,7 +645,7 @@ RESTORE → COMPACT → COMMAND → BUILD → RUN → SAVE → RESPOND → DONE
 npm test
 ```
 
-**365 个测试 · 55 个文件 · 全部通过。**
+**372 个测试 · 56 个文件 · 全部通过。**
 
 ---
 
@@ -745,7 +772,7 @@ Linux 与 macOS 命令通过 <code>/bin/sh</code> 执行；Windows 命令通过�
 ```sh
 git clone https://github.com/arthurpanhku/dvalincode
 cd dvalincode && npm install
-npm test                # 365/365 ✅
+npm test                # 372/372 ✅
 npm run typecheck
 ```
 
@@ -775,6 +802,9 @@ agentic coding 生态；DvalinCode 的产品方向和架构设计也受到了这
 - OpenAI Codex / Codex CLI、Claude Code、Aider、opencode、Cursor、Cline
   等编码 Agent 帮助明确了用户对终端 Agent、plan/build 模式、权限提示、
   项目本地上下文、沙箱、session lifecycle、MCP 集成和 diff-first 编辑工作流的期待。
+- [OpenAI Codex Security](https://github.com/openai/codex-security) 及其公开文档为
+  Dvalin 的专业安全 Agent 研究和可移植 SARIF 交接提供了参考；Dvalin 仍是独立且参与
+  竞争的安全运行时。
 - `AGENTS.md` 项目指令约定在编码 Agent 工具中较常见，也影响了 DvalinCode
   加载项目本地指令的行为设计。
 - CodeQL、GitHub Code Scanning、Semgrep、SARIF、OpenSSF Scorecard 与
@@ -790,31 +820,20 @@ prompt、UI 文案、工具 schema、模块布局和产品实现均为原创；�
 
 ---
 
-## ⭐ Star 增长趋势
-
-<p align="center">
-  <a href="https://www.star-history.com/#arthurpanhku/dvalincode&Date">
-    <picture>
-      <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=arthurpanhku/dvalincode&type=Date&theme=dark">
-      <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=arthurpanhku/dvalincode&type=Date">
-      <img alt="DvalinCode Star 增长趋势图" src="https://api.star-history.com/svg?repos=arthurpanhku/dvalincode&type=Date">
-    </picture>
-  </a>
-</p>
-
----
-
 ## 💛 感谢每一位贡献者
 
 <p align="center">
   每一个 Issue、想法、文档改进、测试和代码贡献，都在帮助 DvalinCode 变得更好。
 </p>
 
-<p align="center">
-  <a href="https://github.com/arthurpanhku/dvalincode/graphs/contributors">
-    <img src="https://contrib.rocks/image?repo=arthurpanhku/dvalincode" alt="DvalinCode 贡献者">
-  </a>
-</p>
+| 贡献者 | GitHub 主页 |
+| --- | --- |
+| Arthur Pan | [@arthurpanhku](https://github.com/arthurpanhku) |
+| Shivas | [@shivasb42](https://github.com/shivasb42) |
+| Aditya | [@adity982](https://github.com/adity982) |
+| badhope | [@weed33834](https://github.com/weed33834) |
+
+查看[完整贡献记录](https://github.com/arthurpanhku/dvalincode/graphs/contributors)，其中也包含自动依赖更新和维护记录。
 
 <p align="center">
   <sub>也想加入？阅读<a href="CONTRIBUTING.md">贡献指南</a>，提交你的第一个 Pull Request。</sub>

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -8,7 +8,7 @@ const HOSTNAME = 'https://dvalincode.dev'
 export default defineConfig({
   title: 'DvalinCode',
   description:
-    'Approvable, local-first AI coding agent for regulated teams — policy-bound, audit-ready, works with any OpenAI-compatible model.',
+    'Open, local-first security engineering for human and agent-written code — discover, remediate, verify, and gate with policy-bound evidence.',
 
   // Internal working notes that live in docs/ but are not public documentation.
   srcExclude: [
@@ -34,13 +34,13 @@ export default defineConfig({
     ['meta', { name: 'theme-color', content: '#818cf8' }],
     ['meta', { property: 'og:type', content: 'website' }],
     ['meta', { property: 'og:site_name', content: 'DvalinCode' }],
-    ['meta', { property: 'og:title', content: 'DvalinCode — the approvable coding agent for regulated teams' }],
+    ['meta', { property: 'og:title', content: 'DvalinCode — open security engineering for human and agent-written code' }],
     [
       'meta',
       {
         property: 'og:description',
         content:
-          'Policy-bound, audit-ready, local-first AI coding agent. Any OpenAI-compatible model. Controllable · transparent · auditable.',
+          'Discover, remediate, verify, and gate human- or agent-written code with a local, policy-bound, audit-ready security runtime.',
       },
     ],
     ['meta', { property: 'og:image', content: `${HOSTNAME}/hero.png` }],
@@ -66,7 +66,7 @@ export default defineConfig({
       lang: 'zh-CN',
       link: '/zh/',
       description:
-        '可被审批的本地优先 AI 编码代理 — 策略约束、审计就绪，支持任何 OpenAI 兼容模型。',
+        '面向人类与 Agent 代码的开放、本地优先安全工程运行时 — 发现、修复、验证与门禁。',
     },
   },
 
@@ -89,6 +89,7 @@ export default defineConfig({
         items: [
           { text: 'Org Policy Reference', link: '/POLICY-REFERENCE' },
           { text: 'Secure Remediation', link: '/SECURE-REMEDIATION' },
+          { text: 'Security Agent Strategy', link: '/SECURITY-AGENT-STRATEGY' },
           { text: 'Skills', link: '/SKILLS' },
           { text: 'Governed MCP', link: '/GOVERNED-MCP' },
         ],

--- a/docs/DVALIN.md
+++ b/docs/DVALIN.md
@@ -53,6 +53,22 @@ unchanged finding is not re-alerted on every run. It composes with `--json` and
 with `--fix`, in which case it reflects the post-remediation state rather than
 the baseline.
 
+### Import external security evidence
+
+Codex Security and other compatible security tools can hand findings to Dvalin
+through SARIF 2.1 without becoming part of the trusted Dvalin scanner process:
+
+```bash
+dvalin import /path/to/codex-security.sarif .
+dvalin import /path/to/codex-security.sarif . --json --no-persist
+```
+
+The first form creates or updates stable local remediation cases. The second
+only validates and normalizes the report. Imported findings remain external
+evidence: they do not pass the Dvalin gate, do not modify the source tool's
+sealed artifacts, and do not transfer that tool's coverage assessment. See the
+[Codex Security integration guide](https://github.com/arthurpanhku/dvalincode/tree/main/integrations/codex-security).
+
 ## GitHub Action
 
 The repository publishes itself as a composite action, so a scan needs nothing

--- a/docs/REFERENCES.md
+++ b/docs/REFERENCES.md
@@ -107,6 +107,7 @@ security tooling and governance standards:
 
 | Source | Influence |
 |---|---|
+| [OpenAI Codex Security](https://github.com/openai/codex-security) and its [official documentation](https://learn.chatgpt.com/docs/security) | Competitive product research into specialist security-agent workflows plus the documented SARIF handoff boundary; Dvalin consumes portable exports without copying implementation or claiming their coverage |
 | CodeQL and GitHub Code Scanning | SARIF-based vulnerability intake and CI/code-scanning posture |
 | Semgrep | Lightweight local/static scanning workflow inspiration |
 | SARIF | Interchange format for security findings |

--- a/docs/SECURE-REMEDIATION.md
+++ b/docs/SECURE-REMEDIATION.md
@@ -8,8 +8,8 @@ branch is published.
 ## Workflow
 
 1. Select a project and run the Dvalin scanner suite, or import a SARIF 2.1
-   report from CodeQL, GitHub Code Scanning, Semgrep, or another compatible
-   scanner.
+   report from Codex Security, CodeQL, GitHub Code Scanning, Semgrep, or another
+   compatible source.
 2. Dvalin normalizes findings into rule, severity, location, tags, source
    context, and stable remediation cases under `~/.dvalincode/remediation/`.
 3. Review and select candidates. Findings remain hypotheses until the agent
@@ -24,4 +24,6 @@ branch is published.
    never merges it automatically.
 
 See [DVALIN.md](DVALIN.md) for scanner installation, policy behavior, scoring,
-and operational boundaries.
+and operational boundaries. For a Codex Security discovery/remediation plus
+Dvalin release-gate workflow, see the
+[Codex Security integration guide](https://github.com/arthurpanhku/dvalincode/tree/main/integrations/codex-security).

--- a/docs/SECURITY-AGENT-STRATEGY.md
+++ b/docs/SECURITY-AGENT-STRATEGY.md
@@ -1,0 +1,111 @@
+# Security Agent Strategy
+
+Dvalin follows one product principle: **cooperate where open boundaries improve
+the user's workflow; compete where a better security outcome is possible**.
+
+Codex Security is therefore neither a mandatory upstream dependency nor a
+category Dvalin agrees to avoid. A user may run Dvalin alone, run both products
+independently, or export portable findings from one workflow into another.
+Interoperability and competition can coexist.
+
+This document describes product direction, not an official partnership with or
+endorsement by OpenAI.
+
+## What we should learn
+
+The public Codex Security workflow demonstrates several useful patterns:
+
+- **Preflight before expensive work.** Validate targets, repository state, and
+  runtime readiness before starting a model-assisted scan.
+- **Two scan depths.** Keep a practical standard workflow and offer a bounded
+  deep-discovery mode for cases that justify more time and model budget.
+- **Explicit lifecycle and coverage.** Preserve whether a finding is new,
+  persisting, reopened, resolved, dismissed, or unknown, and distinguish
+  complete, partial, and unknown coverage.
+- **Evidence that survives the UI.** Keep findings, coverage, manifests, proof
+  gaps, and supporting artifacts portable and reviewable.
+- **Programmable execution.** Expose typed targets, progress, cancellation,
+  budgets, findings, coverage, and artifacts through a supported SDK and CI
+  interface.
+
+These patterns are documented in the official
+[Codex Security overview](https://learn.chatgpt.com/docs/security),
+[TypeScript SDK](https://learn.chatgpt.com/docs/security/sdk), and
+[CI guidance](https://learn.chatgpt.com/docs/security/cli/ci). Learning from a
+public workflow does not require copying private implementation details or
+accepting another product's verdict as Dvalin's own.
+
+## Where Dvalin competes
+
+Dvalin's current and intended advantages are architectural rather than claims
+about an unmeasured detection leaderboard:
+
+- **Immediate local baseline.** Dvalin Built-in runs without an account, API
+  key, model, or external security product. The same deterministic contract can
+  run on a laptop, through MCP, or in CI.
+- **Open scanner fleet.** Built-in rules, Semgrep CE, Trivy, OSV-Scanner, and
+  SARIF evidence share one normalization, baseline, suppression, and gate
+  contract. Additional engines remain replaceable.
+- **Agent-neutral surface.** CLI, MCP, GitHub Action, structured JSON, and SARIF
+  let human developers and different coding agents use the same security layer.
+- **Local and governed operation.** Scanner installation is explicit, model use
+  is optional, paths and execution are policy-bound, and publication remains an
+  explicit step.
+- **Independent evidence.** Baselines, reasoned suppressions, verification,
+  hash-chained audit records, and release evidence are owned by the repository's
+  security workflow rather than by the agent that wrote the patch.
+
+These properties let Dvalin compete for the complete discover → triage → fix →
+test → verify → publish workflow, not only for the final gate.
+
+## Honest gaps today
+
+The competitive position should be measured against current implementation,
+not roadmap language:
+
+- Dvalin Built-in is fast and dependable, but its rule coverage is narrower
+  than a deep model-assisted security investigation.
+- Dvalin has CLI, MCP, Action, and JSON contracts, but not yet a public typed
+  security SDK.
+- The persisted lifecycle distinguishes new, existing, and resolved cases, but
+  does not yet express reopened, dismissed, or unknown states consistently.
+- Imported SARIF is kept separate from Dvalin's own verdict, but Dvalin does not
+  yet expose a complete/partial/unknown coverage contract for every scan.
+- The remediation loop is governed and test-aware, but there is no dedicated
+  bounded multi-worker deep-discovery mode yet.
+
+## Competitive roadmap
+
+### P0 — Trustworthy scan semantics
+
+- Target and scanner preflight.
+- Complete, partial, and unknown coverage with deferred areas preserved.
+- Full finding lifecycle across local scans and imported evidence.
+- Consistent progress, cancellation, budget, and evidence contracts.
+
+### P1 — Deeper discovery and developer integration
+
+- Standard and deep scan profiles with explicit budgets and stop conditions.
+- Bounded parallel discovery workers that cannot bypass Dvalin policy.
+- A public TypeScript SDK over the same contracts used by CLI, MCP, CI, and UI.
+- First-class hooks for coding agents to request a finding, prepare a focused
+  repair, add a regression test, and obtain an independent verification result.
+
+### P2 — Evidence-based comparison
+
+- Public benchmark fixtures covering true findings, false positives,
+  remediation correctness, regression-test quality, latency, and cost.
+- Reproducible comparisons against Codex Security and other security tools when
+  licensing, access, and identical input conditions permit.
+- A local workbench that explains coverage, proof gaps, scanner disagreement,
+  case history, and why a gate passed or failed.
+
+## Guardrails
+
+- Do not claim an official OpenAI partnership without an explicit agreement.
+- Do not read, mutate, or imitate Codex Security's sealed internal state; use
+  documented portable exports such as SARIF.
+- Do not turn another scanner's finding or coverage status into a Dvalin verdict
+  without independent evidence.
+- Do not publish superiority claims without reproducible inputs and scoring.
+- Do not weaken Dvalin's deterministic no-model gate when adding deep discovery.

--- a/docs/design.md
+++ b/docs/design.md
@@ -1,26 +1,49 @@
 # DvalinCode Design
 
-DvalinCode is a small, original CLI foundation for agentic coding workflows.
+DvalinCode is a local-first, agent-compatible security runtime. Its primary
+product is the versioned evidence and release gate between code generation and
+merge. The bundled coding agent and user interfaces are remediation clients of
+that runtime; they are not the source of the security verdict.
 
 ## Goals
 
-- Keep the first version understandable.
-- Make every tool explicit and typed.
-- Make permissions simple enough to audit.
-- Keep the project provider-neutral.
-- Prefer local context and deterministic behavior before model calls.
+- Give humans, coding agents, and CI the same deterministic security contract.
+- Compete on application-security discovery, triage, governed remediation, and
+  independent verification without coupling the result to one model provider.
+- Consume and emit portable evidence through SARIF and structured JSON.
+- Run independently or work alongside specialist security systems, including
+  Codex Security, CodeQL, GitHub Code Scanning, Semgrep, Trivy, and OSV-Scanner.
+- Keep discovery and remediation providers replaceable while Dvalin owns the
+  policy, audit, baseline, verification, and publication gate.
+- Make every tool explicit, typed, locally bounded, and auditable.
+- Prefer local context and deterministic checks before optional model calls.
 
 ## Non-Goals
 
-- Clone any existing commercial assistant.
-- Provide a full autonomous coding agent in the first release.
-- Execute write or shell operations without explicit permission.
-- Bind the project to one model vendor.
+- Match every feature of every general coding agent, or turn Dvalin's bundled
+  coding executor into the product's trust boundary.
+- Claim security superiority or coverage parity without reproducible evidence.
+- Treat an imported finding as independently verified merely because it was
+  accepted, fixed, or absent from a later SARIF export.
+- Reinterpret another product's coverage, sealed scan bundle, credentials, or
+  access policy.
+- Install or execute third-party scanners merely because they were discovered.
+- Execute write, shell, publication, or tracking operations without the
+  corresponding policy and approval.
+- Bind the security gate to one model vendor or agent environment.
+
+The product boundary, competitive thesis, honest gaps, and implementation
+priorities are detailed in [SECURITY-AGENT-STRATEGY.md](SECURITY-AGENT-STRATEGY.md).
 
 ## User-Facing Behavior
 
 DvalinCode starts as a normal CLI with subcommands:
 
+- `security scan` / `dvalin scan` runs the independent security gate.
+- `security import` / `dvalin import` normalizes a SARIF handoff into local
+  remediation cases without executing the source scanner.
+- `security verify` / `dvalin verify` resumes a Dvalin workflow and re-runs its
+  configured scanners and checks.
 - `scan` summarizes a project.
 - `tools` lists available capabilities.
 - `run-tool` invokes a specific tool with JSON input.
@@ -90,7 +113,10 @@ src/
 ├── audit/         hash-chained run log, Run Report renderer, taps
 ├── commands/      CLI command registration (incl. `report`)
 ├── core/          context, permissions, workspace scanning
+├── mcp/           task-level tools for external coding agents
 ├── providers/     planner and model adapters
+├── remediation/   scanner orchestration, SARIF, cases, worktrees
+├── security/      versioned gate, baseline, suppressions, workflow
 ├── server/        Express + WebSocket runtime for the GUI
 ├── sessions/      session persistence
 ├── tools/         tool contracts and built-in tools
@@ -104,4 +130,3 @@ src/
 - Keep process execution opt-in.
 - Prefer small, inspectable outputs.
 - Keep dangerous capabilities out of default flows.
-

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,8 +3,8 @@ layout: home
 
 hero:
   name: DvalinCode
-  text: The approvable coding agent for regulated teams
-  tagline: Any model · local-first · policy-bound · audit-ready — AI coding your security team can actually approve.
+  text: Open security engineering for human and agent-written code
+  tagline: Discover · remediate · verify — run Dvalin independently or alongside any security agent, with a local policy-bound gate before merge.
   image:
     light: /logo-light.png
     dark: /logo-dark.png
@@ -37,8 +37,10 @@ features:
     link: /EVIDENCE-PACK
     linkText: Evidence pack
   - icon: 🔑
-    title: Any model, no lock-in
-    details: DeepSeek, OpenAI, Claude via OpenRouter, Groq, Ollama, or any OpenAI-compatible endpoint. Switch with one click — run fully offline with local models.
+    title: Any agent or security source
+    details: Codex Security, CodeQL, GitHub Code Scanning, Semgrep, Trivy, OSV-Scanner, or another SARIF producer can hand evidence to the same local Dvalin gate.
+    link: /DVALIN
+    linkText: Interoperability
   - icon: 💻
     title: Local-first, zero-dep binary
     details: One ~25 MB executable per platform. No Node, no Python, no Docker. Sessions, config, and audit logs stay in ~/.dvalincode on your machine.
@@ -76,6 +78,11 @@ Dvalin combines the MIT-licensed DvalinCode pipeline with open-source
 [OSV-Scanner](https://github.com/google/osv-scanner), and SARIF 2.1
 interoperability. Scanner evidence guides the configured model; DvalinCode
 records the diff, runs project tests, re-scans, and keeps PR publication explicit.
+Specialist agents such as Codex Security can export SARIF into the same case and
+gate workflow without Dvalin taking ownership of their credentials or sealed
+scan artifacts. Dvalin can also run the complete discovery, remediation, and
+verification loop itself; interoperability is an option, not the product
+boundary.
 
 Prove what the agent did after the fact:
 
@@ -99,12 +106,13 @@ surface, with the same policy and audit chokepoint.
 
 ![DvalinCode web GUI](/hero.png)
 
-## Built for teams that need a "yes" from security
+## Built for every team that needs an independent security decision
 
-DvalinCode is an **approvable agent runtime**, not just another coding agent.
-The product is the evidence a security, compliance, or platform team needs to
-safely allow AI coding in finance, healthcare, and other confidential
-codebases:
+DvalinCode is an **agent-compatible security runtime** that can run alone,
+compete in security discovery and remediation, or interoperate with specialist
+systems. It does not try to replace every general coding agent. The product is
+the discovery, evidence, remediation, and enforcement layer a security,
+compliance, or platform team needs before human- or agent-written code can merge:
 
 - **Controllable** — an [org policy](/POLICY-REFERENCE) bounds the blast radius.
 - **Transparent** — `dvalincode trust` makes the posture self-verifiable.
@@ -117,7 +125,8 @@ honest residual gap.
 
 ## Is DvalinCode for you?
 
-An honest fit check — we compete on approvability, not on being everything.
+An honest fit check — we compete on measurable security outcomes and
+approvability, not on being everything.
 
 **Choose DvalinCode when…**
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -40,3 +40,28 @@
   gating layer; `policy_violation` audit events; `THREAT-MODEL.md`.
 - Checkpoint / rollback (P1-1): run-level snapshot + one-click rollback.
 
+## 0.18 Security Ecosystem Interoperability and Competitive Depth
+
+- **[done] Portable SARIF handoff:** `dvalin import <report> [workspace]`
+  validates external paths and creates stable remediation cases.
+- **[done] Codex Security integration:** consume the officially exported SARIF
+  projection without reading or modifying the sealed scan bundle; retain its
+  manifest, findings, and coverage as companion evidence.
+- Add target preflight that validates repository state, supported scan scope,
+  scanner readiness, and expected evidence before consuming model budget.
+- Add an explicit coverage contract: complete, partial, or unknown, with
+  deferred areas and open questions preserved as evidence rather than silently
+  converted into a pass.
+- Add a public TypeScript security SDK for preflight, scan/import progress,
+  budgets, cancellation, structured findings, coverage, and gate results.
+- Add explicit finding lifecycle states across scans: new, persisting,
+  reopened, resolved, dismissed, and unknown when coverage is incomplete.
+- Keep fast deterministic gates separate from optional deep agent-assisted
+  discovery so CI never needs a model merely to enforce the baseline.
+- Add standard and deep scan profiles. Deep scans may use bounded parallel
+  workers, progress events, discovery budgets, and explicit stop conditions;
+  standard scans retain the fast local contract.
+- Publish reproducible benchmark fixtures for finding quality, false positives,
+  remediation correctness, test preservation, latency, and cost. Compare with
+  Codex Security and other tools only when the same public inputs and scoring
+  method can be reproduced.

--- a/docs/zh/index.md
+++ b/docs/zh/index.md
@@ -3,8 +3,8 @@ layout: home
 
 hero:
   name: DvalinCode
-  text: 面向受监管团队的可审批编码代理
-  tagline: 任意模型 · 本地优先 · 策略约束 · 审计就绪 —— 一个安全团队真正敢批准的 AI 编码代理。
+  text: 面向人类与 Agent 代码的开放安全工程
+  tagline: 发现 · 修复 · 验证 —— Dvalin 可以独立运行，也可与任意安全 Agent 协作，并在合并前执行本地、受策略约束的门禁。
   image:
     light: /logo-light.png
     dark: /logo-dark.png
@@ -37,8 +37,10 @@ features:
     link: /EVIDENCE-PACK
     linkText: 证据包
   - icon: 🔑
-    title: 任意模型，无锁定
-    details: DeepSeek、OpenAI、Claude（经 OpenRouter）、Groq、Ollama，或任何 OpenAI 兼容端点。一键切换，也可用本地模型完全离线运行。
+    title: 任意 Agent 或安全证据源
+    details: Codex Security、CodeQL、GitHub Code Scanning、Semgrep、Trivy、OSV-Scanner 或其他 SARIF 生产者，都可以把证据交给同一个本地 Dvalin 门禁。
+    link: /DVALIN
+    linkText: 互操作
   - icon: 💻
     title: 本地优先的零依赖二进制
     details: 每个平台一个约 25 MB 的可执行文件。不需要 Node、Python 或 Docker。会话、配置和审计日志都留在你机器的 ~/.dvalincode 下。
@@ -75,6 +77,9 @@ Dvalin 将 MIT 许可的 DvalinCode 流水线与开源
 [OSV-Scanner](https://github.com/google/osv-scanner) 和 SARIF 2.1 互操作结合起来。
 扫描证据指导配置的模型；DvalinCode 记录 diff、运行项目测试、复扫，并要求用户
 显式发布 PR。
+Codex Security 等专业 Agent 也可以把 SARIF 导入同一个 case 和门禁流程，
+而 Dvalin 不接管它们的凭据或密封扫描工件。Dvalin 也可以独立完成发现、修复和
+验证闭环；互操作是一种选择，不是产品边界。
 
 代理完成工作后仍可事后证明它做过什么：
 
@@ -94,10 +99,12 @@ Windows 构建和各平台手动下载见
 
 ![DvalinCode 网页界面](/hero.png)
 
-## 为需要安全团队点头的场景而造
+## 为需要独立安全结论的团队而造
 
-DvalinCode 是一个**可审批的代理运行时**，不只是又一个编码代理。产品本身就是
-安全、合规或平台团队放行 AI 编码所需要的证据，适用于金融、医疗和其他机密代码库：
+DvalinCode 是一个 **Agent 可调用的安全运行时**：它可以独立运行、在安全发现和修复
+领域参与竞争，也可以与专业系统互操作；但它不以替代所有通用 Coding Agent 为目标。
+产品本身是人类或 Agent 代码合并前，安全、合规或平台团队所需要的发现、证据、修复
+与强制执行层：
 
 - **可控** —— [组织策略](/POLICY-REFERENCE)限定影响范围。
 - **透明** —— `dvalincode trust` 让安全态势可自证。
@@ -109,7 +116,7 @@ MCP 服务器、提示注入升级、数据外流、审计篡改——每一项�
 
 ## DvalinCode 适合你吗？
 
-诚实的适配判断——我们比拼的是"可审批"，而不是包打天下。
+诚实的适配判断——我们比拼的是可衡量的安全结果和“可审批”，而不是包打天下。
 
 **选择 DvalinCode，当……**
 

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -4,6 +4,7 @@ Ways to reach DvalinCode from something other than its own CLI.
 
 | Path | What it is |
 |---|---|
+| [`codex-security/`](codex-security/) | Optional SARIF interoperability between two independently runnable, potentially competing security workflows. |
 | [`claude-code/`](claude-code/) | A Claude Code skill that runs a Dvalin scan and reads the result. |
 | [`agents/`](agents/) | Portable security-gate instructions for coding agents. |
 | [`mcp/`](mcp/) | A generic stdio MCP server configuration. |

--- a/integrations/codex-security/README.md
+++ b/integrations/codex-security/README.md
@@ -1,0 +1,107 @@
+# Codex Security and Dvalin
+
+Dvalin can interoperate with Codex Security, and it can also compete in the
+security workflows where their capabilities overlap:
+
+- **Codex Security** performs model-assisted threat modeling, deep discovery,
+  validation, and focused remediation in its own security environment.
+- **Dvalin** can perform its own deterministic and multi-engine discovery,
+  orchestrate governed remediation, and independently verify the result. It can
+  also accept Codex Security's portable findings as local remediation cases.
+
+The integration described here is an interoperability path, not a claim of an
+official partnership or endorsement. Neither product is required to run the
+other. Codex Security access, credentials, execution, and sealed scan artifacts
+remain governed by OpenAI's product and documentation.
+
+## Handoff contract
+
+The boundary is **SARIF 2.1**, not Codex Security's internal state directory.
+OpenAI documents SARIF as the portable format for tools that support the SARIF
+interchange standard. A completed scan can be exported with:
+
+```sh
+DVALIN_CODEX_SCAN_DIR=/tmp/codex-security-results
+DVALIN_CODEX_SARIF=/tmp/codex-security.sarif
+
+npx @openai/codex-security scan . \
+  --output-dir "$DVALIN_CODEX_SCAN_DIR"
+
+npx @openai/codex-security export "$DVALIN_CODEX_SCAN_DIR" \
+  --export-format sarif \
+  --source-root "$PWD" \
+  --output "$DVALIN_CODEX_SARIF"
+```
+
+Running a Codex Security scan requires Codex Security access and its supported
+authentication. Follow the current
+[Codex Security documentation](https://learn.chatgpt.com/docs/security) rather
+than copying credentials into project files.
+
+## Import into Dvalin
+
+Import the exported report against the matching workspace root:
+
+```sh
+dvalin import "$DVALIN_CODEX_SARIF" .
+```
+
+The command:
+
+1. Parses the report without executing Codex Security or modifying its sealed
+   scan bundle.
+2. Rejects absolute result paths outside the selected workspace.
+3. Normalizes source, rule, severity, location, tags, and source context.
+4. Creates or updates stable local remediation cases under
+   `~/.dvalincode/remediation/`.
+
+Use `--json` for a versioned machine-readable import envelope. Use
+`--no-persist` to validate a report without changing the remediation backlog:
+
+```sh
+dvalin import "$DVALIN_CODEX_SARIF" . --json --no-persist
+```
+
+## Use Dvalin from the same Codex workspace
+
+Codex can also call Dvalin's deterministic gate over MCP while the Codex
+Security plugin remains available for deep security work:
+
+```sh
+codex mcp add dvalin -- npx -y dvalincode mcp-serve --workspace .
+```
+
+This exposes `dvalin_scan`, `dvalin_get_finding`,
+`dvalin_verify_findings`, and scanner/evidence tools to Codex. It does not make
+Dvalin an internal Codex Security scanner and does not cause either product to
+invoke the other automatically. The SARIF handoff remains the explicit boundary
+between their security findings.
+
+## Remediate and gate
+
+An imported finding is external evidence, not a Dvalin pass or failure. Review
+and validate it, then let Codex Security, DvalinCode, or another coding agent
+prepare the smallest safe patch and its focused regression test. After applying
+the accepted patch, run the project tests and the independent Dvalin gate:
+
+```sh
+npm test                         # use the repository's actual checks
+dvalin scan . --fail-on high
+```
+
+Keep Codex Security's `scan-manifest.json`, `findings.json`, `coverage.json`,
+and supporting artifacts together when they are part of the security evidence.
+SARIF carries the finding projection; it does not preserve the complete coverage
+or threat-model record. Dvalin therefore does not turn partial or unknown Codex
+Security coverage into a complete result, and a clean Dvalin scan does not erase
+an unresolved Codex Security finding.
+
+Official references:
+
+- [Export and track Codex Security findings](https://learn.chatgpt.com/docs/security/plugin/export-findings)
+- [Run Codex Security in CI](https://learn.chatgpt.com/docs/security/cli/ci)
+- [Codex Security TypeScript SDK](https://learn.chatgpt.com/docs/security/sdk)
+
+For Dvalin's product boundary, competitive differentiation, current gaps, and
+roadmap, see
+[Security Agent Strategy](../../docs/SECURITY-AGENT-STRATEGY.md).

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dvalincode",
   "version": "0.17.0",
-  "description": "Independent security verification for code written by humans and AI agents.",
+  "description": "Open security engineering for code written by humans and AI agents.",
   "type": "module",
   "license": "MIT",
   "repository": {

--- a/src/commands/security.ts
+++ b/src/commands/security.ts
@@ -1,4 +1,4 @@
-import { access, mkdir, writeFile } from 'node:fs/promises';
+import { access, mkdir, open, writeFile } from 'node:fs/promises';
 import { constants } from 'node:fs';
 import path from 'node:path';
 import type { Command } from 'commander';
@@ -17,6 +17,8 @@ import {
   type DvalinScanSuiteResult,
 } from '../remediation/scannerSuite.js';
 import { buildDvalinSarif } from '../remediation/sarifExport.js';
+import { parseSarifForRemediation, type RemediationFinding } from '../remediation/sarif.js';
+import { upsertRemediationCases, type RemediationCase } from '../remediation/cases.js';
 import { runCheckTool } from '../tools/runCheck.js';
 import { readSecurityBaseline, writeSecurityBaseline } from '../security/baseline.js';
 import {
@@ -56,6 +58,22 @@ type ScanOptions = {
 };
 
 type BaselineOptions = { config?: string; scanners?: string; timeout: string; output?: string; json?: boolean };
+type ImportOptions = { json?: boolean; persist: boolean };
+
+export const MAX_SECURITY_SARIF_IMPORT_BYTES = 64 * 1024 * 1024;
+
+export type SecuritySarifImport = {
+  schemaVersion: 1;
+  kind: 'dvalin-security-import';
+  root: string;
+  reportPath: string;
+  source: string;
+  totalResults: number;
+  skippedResults: number;
+  findings: RemediationFinding[];
+  cases: RemediationCase[];
+  persisted: boolean;
+};
 
 export type ExecutedSecurityScan = SecurityScanEnvelope & {
   root: string;
@@ -123,6 +141,31 @@ export function registerSecuritySubcommands(parent: Command): void {
       }
       if (options.sarif) await writeSarif(execution.scan, execution.root, options.sarif, !options.json);
       if (!execution.gate.passed) process.exitCode = EXIT.gateNotMet;
+    });
+
+  parent
+    .command('import')
+    .description('Import a SARIF handoff into Dvalin remediation cases')
+    .argument('<report>', 'SARIF 2.1 report exported by Codex Security or another compatible scanner')
+    .argument('[path]', 'workspace path used to resolve finding locations', '.')
+    .option('--json', 'print the versioned import envelope as JSON')
+    .option('--no-persist', 'parse the report without creating remediation cases')
+    .action(async (report: string, inputPath: string, options: ImportOptions) => {
+      const imported = await executeSecuritySarifImport({
+        root: path.resolve(process.cwd(), inputPath),
+        reportPath: path.resolve(process.cwd(), report),
+        persist: options.persist,
+      });
+      if (options.json) {
+        console.log(JSON.stringify(imported, null, 2));
+      } else {
+        console.log(`Imported ${imported.findings.length}/${imported.totalResults} finding(s) from ${imported.source}.`);
+        if (imported.skippedResults) console.log(`Skipped ${imported.skippedResults} result(s) without a safe workspace location.`);
+        console.log(imported.persisted
+          ? `Created or updated ${imported.cases.length} remediation case(s).`
+          : 'Persistence disabled; no remediation cases were changed.');
+        console.log('Next: review the external evidence, then run `dvalin scan .` as the independent release gate.');
+      }
     });
 
   parent
@@ -266,6 +309,78 @@ export async function executeSecurityScan(input: {
     suppressed: suppression.suppressed.length,
     expiredSuppressions: suppression.expired.length,
   };
+}
+
+export async function executeSecuritySarifImport(input: {
+  root: string;
+  reportPath: string;
+  persist?: boolean;
+}): Promise<SecuritySarifImport> {
+  const root = await resolveWorkspaceRoot(input.root);
+  const reportPath = path.resolve(input.reportPath);
+  let reportText: string;
+  try {
+    reportText = await readUtf8FileWithLimit(reportPath, MAX_SECURITY_SARIF_IMPORT_BYTES);
+  } catch (error) {
+    if (error instanceof UsageError) throw error;
+    throw new UsageError(`Cannot read SARIF report ${reportPath}: ${error instanceof Error ? error.message : String(error)}`);
+  }
+  let report: unknown;
+  try {
+    report = JSON.parse(reportText) as unknown;
+  } catch (error) {
+    throw new UsageError(`Invalid SARIF JSON in ${reportPath}: ${error instanceof Error ? error.message : String(error)}`);
+  }
+  const parsed = await parseSarifForRemediation(report, { cwd: root }).catch(error => {
+    throw new UsageError(`Cannot import SARIF report ${reportPath}: ${error instanceof Error ? error.message : String(error)}`);
+  });
+  const persisted = input.persist !== false;
+  const cases = persisted
+    ? await upsertRemediationCases({ cwd: root, findings: parsed.findings })
+    : [];
+  return {
+    schemaVersion: 1,
+    kind: 'dvalin-security-import',
+    root,
+    reportPath,
+    source: parsed.source,
+    totalResults: parsed.totalResults,
+    skippedResults: parsed.skippedResults,
+    findings: parsed.findings,
+    cases,
+    persisted,
+  };
+}
+
+async function readUtf8FileWithLimit(file: string, maxBytes: number): Promise<string> {
+  const handle = await open(file, 'r');
+  try {
+    const info = await handle.stat();
+    if (!info.isFile()) throw new UsageError(`SARIF report is not a regular file: ${file}`);
+    if (info.size > maxBytes) {
+      throw new UsageError(`SARIF report exceeds the ${Math.floor(maxBytes / 1024 / 1024)} MiB import limit: ${file}`);
+    }
+
+    const chunks: Buffer[] = [];
+    let totalBytes = 0;
+    while (true) {
+      const remaining = maxBytes + 1 - totalBytes;
+      if (remaining <= 0) {
+        throw new UsageError(`SARIF report exceeds the ${Math.floor(maxBytes / 1024 / 1024)} MiB import limit: ${file}`);
+      }
+      const chunk = Buffer.allocUnsafe(Math.min(64 * 1024, remaining));
+      const { bytesRead } = await handle.read(chunk, 0, chunk.length, null);
+      if (bytesRead === 0) break;
+      totalBytes += bytesRead;
+      if (totalBytes > maxBytes) {
+        throw new UsageError(`SARIF report exceeds the ${Math.floor(maxBytes / 1024 / 1024)} MiB import limit: ${file}`);
+      }
+      chunks.push(chunk.subarray(0, bytesRead));
+    }
+    return Buffer.concat(chunks, totalBytes).toString('utf8');
+  } finally {
+    await handle.close();
+  }
 }
 
 function renderSecurityExecution(execution: ExecutedSecurityScan, limit: number): string {

--- a/src/dvalinCli.ts
+++ b/src/dvalinCli.ts
@@ -7,7 +7,7 @@ import { VERSION } from './version.js';
 export function buildDvalinProgram(): Command {
   const program = new Command()
     .name('dvalin')
-    .description('Independent security verification for human- and agent-written code')
+    .description('Discover, remediate, and independently verify security findings')
     .version(VERSION);
   registerSecuritySubcommands(program);
   registerMcpServeCommand(program);

--- a/src/remediation/sarif.ts
+++ b/src/remediation/sarif.ts
@@ -1,6 +1,7 @@
 import { readFile } from 'node:fs/promises';
 import path from 'node:path';
-import { resolveInsideWorkspace } from '../core/workspace.js';
+import { fileURLToPath } from 'node:url';
+import { resolveInsideWorkspace, resolveWorkspaceRoot } from '../core/workspace.js';
 
 type SarifArtifactLocation = {
   uri?: string;
@@ -124,31 +125,48 @@ function normalizeLevel(level?: string): RemediationFinding['severity'] {
   return 'warning';
 }
 
-function normalizeSarifPath(uri: string | undefined, cwd?: string): string | undefined {
+async function normalizeSarifPath(uri: string | undefined, cwd?: string): Promise<string | undefined> {
   if (!uri) return undefined;
   const trimmed = uri.trim();
-  if (!trimmed || trimmed.includes('\0') || trimmed.startsWith('http:') || trimmed.startsWith('https:')) {
+  if (!trimmed || trimmed.includes('\0')) {
     return undefined;
   }
 
-  const withoutFileScheme = trimmed.startsWith('file://')
-    ? trimmed.replace(/^file:\/+/, '/')
-    : trimmed;
   let decoded: string;
   try {
-    decoded = decodeURIComponent(withoutFileScheme);
+    if (/^file:/i.test(trimmed)) decoded = fileURLToPath(trimmed);
+    else {
+      const looksLikeWindowsPath = path.win32.isAbsolute(trimmed);
+      if (!looksLikeWindowsPath && /^[a-z][a-z0-9+.-]*:/i.test(trimmed)) return undefined;
+      decoded = decodeURIComponent(trimmed);
+    }
   } catch {
     return undefined;
   }
   const normalized = path.normalize(decoded);
-  if (path.isAbsolute(normalized) && cwd) {
-    const relative = path.relative(path.resolve(cwd), normalized);
-    if (!relative || (!relative.startsWith('..') && !path.isAbsolute(relative))) {
-      return (relative || path.basename(normalized)).replace(/\\/g, '/');
-    }
-    return undefined;
+
+  if (!cwd) {
+    const portable = normalized.replace(/\\/g, '/');
+    if (path.isAbsolute(normalized) || path.win32.isAbsolute(normalized)
+      || portable === '..' || portable.startsWith('../')) return undefined;
+    return portable.replace(/^\.\//, '');
   }
-  return normalized.replace(/\\/g, '/');
+
+  const root = await resolveWorkspaceRoot(cwd);
+  if (path.win32.isAbsolute(normalized) && !path.isAbsolute(normalized)) return undefined;
+  const candidates = path.isAbsolute(normalized)
+    ? [path.relative(path.resolve(cwd), normalized), path.relative(root, normalized)]
+    : [normalized];
+  for (const candidate of new Set(candidates)) {
+    try {
+      const resolved = await resolveInsideWorkspace(root, candidate);
+      const relative = path.relative(root, resolved).replace(/\\/g, '/');
+      if (relative && relative !== '..' && !relative.startsWith('../')) return relative;
+    } catch {
+      // Try the canonical-root-relative form before rejecting an absolute URI.
+    }
+  }
+  return undefined;
 }
 
 async function readSnippet(cwd: string | undefined, findingPath: string, startLine: number | undefined): Promise<string | undefined> {
@@ -220,7 +238,7 @@ export async function parseSarifForRemediation(report: unknown, opts: { cwd?: st
 
       const location = result.locations?.[0];
       const physical = location?.physicalLocation;
-      const findingPath = normalizeSarifPath(physical?.artifactLocation?.uri, opts.cwd);
+      const findingPath = await normalizeSarifPath(physical?.artifactLocation?.uri, opts.cwd);
       if (!findingPath) {
         skippedResults += 1;
         continue;

--- a/tests/remediationSarif.test.ts
+++ b/tests/remediationSarif.test.ts
@@ -1,6 +1,7 @@
 import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
+import { pathToFileURL } from 'node:url';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { parseSarifForRemediation } from '../src/remediation/sarif.js';
 
@@ -113,7 +114,7 @@ describe('parseSarifForRemediation', () => {
         results: [{
           ruleId: 'typescript.lang.security.test',
           message: { text: 'Finding from an absolute URI' },
-          locations: [{ physicalLocation: { artifactLocation: { uri: `file://${absolute}` }, region: { startLine: 4 } } }],
+          locations: [{ physicalLocation: { artifactLocation: { uri: pathToFileURL(absolute).href }, region: { startLine: 4 } } }],
         }],
       }],
     }, { cwd });
@@ -137,6 +138,37 @@ describe('parseSarifForRemediation', () => {
     }, { cwd });
 
     expect(result.skippedResults).toBe(1);
+    expect(result.findings).toEqual([]);
+  });
+
+  it('rejects relative, encoded, and file URI paths outside the workspace', async () => {
+    const outside = path.join(path.dirname(cwd), 'outside.ts');
+    const result = await parseSarifForRemediation({
+      runs: [{
+        tool: { driver: { name: 'Scanner' } },
+        results: [
+          {
+            ruleId: 'relative-escape',
+            locations: [{ physicalLocation: { artifactLocation: { uri: '../outside.ts' } } }],
+          },
+          {
+            ruleId: 'encoded-escape',
+            locations: [{ physicalLocation: { artifactLocation: { uri: '%2e%2e%2foutside.ts' } } }],
+          },
+          {
+            ruleId: 'file-uri-escape',
+            locations: [{
+              physicalLocation: {
+                artifactLocation: { uri: pathToFileURL(outside).href },
+              },
+            }],
+          },
+        ],
+      }],
+    }, { cwd });
+
+    expect(result.totalResults).toBe(3);
+    expect(result.skippedResults).toBe(3);
     expect(result.findings).toEqual([]);
   });
 });

--- a/tests/securitySarifImport.test.ts
+++ b/tests/securitySarifImport.test.ts
@@ -1,0 +1,142 @@
+import { mkdtemp, mkdir, rm, truncate, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  executeSecuritySarifImport,
+  MAX_SECURITY_SARIF_IMPORT_BYTES,
+} from '../src/commands/security.js';
+import { buildDvalinProgram } from '../src/dvalinCli.js';
+import { listRemediationCases } from '../src/remediation/cases.js';
+
+describe.sequential('security SARIF handoff', () => {
+  let home: string;
+  let workspace: string;
+  let originalHome: string | undefined;
+
+  beforeEach(async () => {
+    home = await mkdtemp(path.join(tmpdir(), 'dvalin-sarif-home-'));
+    workspace = await mkdtemp(path.join(tmpdir(), 'dvalin-codex-security-'));
+    originalHome = process.env.DVALINCODE_HOME;
+    process.env.DVALINCODE_HOME = home;
+    await mkdir(path.join(workspace, 'src'));
+    await writeFile(path.join(workspace, 'src', 'app.ts'), 'export const query = input;\n', 'utf8');
+  });
+
+  afterEach(async () => {
+    if (originalHome === undefined) delete process.env.DVALINCODE_HOME;
+    else process.env.DVALINCODE_HOME = originalHome;
+    await rm(home, { recursive: true, force: true });
+    await rm(workspace, { recursive: true, force: true });
+  });
+
+  it('imports a Codex Security SARIF export as stable remediation cases', async () => {
+    const reportPath = path.join(home, 'codex-security.sarif');
+    await writeFile(reportPath, JSON.stringify({
+      version: '2.1.0',
+      runs: [{
+        tool: {
+          driver: {
+            name: 'Codex Security',
+            rules: [{
+              id: 'codex-security/authz-bypass',
+              name: 'Authorization bypass',
+              properties: { tags: ['security', 'authorization'], security_severity: '8.2' },
+            }],
+          },
+        },
+        results: [{
+          ruleId: 'codex-security/authz-bypass',
+          level: 'error',
+          message: { text: 'A request can reach this operation without the expected authorization check.' },
+          locations: [{
+            physicalLocation: {
+              artifactLocation: { uri: 'src/app.ts' },
+              region: { startLine: 1 },
+            },
+          }],
+          partialFingerprints: { primaryLocationLineHash: 'codex-security-finding-1' },
+        }],
+      }],
+    }), 'utf8');
+
+    const imported = await executeSecuritySarifImport({ root: workspace, reportPath });
+    const cases = await listRemediationCases({ cwd: imported.root });
+
+    expect(imported).toMatchObject({
+      schemaVersion: 1,
+      kind: 'dvalin-security-import',
+      source: 'Codex Security',
+      totalResults: 1,
+      skippedResults: 0,
+      persisted: true,
+    });
+    expect(imported.findings).toHaveLength(1);
+    expect(imported.findings[0]).toMatchObject({
+      source: 'Codex Security',
+      ruleId: 'codex-security/authz-bypass',
+      path: 'src/app.ts',
+      securitySeverity: '8.2',
+    });
+    expect(cases).toHaveLength(1);
+    expect(cases[0]).toMatchObject({ source: 'Codex Security', status: 'open' });
+  });
+
+  it('can validate a handoff without changing the remediation backlog', async () => {
+    const reportPath = path.join(home, 'empty.sarif');
+    await writeFile(reportPath, JSON.stringify({ version: '2.1.0', runs: [] }), 'utf8');
+
+    const imported = await executeSecuritySarifImport({ root: workspace, reportPath, persist: false });
+
+    expect(imported.persisted).toBe(false);
+    expect(imported.cases).toEqual([]);
+    expect(await listRemediationCases({ cwd: workspace })).toEqual([]);
+  });
+
+  it('does not persist SARIF findings whose relative path escapes the workspace', async () => {
+    const reportPath = path.join(home, 'escape.sarif');
+    await writeFile(reportPath, JSON.stringify({
+      version: '2.1.0',
+      runs: [{
+        tool: { driver: { name: 'Untrusted Scanner' } },
+        results: [{
+          ruleId: 'path-escape',
+          locations: [{ physicalLocation: { artifactLocation: { uri: '../outside.ts' } } }],
+        }],
+      }],
+    }), 'utf8');
+
+    const imported = await executeSecuritySarifImport({ root: workspace, reportPath });
+
+    expect(imported).toMatchObject({ totalResults: 1, skippedResults: 1, persisted: true });
+    expect(imported.findings).toEqual([]);
+    expect(imported.cases).toEqual([]);
+    expect(await listRemediationCases({ cwd: imported.root })).toEqual([]);
+  });
+
+  it('reports malformed JSON and invalid SARIF structure as usage errors', async () => {
+    const malformedPath = path.join(home, 'malformed.sarif');
+    const invalidPath = path.join(home, 'invalid.sarif');
+    await writeFile(malformedPath, '{not-json', 'utf8');
+    await writeFile(invalidPath, JSON.stringify({ version: '2.1.0' }), 'utf8');
+
+    await expect(executeSecuritySarifImport({ root: workspace, reportPath: malformedPath }))
+      .rejects.toThrow('Invalid SARIF JSON');
+    await expect(executeSecuritySarifImport({ root: workspace, reportPath: invalidPath }))
+      .rejects.toThrow('expected a top-level runs array');
+  });
+
+  it('rejects oversized SARIF before parsing it', async () => {
+    const reportPath = path.join(home, 'oversized.sarif');
+    await writeFile(reportPath, '', 'utf8');
+    await truncate(reportPath, MAX_SECURITY_SARIF_IMPORT_BYTES + 1);
+
+    await expect(executeSecuritySarifImport({ root: workspace, reportPath }))
+      .rejects.toThrow('exceeds the 64 MiB import limit');
+  });
+
+  it('exposes import directly on the focused dvalin CLI', () => {
+    const commands = buildDvalinProgram().commands.map(command => command.name());
+    expect(commands).toContain('import');
+  });
+});


### PR DESCRIPTION
## Summary

- add `dvalin import <report> [workspace]` and `dvalincode security import` for portable SARIF handoffs
- normalize imported findings into stable local remediation cases without treating external evidence as a Dvalin gate verdict
- reject workspace path escapes, malformed reports, and SARIF imports larger than 64 MiB
- document optional Codex Security interoperability without claiming an official partnership or coupling to sealed internal state
- position Dvalin to run independently, interoperate, or compete across security discovery, remediation, and verification workflows
- add a security-agent strategy covering differentiation, honest gaps, and an evidence-based roadmap

## Why

Dvalin should be easy to use from human and agent development workflows while remaining provider-neutral. Portable SARIF creates a standards-based boundary with Codex Security and other scanners, while Dvalin continues to own its local policy, audit, baseline, remediation, verification, and release-gate evidence.

The documentation previously described Dvalin and Codex Security as complementary-only. This narrows the product unnecessarily. The updated positioning keeps interoperability optional and allows Dvalin to compete where measurable user outcomes improve.

## Security and developer impact

- absolute, relative, encoded, and `file://` paths outside the workspace are skipped before case persistence
- imports are bounded to 64 MiB and malformed JSON receives a usage error
- `--no-persist` validates a handoff without modifying the remediation backlog
- the focused `dvalin import` CLI entrypoint is covered by a regression test
- external findings remain evidence, not an automatic Dvalin pass or failure

## Validation

- `npm run check` — 56 test files, 372 tests passed
- `npm run site:build`
- `git diff --check`
- read-only Claude Code pre-commit review followed by a successful fix re-review
