### PR TITLE
fix(dvalin): make the builtin scanner's output trustworthy, and scope it to a diff

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,14 +83,22 @@ permissions:
   security-events: write
 steps:
   - uses: actions/checkout@v5
+    with:
+      fetch-depth: 0        # so the scan can reach the base commit
   - uses: arthurpanhku/dvalincode@v0.17.0
     with:
       fail-on: high
+      diff: true            # only report on what this PR changed
 ```
 
 Findings land inline on the pull request diff and in your Security tab.
 No API key, no secrets, no model — the scan is deterministic and local to the
 runner. [Full example →](docs/examples/dvalin-scan.yml)
+
+`diff: true` reports only on lines the pull request changed, so the gate blocks
+what this change *adds* instead of everything the repository already carried.
+That is what makes the check adoptable on a codebase that was not clean to
+begin with. Drop it to scan the whole repository.
 
 ### Or let your agent call it
 
@@ -101,7 +109,10 @@ it. DvalinCode is an MCP server, so any agent that speaks MCP can:
 claude mcp add dvalin -- npx -y dvalincode mcp-serve --workspace .
 ```
 
-`dvalin_scan` never runs a model or edits the target workspace. It records a
+`dvalin_scan` accepts `diff: "uncommitted"`, which reports only on what the
+agent just wrote rather than everything the repository already carried — the
+difference between a usable answer and a wall of pre-existing findings. It never
+runs a model or edits the target workspace. It records a
 small local workflow so an agent can retrieve one finding by fingerprint and
 request an independent re-scan through `dvalin_get_finding` and
 `dvalin_verify_findings`. Responses include MCP `structuredContent`; scanner

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -74,14 +74,21 @@ permissions:
   security-events: write
 steps:
   - uses: actions/checkout@v5
+    with:
+      fetch-depth: 0        # 让扫描能取到 base commit
   - uses: arthurpanhku/dvalincode@v0.17.0
     with:
       fail-on: high
+      diff: true            # 只报告这个 PR 改动的部分
 ```
 
 扫描结果会直接标注在 PR 的 diff 上，同时进入仓库的 Security 页。不需要 API Key、
 不需要任何 secret、不调用模型 —— 扫描是确定性的，且只在 runner 本地进行。
 [完整示例 →](docs/examples/dvalin-scan.yml)
+
+`diff: true` 只报告 PR 改动到的行，因此这道门禁拦的是这次改动**新引入**的问题，
+而不是仓库里本来就有的一堆存量问题。这正是它能在一个并不干净的代码库上被接受的
+原因。去掉它就是全仓库扫描。
 
 ### 或者让你的 agent 调用它
 
@@ -92,7 +99,7 @@ server，任何支持 MCP 的 agent 都能接：
 claude mcp add dvalin -- npx -y dvalincode mcp-serve --workspace .
 ```
 
-`dvalin_scan` 不跑模型，也不会修改目标 workspace；它只持久化一份精简的本地安全
+`dvalin_scan` 支持 `diff: "uncommitted"`，只报告 agent 刚写的部分，而不是仓库里的全部存量问题。它不跑模型，也不会修改目标 workspace；它只持久化一份精简的本地安全
 workflow。Agent 可以用 fingerprint 精确读取单条发现，再通过 `dvalin_get_finding` 和
 `dvalin_verify_findings` 请求独立复扫。响应包含 MCP `structuredContent`，并可通过
 `dvalin_list_scanners` 查询组件是否就绪。同一 server 也提供可选的 `dvalin_run_task`

--- a/action.yml
+++ b/action.yml
@@ -20,6 +20,14 @@ inputs:
     description: 'Fail the job at or above this severity: critical, high, medium, low, none.'
     required: false
     default: 'none'
+  diff:
+    description: >-
+      Report only on lines this pull request changed, instead of the whole
+      repository. Needs a checkout with enough history to reach the base
+      commit — set `fetch-depth: 0` on actions/checkout. Ignored outside
+      pull_request events, where there is no base to compare against.
+    required: false
+    default: 'false'
   version:
     description: >-
       npm version of the dvalincode package to run. The literal value `local`
@@ -87,6 +95,8 @@ runs:
         DVALIN_VERSION: ${{ inputs.version }}
         DVALIN_TIMEOUT: ${{ inputs.timeout }}
         DVALIN_SARIF: ${{ inputs.sarif-file }}
+        DVALIN_DIFF: ${{ inputs.diff }}
+        DVALIN_BASE_REF: ${{ github.event.pull_request.base.ref }}
       run: |
         set -o pipefail
 
@@ -109,6 +119,17 @@ runs:
           cli=(npx -y "dvalincode@${DVALIN_VERSION}")
         fi
 
+        # Only a pull request has a base to compare against; on push there is
+        # no meaningful diff and the scan stays repository-wide.
+        scope=()
+        if [ "${DVALIN_DIFF}" = "true" ] && [ -n "${DVALIN_BASE_REF}" ]; then
+          if git rev-parse --verify --quiet "origin/${DVALIN_BASE_REF}" >/dev/null; then
+            scope=(--diff "origin/${DVALIN_BASE_REF}...HEAD")
+          else
+            echo "::warning::diff was requested but origin/${DVALIN_BASE_REF} is not available — scanning the whole repository. Set fetch-depth: 0 on actions/checkout."
+          fi
+        fi
+
         # The gate must not abort the job before the SARIF upload and summary
         # run, so the exit code is captured and re-applied at the end.
         code=0
@@ -117,6 +138,7 @@ runs:
           --timeout "${DVALIN_TIMEOUT}" \
           --fail-on "${DVALIN_FAIL_ON}" \
           --sarif "${DVALIN_SARIF}" \
+          "${scope[@]+"${scope[@]}"}" \
           --json > dvalin-result.json || code=$?
 
         if [ ! -s dvalin-result.json ]; then
@@ -149,7 +171,9 @@ runs:
           const lines = [
             `## ${icon} Dvalin security scan`,
             "",
-            `**Health ${r.score}/100 (${r.grade})** · ${r.findings.length} ${r.findings.length === 1 ? "finding" : "findings"} across ${m.files} ${m.files === 1 ? "file" : "files"}`,
+            r.scope
+              ? `**${r.findings.length} ${r.findings.length === 1 ? "finding" : "findings"}** on lines this pull request changed (${r.scope.files} ${r.scope.files === 1 ? "file" : "files"} vs \`${r.scope.ref}\`)`
+              : `**Health ${r.score}/100 (${r.grade})** · ${r.findings.length} ${r.findings.length === 1 ? "finding" : "findings"} across ${m.files} ${m.files === 1 ? "file" : "files"}`,
             "",
             "| Critical | High | Medium | Low |",
             "|---:|---:|---:|---:|",

--- a/docs/DVALIN.md
+++ b/docs/DVALIN.md
@@ -32,6 +32,9 @@ dvalincode dvalin . --scanners builtin --limit 10
 dvalincode dvalin . --json
 dvalincode dvalin . --sarif dvalin.sarif
 dvalincode dvalin . --fail-on high
+dvalincode dvalin . --diff
+dvalincode dvalin . --diff origin/main...HEAD
+dvalincode dvalin . --staged
 dvalincode dvalin . --scanners builtin --fix
 dvalincode dvalin . --fix --verify
 dvalincode dvalin . --fix --verify --draft-pr
@@ -46,6 +49,28 @@ exits 2 and a scanner crash still exits 1, so a pipeline can tell a real finding
 apart from a typo. See the table in
 [HARNESS-MODE.md](HARNESS-MODE.md#exit-codes). This changed in 0.17.0; it was
 previously 2, which collided with usage errors.
+
+### Scanning only what changed
+
+`--diff` narrows the report to lines that changed, so a scan answers "did this
+edit introduce anything?" rather than "what is wrong with this repository?".
+That is the question worth asking after an agent writes code, and it is the
+only form that stays quiet enough to run on every save.
+
+`--diff` with no value compares the working tree against `HEAD` and treats
+untracked files as new in full — an agent's brand-new file is entirely in scope.
+`--diff <ref>` takes any revision or range, such as `origin/main...HEAD` for a
+pull request. `--staged` reads the index instead.
+
+A scoped run reports a finding count rather than a health grade: a score
+computed from a forty-line diff would not describe the repository, and pretending
+otherwise is how a number stops meaning anything. The `--fail-on` gate still
+applies, so CI can block a pull request that *adds* a high-severity finding while
+ignoring pre-existing ones.
+
+Scoping is read-only. It cannot be combined with `--fix`, `--verify`, or
+`--draft-pr`, because a repair may touch lines the diff never named and
+verifying it has to look wider than the scan did.
 
 `--sarif <file>` additionally writes the result as SARIF 2.1.0, with
 `security-severity` on each rule and a stable fingerprint per finding so an

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -33,7 +33,8 @@ or set `dvalin.command` to `npx -y dvalincode` and skip the install entirely.
 |---|---|---|
 | `dvalin.command` | `dvalincode` | Set to `npx -y dvalincode` to run without installing. |
 | `dvalin.scanners` | `builtin` | Add `semgrep`, `trivy`, `osv-scanner` when they are on `PATH`. |
-| `dvalin.scanOnSave` | `true` | Re-scan the workspace on save. |
+| `dvalin.scanScope` | `changed` | `changed` reports only lines you have not committed yet; `workspace` reads everything. Needs a git repository. |
+| `dvalin.scanOnSave` | `true` | Re-scan on save. |
 | `dvalin.timeoutSeconds` | `60` | Abandon a scan that runs longer. |
 
 Only `builtin` runs with no extra setup, which is why it is the default — it

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -29,6 +29,16 @@
           "default": "builtin",
           "markdownDescription": "Comma-separated scanners. Only `builtin` runs with no extra setup; `semgrep`, `trivy`, and `osv-scanner` are used when already on `PATH`."
         },
+        "dvalin.scanScope": {
+          "type": "string",
+          "enum": ["changed", "workspace"],
+          "enumDescriptions": [
+            "Only lines changed since the last commit, including new files. Fast, and reports what you just wrote.",
+            "The entire workspace, including findings that were already there."
+          ],
+          "default": "changed",
+          "markdownDescription": "What each scan reads. `changed` needs the folder to be a git repository; outside one, use `workspace`."
+        },
         "dvalin.scanOnSave": {
           "type": "boolean",
           "default": true,

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -31,6 +31,7 @@ function config() {
   return {
     command: c.get<string>('command', 'dvalincode'),
     scanners: c.get<string>('scanners', 'builtin'),
+    scope: c.get<'workspace' | 'changed'>('scanScope', 'changed'),
     scanOnSave: c.get<boolean>('scanOnSave', true),
     timeoutMs: c.get<number>('timeoutSeconds', 60) * 1000,
   };
@@ -58,8 +59,8 @@ async function scanWorkspace(folder: vscode.WorkspaceFolder, silent: boolean): P
   status.text = '$(sync~spin) Dvalin';
   status.show();
   try {
-    const { command, scanners, timeoutMs } = config();
-    const outcome = await runScan({ command, cwd: folder.uri.fsPath, scanners, timeoutMs });
+    const { command, scanners, timeoutMs, scope } = config();
+    const outcome = await runScan({ command, cwd: folder.uri.fsPath, scanners, timeoutMs, scope });
 
     if (!outcome.ok) {
       status.text = '$(warning) Dvalin';

--- a/editors/vscode/src/scan.ts
+++ b/editors/vscode/src/scan.ts
@@ -12,6 +12,8 @@ export type ScanRequest = {
   cwd: string;
   scanners: string;
   timeoutMs: number;
+  /** `workspace` reads everything; `changed` reads only uncommitted lines. Defaults to `workspace`. */
+  scope?: 'workspace' | 'changed';
 };
 
 export type ScanOutcome =
@@ -23,10 +25,14 @@ export function commandToArgv(command: string): string[] {
   return command.trim().split(/\s+/).filter(Boolean);
 }
 
-export function scanArgs(scanners: string): string[] {
+export function scanArgs(scanners: string, scope: ScanRequest['scope'] = 'workspace'): string[] {
   // `--fail-on none` keeps the exit code meaningful for real errors only: the
   // editor wants findings as data, not as a failed process.
-  return ['dvalin', '.', '--scanners', scanners, '--fail-on', 'none', '--json'];
+  const args = ['dvalin', '.', '--scanners', scanners, '--fail-on', 'none', '--json'];
+  // On every save, the whole workspace is both slow and mostly irrelevant —
+  // what the author wants to see is what they just wrote.
+  if (scope === 'changed') args.push('--diff', 'uncommitted');
+  return args;
 }
 
 /**
@@ -60,7 +66,7 @@ export function runScan(request: ScanRequest): Promise<ScanOutcome> {
       resolve(outcome);
     };
 
-    const child = spawn(argv[0]!, [...argv.slice(1), ...scanArgs(request.scanners)], {
+    const child = spawn(argv[0]!, [...argv.slice(1), ...scanArgs(request.scanners, request.scope)], {
       cwd: request.cwd,
       env: process.env,
       stdio: ['ignore', 'pipe', 'pipe'],

--- a/editors/vscode/tests/scan.test.ts
+++ b/editors/vscode/tests/scan.test.ts
@@ -25,6 +25,15 @@ describe('scanArgs', () => {
   it('passes the configured scanners through', () => {
     expect(scanArgs('builtin,semgrep').join(' ')).toContain('--scanners builtin,semgrep');
   });
+
+  it('narrows to uncommitted lines when the scope is `changed`', () => {
+    expect(scanArgs('builtin', 'changed').join(' ')).toContain('--diff uncommitted');
+  });
+
+  it('reads the whole workspace by default', () => {
+    expect(scanArgs('builtin').join(' ')).not.toContain('--diff');
+    expect(scanArgs('builtin', 'workspace').join(' ')).not.toContain('--diff');
+  });
 });
 
 describe('classifyExit', () => {

--- a/integrations/claude-code/README.md
+++ b/integrations/claude-code/README.md
@@ -37,7 +37,7 @@ This exposes seven tools:
 
 | Tool | Needs a model? | Notes |
 |---|---|---|
-| `dvalin_scan` | no | Does not edit the workspace; returns structured findings and persists a compact workflow. |
+| `dvalin_scan` | no | Does not edit the workspace; returns structured findings and persists a compact workflow. Pass `diff: "uncommitted"` to report only on what you just wrote. |
 | `dvalin_get_finding` | no | Reads one finding by workflow ID and fingerprint. |
 | `dvalin_verify_findings` | no | Re-scans and applies the deterministic verification gate. |
 | `dvalin_list_scanners` | no | Reports scanner readiness and fixed install commands. |

--- a/src/commands/dvalin.ts
+++ b/src/commands/dvalin.ts
@@ -7,6 +7,7 @@ import { EXIT, UsageError } from '../core/exitCodes.js';
 import { runAgentTurn } from '../agent/session.js';
 import type { AgentEvent } from '../agent/types.js';
 import { upsertRemediationCases, updateRemediationCase } from '../remediation/cases.js';
+import { resolveDiffScope } from '../remediation/diffScope.js';
 import { createRemediationWorktree } from '../remediation/worktree.js';
 import {
   runDvalinScanSuite,
@@ -42,6 +43,8 @@ type DvalinOptions = {
   maxFixes: string;
   provider?: string;
   sarif?: string;
+  diff?: string | boolean;
+  staged?: boolean;
 };
 
 export function parseDvalinScannerIds(value: string): DvalinScannerId[] {
@@ -81,8 +84,12 @@ export function dvalinFailureThresholdMet(result: DvalinScanSuiteResult, thresho
 
 export function renderDvalinResult(result: DvalinScanSuiteResult, root: string, limit = 20): string {
   const lines = [
-    `Dvalin security scan · ${root}`,
-    `Health ${result.score}/100 (${result.grade}) · ${result.findings.length} findings · ${result.metrics.files} files · ${result.metrics.rules} rules`,
+    result.scope
+      ? `Dvalin security scan · ${root} · changed lines vs ${result.scope.ref}`
+      : `Dvalin security scan · ${root}`,
+    result.scope
+      ? `${result.findings.length} findings in ${result.scope.files} changed file(s) · ${result.metrics.rules} rules`
+      : `Health ${result.score}/100 (${result.grade}) · ${result.findings.length} findings · ${result.metrics.files} files · ${result.metrics.rules} rules`,
     `Severity critical ${result.metrics.critical} · high ${result.metrics.high} · medium ${result.metrics.medium} · low ${result.metrics.low}`,
     '',
     'Scanners',
@@ -101,7 +108,9 @@ export function renderDvalinResult(result: DvalinScanSuiteResult, root: string, 
       lines.push(`    ${finding.message}`);
     }
   } else {
-    lines.push('', 'No actionable findings. Review scanner coverage before treating this as assurance.');
+    lines.push('', result.scope
+      ? 'No actionable findings on the changed lines. Pre-existing findings elsewhere were not read.'
+      : 'No actionable findings. Review scanner coverage before treating this as assurance.');
   }
   if (result.skippedResults) lines.push('', `Note: ${result.skippedResults} result(s) were skipped or truncated.`);
   return lines.join('\n');
@@ -124,6 +133,8 @@ export function registerDvalinCommand(program: Command): void {
     .option('--in-place', 'apply fixes in the selected workspace instead of an isolated worktree')
     .option('--max-fixes <count>', 'maximum findings sent to one remediation run', '20')
     .option('--provider <name>', 'override the configured model provider for remediation')
+    .option('--diff [ref]', 'only report on changed lines; optionally against a revision (e.g. origin/main...HEAD)')
+    .option('--staged', 'only report on changed lines in the git index')
     .action(async (inputPath: string, options: DvalinOptions) => {
       const root = path.resolve(process.cwd(), inputPath);
       const scanners = parseDvalinScannerIds(options.scanners);
@@ -137,7 +148,21 @@ export function registerDvalinCommand(program: Command): void {
       if (options.draftPr && options.inPlace) {
         throw new UsageError('--draft-pr requires the default isolated worktree; remove --in-place.');
       }
-      const result = await runDvalinScanSuite(root, { scanners, timeoutMs });
+      if (options.diff && options.staged) throw new UsageError('Use either --diff or --staged, not both.');
+      const scoped = Boolean(options.diff || options.staged);
+      if (scoped && shouldFix) {
+        // A repair may touch lines the diff never named, so verifying it needs
+        // to look wider than the scan did. Until that widening exists, refuse
+        // rather than verify against the wrong surface.
+        throw new UsageError('--diff and --staged scan only; they cannot be combined with --fix, --verify, or --draft-pr.');
+      }
+      const scope = scoped
+        ? await resolveDiffScope(root, {
+            staged: Boolean(options.staged),
+            ref: typeof options.diff === 'string' ? options.diff : undefined,
+          })
+        : undefined;
+      const result = await runDvalinScanSuite(root, { scanners, timeoutMs, scope });
       console.log(options.json ? JSON.stringify(result, null, 2) : renderDvalinResult(result, root, limit));
       let thresholdResult = result;
       if (shouldFix && result.findings.length) {

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -20,6 +20,7 @@ import {
   type DvalinScannerId,
   type DvalinScanSuiteResult,
 } from '../remediation/scannerSuite.js';
+import { resolveDiffScope, type DiffScope, type DiffScopeOptions } from '../remediation/diffScope.js';
 import { evaluateSecurityGate, findingFingerprint, type SecurityThreshold } from '../security/contracts.js';
 import {
   createSecurityWorkflow,
@@ -72,7 +73,7 @@ export type McpServerOptions = {
 
 export type McpServerDependencies = {
   executeRun: (request: HarnessRunRequest, hooks?: HarnessRunHooks) => Promise<HarnessRunExecution>;
-  runScan: (cwd: string, options: { scanners?: DvalinScannerId[]; timeoutMs?: number }) => Promise<DvalinScanSuiteResult>;
+  runScan: (cwd: string, options: { scanners?: DvalinScannerId[]; timeoutMs?: number; scope?: DiffScope }) => Promise<DvalinScanSuiteResult>;
   loadSession: (id: string) => Promise<Session | null>;
   renderReport: (runId: string) => string;
   latestRun: () => string | null;
@@ -103,6 +104,13 @@ const MCP_TOOLS = [
           description: 'Defaults to builtin only, which needs nothing installed. The others are used when on PATH.',
         },
         limit: { type: 'integer', minimum: 1, description: `Maximum findings returned (default ${DEFAULT_FINDING_LIMIT}).` },
+        diff: {
+          type: 'string',
+          description:
+            'Narrow the scan to changed lines only — use this after writing code, to see what your edit introduced rather than '
+            + "everything already in the repository. Accepts \"uncommitted\" (working tree vs HEAD, including new files), "
+            + '"staged" (the git index), or any git revision or range such as "origin/main...HEAD". Omit to scan the whole workspace.',
+        },
         timeout_seconds: { type: 'number', exclusiveMinimum: 0 },
         fail_on: {
           type: 'string',
@@ -300,9 +308,14 @@ async function callTool(
     const includePrompts = args.include_remediation_prompts === true;
     const threshold = optionalSecurityThreshold(args.fail_on) ?? 'high';
 
+    const scope = args.diff === undefined
+      ? undefined
+      : await resolveDiffScope(resolvedCwd, diffScopeOptions(requireString(args.diff, 'diff')));
+
     const result = await context.deps.runScan(resolvedCwd, {
       scanners,
       timeoutMs: timeoutSeconds === undefined ? undefined : timeoutSeconds * 1000,
+      scope,
     });
     const gate = evaluateSecurityGate({ result, threshold, mode: 'all' });
     const workflow = await context.deps.createWorkflow({ root: resolvedCwd, result, gate });
@@ -331,6 +344,7 @@ async function callTool(
       score: result.score,
       grade: result.grade,
       metrics: result.metrics,
+      ...(result.scope ? { scope: result.scope } : {}),
       totalFindings: result.findings.length,
       returnedFindings: findings.length,
       findings,
@@ -476,6 +490,13 @@ function rpcResult(id: JsonRpcId, result: unknown): JsonRpcResponse {
 
 function rpcError(id: JsonRpcId, code: number, message: string): JsonRpcResponse {
   return { jsonrpc: '2.0', id, error: { code, message } };
+}
+
+/** `uncommitted` and `staged` are names, not revisions; anything else is a ref. */
+function diffScopeOptions(value: string): DiffScopeOptions {
+  if (value === 'uncommitted') return {};
+  if (value === 'staged') return { staged: true };
+  return { ref: value };
 }
 
 function toolResult(

--- a/src/remediation/diffScope.ts
+++ b/src/remediation/diffScope.ts
@@ -1,0 +1,138 @@
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * The set of lines a scan should report on.
+ *
+ * A path present in `files` but absent from `lines` is in scope in full — that
+ * is how a newly added or untracked file is represented, since every line of it
+ * is new.
+ */
+export type DiffScope = {
+  /** What was compared, for reporting. */
+  ref: string;
+  /** Workspace-relative POSIX paths. */
+  files: Set<string>;
+  /** Changed line numbers on the new side, per path. */
+  lines: Map<string, Set<number>>;
+};
+
+export type DiffScopeOptions = {
+  /** A git revision or range. Defaults to uncommitted work against HEAD. */
+  ref?: string;
+  /** Compare the index instead of the working tree. */
+  staged?: boolean;
+};
+
+/**
+ * Refs reach `git` as a single argv element, so there is no shell to inject
+ * into — but a leading dash would still be read as a flag, and git's own ref
+ * grammar is narrower than "any string".
+ */
+const SAFE_REF = /^[A-Za-z0-9][A-Za-z0-9._/@{}~^:-]*$/;
+
+/** `@@ -old,count +new,count @@` — the new-side pair is what a scan reports on. */
+const HUNK_HEADER = /^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@/;
+
+export function assertSafeRef(ref: string): void {
+  if (!SAFE_REF.test(ref)) {
+    throw new Error(`Refusing to use '${ref}' as a git revision: expected a ref name or range.`);
+  }
+}
+
+/**
+ * Resolve which files and lines changed, so a scan can report on new work
+ * without drowning it in a repository's pre-existing findings.
+ */
+export async function resolveDiffScope(root: string, options: DiffScopeOptions = {}): Promise<DiffScope> {
+  const args = ['diff', '--unified=0', '--no-color', '--no-ext-diff', '--diff-filter=d'];
+  let ref: string;
+
+  if (options.staged) {
+    args.push('--cached');
+    ref = 'staged';
+  } else if (options.ref) {
+    assertSafeRef(options.ref);
+    args.push(options.ref);
+    ref = options.ref;
+  } else {
+    args.push('HEAD');
+    ref = 'HEAD';
+  }
+
+  const files = new Set<string>();
+  const lines = new Map<string, Set<number>>();
+  parseUnifiedDiff(await git(root, args), files, lines);
+
+  // An agent's new files are untracked, and `git diff` cannot see them. They
+  // are in scope whole — every line is new.
+  if (!options.staged && !options.ref) {
+    for (const file of await git(root, ['ls-files', '--others', '--exclude-standard']).then(splitLines)) {
+      files.add(file);
+    }
+  }
+
+  return { ref, files, lines };
+}
+
+/** Whether a finding at this path and line falls inside the scope. */
+export function isWithinDiffScope(scope: DiffScope, filePath: string, startLine: number | undefined): boolean {
+  if (!scope.files.has(filePath)) return false;
+  const changed = scope.lines.get(filePath);
+  // No line detail means the whole file is in scope.
+  if (changed === undefined) return true;
+  // A finding without a line cannot be placed, so keep it rather than lose it.
+  return startLine === undefined || changed.has(startLine);
+}
+
+function parseUnifiedDiff(diff: string, files: Set<string>, lines: Map<string, Set<number>>): void {
+  let current: string | undefined;
+
+  for (const line of diff.split('\n')) {
+    if (line.startsWith('+++ ')) {
+      const target = line.slice(4).trim();
+      current = target === '/dev/null' ? undefined : stripDiffPrefix(target);
+      if (current) files.add(current);
+      continue;
+    }
+
+    if (!current) continue;
+
+    const hunk = HUNK_HEADER.exec(line);
+    if (!hunk) continue;
+
+    const start = Number(hunk[1]);
+    // An absent count means one line; an explicit zero means the hunk only
+    // removed lines, and there is nothing on the new side to scan.
+    const count = hunk[2] === undefined ? 1 : Number(hunk[2]);
+    if (count === 0) continue;
+
+    let changed = lines.get(current);
+    if (!changed) {
+      changed = new Set<number>();
+      lines.set(current, changed);
+    }
+    for (let offset = 0; offset < count; offset += 1) changed.add(start + offset);
+  }
+}
+
+/** `+++ b/src/app.ts` → `src/app.ts`. Quoted paths keep git's own escaping. */
+function stripDiffPrefix(target: string): string {
+  return target.replace(/^[abciow]\//, '');
+}
+
+function splitLines(output: string): string[] {
+  return output.split('\n').map(line => line.trim()).filter(Boolean);
+}
+
+async function git(root: string, args: string[]): Promise<string> {
+  try {
+    const { stdout } = await execFileAsync('git', args, { cwd: root, maxBuffer: 32 * 1024 * 1024 });
+    return stdout;
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    throw new Error(`git ${args.join(' ')} failed: ${detail}`);
+  }
+}

--- a/src/remediation/localScan.ts
+++ b/src/remediation/localScan.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 import fg from 'fast-glob';
 import { loadIgnorePatterns } from '../core/ignorefile.js';
 import { resolveRelativeInside, resolveWorkspaceRoot } from '../core/workspace.js';
+import { isWithinDiffScope, type DiffScope } from './diffScope.js';
 import { buildRemediationPrompt, type RemediationFinding, type SarifImportResult } from './sarif.js';
 
 const DEFAULT_IGNORES = [
@@ -24,11 +25,33 @@ const DEFAULT_IGNORES = [
   '**/eval/swebench/workspaces/**',
   '**/eval/swebench/cache/**',
   '**/*.min.js',
+  // Minifiers are not consistent about the separator, and `foo-min.js` is
+  // common enough that missing it means reporting on vendored bundles.
+  '**/*-min.js',
   '**/*-lock.json',
   '**/package-lock.json',
   '**/pnpm-lock.yaml',
   '**/yarn.lock',
+  // Vendored third-party code. Real findings here belong upstream, and the
+  // reader of this report cannot act on them.
+  '**/vendor/**',
+  '**/vendored/**',
+  '**/third_party/**',
+  '**/third-party/**',
 ];
+
+/**
+ * Test code is not production attack surface: credentials in a test are
+ * fixtures, `innerHTML` in a harness is teardown, and reporting on either
+ * trains people to ignore the tool. Rules precise enough to mean a real leak
+ * opt back in with `reportInTests`.
+ */
+const TEST_DIRECTORY = /(?:^|\/)(?:tests?|specs?|__tests__|__mocks__|testdata)\//i;
+const TEST_FILENAME = /(?:^|\/)[^/]*\.(?:test|spec)\.[cm]?[jt]sx?$/i;
+
+function isTestPath(file: string): boolean {
+  return TEST_DIRECTORY.test(file) || TEST_FILENAME.test(file);
+}
 
 const SCANNABLE_EXTENSIONS = new Set([
   '.cjs',
@@ -64,7 +87,22 @@ type LocalRule = {
   helpUri: string;
   pattern: RegExp;
   message: (match: RegExpMatchArray) => string;
+  /** Report in test code too. Only for patterns precise enough to mean a real leak. */
+  reportInTests?: boolean;
 };
+
+/**
+ * A bare verb is not a statement: `'delete ' + name` is an HTTP message, not
+ * SQL. Requiring the companion keyword — FROM, INTO, SET — is what separates a
+ * query from an English sentence that happens to start with the same word.
+ */
+const SQL_STATEMENT = String.raw`(?:SELECT\b[^'"\`]*\bFROM|DELETE\b[^'"\`]*\bFROM|INSERT\b[^'"\`]*\bINTO|UPDATE\b[^'"\`]*\bSET)`;
+
+const SQL_CONCATENATION = new RegExp(
+  String.raw`['"\`]\s*${SQL_STATEMENT}\b[^;\n]*['"\`]\s*\+`
+  + String.raw`|\+\s*['"\`]\s*${SQL_STATEMENT}\b`,
+  'i',
+);
 
 const RULES: LocalRule[] = [
   {
@@ -86,6 +124,8 @@ const RULES: LocalRule[] = [
     helpUri: 'https://cwe.mitre.org/data/definitions/798.html',
     pattern: /\bAKIA[0-9A-Z]{16}\b/,
     message: () => 'Possible AWS access key literal. Revoke the key if real and replace it with secret-managed credentials.',
+    // A key in the shape of a real one is an incident wherever it is committed.
+    reportInTests: true,
   },
   {
     id: 'dvalin/sql-string-concatenation',
@@ -94,8 +134,20 @@ const RULES: LocalRule[] = [
     securitySeverity: '8.8',
     tags: ['security', 'sql-injection', 'cwe-089'],
     helpUri: 'https://cwe.mitre.org/data/definitions/89.html',
-    pattern: /['"`]\s*(?:SELECT|INSERT|UPDATE|DELETE)\b[^;\n]*['"`]\s*\+|\+\s*['"`]\s*(?:SELECT|INSERT|UPDATE|DELETE)\b/i,
+    pattern: SQL_CONCATENATION,
     message: () => 'SQL appears to be built with string concatenation. Use parameterized queries or a safe query builder.',
+  },
+  {
+    id: 'dvalin/nosql-injection',
+    name: 'NoSQL query built from untrusted input',
+    severity: 'error',
+    securitySeverity: '9.0',
+    tags: ['security', 'nosql-injection', 'cwe-943'],
+    helpUri: 'https://cwe.mitre.org/data/definitions/943.html',
+    // `$where` runs JavaScript on the database server, so an interpolated or
+    // concatenated value there is remote code execution, not just a bad query.
+    pattern: /\$where\s*:\s*(?:`[^`]*\$\{[^`]*`|['"][^'"]*['"]\s*\+)/,
+    message: () => '$where runs JavaScript on the database server and this query interpolates a value into it. Use a structured query, or validate and cast the value first.',
   },
   {
     id: 'dvalin/dom-html-injection',
@@ -151,6 +203,15 @@ function snippetFor(lines: string[], lineNumber: number): string {
     .join('\n');
 }
 
+/**
+ * A line that only documents a risk — `// never eval() user input` — is not
+ * the risk. Only whole-line comments are skipped, so trailing notes on real
+ * code (`const x = eval(y); // FIXME`) still report.
+ */
+function isCommentLine(trimmed: string): boolean {
+  return /^(?:\/\/|#|\*|\/\*)/.test(trimmed);
+}
+
 function isLikelyPlaceholder(line: string): boolean {
   return /\b(example|sample|fixture|placeholder|dummy|changeme|fake|invalid|do[-_]?not[-_]?log|your[-_]?key|not[-_]?real|test[-_]?only)\b/i.test(line);
 }
@@ -171,7 +232,7 @@ async function readScannableFile(root: string, file: string): Promise<string | u
   }
 }
 
-export async function runLocalSecurityScan(cwd: string): Promise<SarifImportResult> {
+export async function runLocalSecurityScan(cwd: string, scope?: DiffScope): Promise<SarifImportResult> {
   const root = await resolveWorkspaceRoot(cwd);
   const ignore = [...DEFAULT_IGNORES, ...(await loadIgnorePatterns(root))];
   const files = (await fg('**/*', {
@@ -182,6 +243,7 @@ export async function runLocalSecurityScan(cwd: string): Promise<SarifImportResu
     followSymbolicLinks: false,
   }))
     .filter(isScannableFile)
+    .filter(file => scope === undefined || scope.files.has(file))
     .sort();
 
   const findings: RemediationFinding[] = [];
@@ -195,8 +257,24 @@ export async function runLocalSecurityScan(cwd: string): Promise<SarifImportResu
       continue;
     }
 
+    const rules = isTestPath(file) ? RULES.filter(rule => rule.reportInTests) : RULES;
+    if (rules.length === 0) continue;
+
     const lines = content.split(/\r?\n/);
+    let inBlockComment = false;
     for (const [lineIndex, line] of lines.entries()) {
+      const trimmed = line.trim();
+      const wasInBlockComment = inBlockComment;
+      if (inBlockComment) {
+        if (trimmed.includes('*/')) inBlockComment = false;
+      } else if (trimmed.startsWith('/*') && !trimmed.includes('*/')) {
+        inBlockComment = true;
+      }
+      if (wasInBlockComment || isCommentLine(trimmed)) continue;
+
+      // After the comment state is updated, so a scoped scan cannot desync it.
+      if (scope !== undefined && !isWithinDiffScope(scope, file, lineIndex + 1)) continue;
+
       if (findings.length >= MAX_FINDINGS) {
         skippedResults += 1;
         continue;
@@ -204,7 +282,7 @@ export async function runLocalSecurityScan(cwd: string): Promise<SarifImportResu
 
       if (isLikelyPlaceholder(line)) continue;
 
-      for (const rule of RULES) {
+      for (const rule of rules) {
         const match = line.match(rule.pattern);
         if (!match) continue;
         if (isBenignSecretLikeValue(rule, match)) continue;

--- a/src/remediation/scannerSuite.ts
+++ b/src/remediation/scannerSuite.ts
@@ -5,6 +5,7 @@ import { randomUUID } from 'node:crypto';
 import { checkCommand, loadPolicy } from '../core/policy.js';
 import { buildShellScript, runGovernedExecutable } from '../core/subprocessSandbox.js';
 import { resolveWorkspaceRoot } from '../core/workspace.js';
+import { isWithinDiffScope, type DiffScope } from './diffScope.js';
 import { runLocalSecurityScan } from './localScan.js';
 import { parseSarifForRemediation, type RemediationFinding } from './sarif.js';
 
@@ -57,6 +58,8 @@ export type DvalinScanSuiteResult = {
   skippedResults: number;
   scanners: DvalinScannerRun[];
   metrics: DvalinScanMetrics;
+  /** Set when the scan was narrowed to a diff; absent for a whole-workspace scan. */
+  scope?: { ref: string; files: number };
 };
 
 type ExternalScanner = {
@@ -177,7 +180,7 @@ export async function installDvalinScanner(cwd: string, id: DvalinScannerId): Pr
 
 export async function runDvalinScanSuite(
   cwd: string,
-  options: { scanners?: DvalinScannerId[]; timeoutMs?: number } = {},
+  options: { scanners?: DvalinScannerId[]; timeoutMs?: number; scope?: DiffScope } = {},
 ): Promise<DvalinScanSuiteResult> {
   const root = await resolveWorkspaceRoot(cwd);
   const started = new Date();
@@ -189,7 +192,7 @@ export async function runDvalinScanSuite(
 
   if (selected.has('builtin')) {
     const t0 = Date.now();
-    const result = await runLocalSecurityScan(root);
+    const result = await runLocalSecurityScan(root, options.scope);
     findings.push(...result.findings);
     totalResults += result.totalResults;
     skippedResults += result.skippedResults;
@@ -272,7 +275,13 @@ export async function runDvalinScanSuite(
     await rm(resolvedOutputDir, { recursive: true, force: true });
   }
 
-  const deduped = dedupeFindings(findings);
+  // The builtin scanner is narrowed before it reads anything, but the external
+  // ones only take a root. Filtering here catches all of them at once, because
+  // `normalizeSarifPath` has already made every path workspace-relative.
+  const scoped = options.scope === undefined
+    ? findings
+    : findings.filter(finding => isWithinDiffScope(options.scope!, finding.path, finding.startLine));
+  const deduped = dedupeFindings(scoped);
   const metrics = scanMetrics(deduped);
   const score = scoreFindings(metrics);
   return {
@@ -287,6 +296,7 @@ export async function runDvalinScanSuite(
     skippedResults,
     scanners: runs,
     metrics,
+    ...(options.scope === undefined ? {} : { scope: { ref: options.scope.ref, files: options.scope.files.size } }),
   };
 }
 

--- a/tests/fixtures/scanCorpus.ts
+++ b/tests/fixtures/scanCorpus.ts
@@ -1,0 +1,173 @@
+import { mkdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+/**
+ * Two corpora that pin the builtin scanner against real-world code.
+ *
+ * They reproduce the patterns measured on two public repositories:
+ *
+ * - `MATURE_LIBRARY` mirrors what `axios` looks like to the scanner. Everything
+ *   here is a false positive the scanner produced on that repository: test
+ *   fixtures that read like credentials, DOM teardown in a test harness, and a
+ *   vendored third-party file whose name evades the `**\/*.min.js` ignore.
+ *   A well-audited library must scan silent.
+ *
+ * - `VULNERABLE_APP` mirrors OWASP NodeGoat: genuinely exploitable sinks that
+ *   the scanner must report, alongside the same vendored noise it must not.
+ *
+ * Files are written at run time rather than committed as fixtures so this
+ * repository's own scanners have nothing to flag. The `// scanner fixture`
+ * markers keep the *source* lines below out of the builtin scanner too — see
+ * `isLikelyPlaceholder` in src/remediation/localScan.ts.
+ */
+export type CorpusFile = { path: string; content: string };
+
+/** A well-audited library. Every line here has been a false positive. */
+export const MATURE_LIBRARY: CorpusFile[] = [
+  {
+    path: 'src/core/dispatchRequest.js',
+    content: [
+      'export function dispatchRequest(config) {',
+      '  return config.adapter(config);',
+      '}',
+      '',
+    ].join('\n'),
+  },
+  {
+    // Credentials in a test are fixtures, not secrets. The value deliberately
+    // avoids the words `isLikelyPlaceholder` already knows about, because that
+    // is exactly how the real ones slipped through.
+    path: 'test/unit/auth.test.js',
+    content: [
+      "import { describe, it } from 'vitest';",
+      '',
+      "describe('auth', () => {",
+      "  it('sends basic auth', async () => {",
+      '    await request({',
+      '      auth: {',
+      "        username: 'janedoe',", // scanner fixture
+      "        password: 'correcthorsebatterystaple',", // scanner fixture
+      '      },',
+      '    });',
+      '  });',
+      '});',
+      '',
+    ].join('\n'),
+  },
+  {
+    // The same fixture repeated across module formats and smoke suites. The
+    // repetition is the point: false positives scale with how thoroughly a
+    // project tests itself, which is backwards.
+    path: 'test/smoke/esm/auth.smoke.test.js',
+    content: [
+      'const response = await requestWithConfig({',
+      '  auth: {',
+      "    username: 'janedoe',", // scanner fixture
+      "    password: 'correcthorsebatterystaple',", // scanner fixture
+      '  },',
+      '});',
+      '',
+    ].join('\n'),
+  },
+  {
+    path: 'test/module/cjs/cjs-typing.test.cjs',
+    content: [
+      'const config = {',
+      '  withCredentials: true,',
+      '  auth: {',
+      "    username: 'janedoe',", // scanner fixture
+      "    password: 'correcthorsebatterystaple',", // scanner fixture
+      '  },',
+      '};',
+      '',
+    ].join('\n'),
+  },
+  {
+    path: 'test/unit/prototypePollution.test.js',
+    content: [
+      'const session = {',
+      "  role: 'viewer',",
+      '  isAdmin: false,',
+      "  token: 'aaaaaaaabbbbbbbbccccccccdddddddd',", // scanner fixture
+      '};',
+      '',
+    ].join('\n'),
+  },
+  {
+    // Clearing the DOM between tests is teardown, not an XSS sink.
+    path: 'test/setup/browser.setup.js',
+    content: [
+      "import { afterEach } from 'vitest';",
+      '',
+      'afterEach(() => {',
+      "  document.body.innerHTML = '';", // scanner fixture
+      '});',
+      '',
+    ].join('\n'),
+  },
+  {
+    // Vendored third-party code. Named `-min` rather than `.min`, so the
+    // existing `**/*.min.js` ignore does not cover it.
+    path: 'assets/vendor/html5shiv-min.js',
+    content: [
+      '/*! HTML5 Shiv 3.7.3 | MIT/GPL2 Licensed */',
+      'function shivDocument(doc) {',
+      "  var frag = doc.createElement('div');",
+      "  frag.innerHTML = '<x-element></x-element>';", // scanner fixture
+      '  return frag;',
+      '}',
+      '',
+    ].join('\n'),
+  },
+];
+
+/** A deliberately vulnerable application. The real sinks must be reported. */
+export const VULNERABLE_APP: CorpusFile[] = [
+  {
+    // Dynamic evaluation of request input.
+    path: 'app/routes/contributions.js',
+    content: [
+      "router.post('/contributions', (req, res) => {",
+      '  const preTax = eval(req.body.preTax);', // scanner fixture
+      '  const afterTax = eval(req.body.afterTax);', // scanner fixture
+      '  res.json({ preTax, afterTax });',
+      '});',
+      '',
+    ].join('\n'),
+  },
+  {
+    // Server-side JavaScript evaluation in a Mongo query: user input is
+    // interpolated straight into `$where`.
+    path: 'app/data/allocations-dao.js',
+    content: [
+      'function search(userId, threshold) {',
+      "  return db.collection('allocations').find({", // scanner fixture
+      '    $where: `this.userId == ${userId} && this.stocks > ${threshold}`,', // scanner fixture
+      '  });',
+      '}',
+      '',
+    ].join('\n'),
+  },
+  {
+    // The same vendored noise as the mature corpus: still not a finding, even
+    // in a repository that has real ones.
+    path: 'app/assets/vendor/html5shiv-min.js',
+    content: [
+      '/*! HTML5 Shiv 3.7.3 | MIT/GPL2 Licensed */',
+      'function shivDocument(doc) {',
+      "  var frag = doc.createElement('div');",
+      "  frag.innerHTML = '<x-element></x-element>';", // scanner fixture
+      '  return frag;',
+      '}',
+      '',
+    ].join('\n'),
+  },
+];
+
+export async function materializeCorpus(root: string, corpus: CorpusFile[]): Promise<void> {
+  for (const file of corpus) {
+    const absolute = path.join(root, file.path);
+    await mkdir(path.dirname(absolute), { recursive: true });
+    await writeFile(absolute, file.content, 'utf8');
+  }
+}

--- a/tests/remediationDiffScope.test.ts
+++ b/tests/remediationDiffScope.test.ts
@@ -1,0 +1,228 @@
+import { execFile } from 'node:child_process';
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { promisify } from 'node:util';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { assertSafeRef, isWithinDiffScope, resolveDiffScope } from '../src/remediation/diffScope.js';
+import { runLocalSecurityScan } from '../src/remediation/localScan.js';
+import { runDvalinScanSuite } from '../src/remediation/scannerSuite.js';
+
+const execFileAsync = promisify(execFile);
+
+describe('resolveDiffScope', () => {
+  let cwd: string;
+
+  const git = (...args: string[]) => execFileAsync('git', args, { cwd });
+
+  const commit = async (message: string) => {
+    await git('add', '-A');
+    await git('-c', 'user.email=test@example.com', '-c', 'user.name=Test', 'commit', '-q', '-m', message);
+  };
+
+  beforeEach(async () => {
+    cwd = await mkdtemp(path.join(tmpdir(), 'dvalin-diff-scope-'));
+    await mkdir(path.join(cwd, 'src'), { recursive: true });
+    await git('init', '-q', '-b', 'main');
+    await writeFile(
+      path.join(cwd, 'src', 'app.ts'),
+      ['const a = 1;', 'const b = 2;', 'const c = 3;', 'const d = 4;'].join('\n') + '\n',
+      'utf8',
+    );
+    await commit('base');
+  });
+
+  afterEach(async () => {
+    await rm(cwd, { recursive: true, force: true });
+  });
+
+  it('scopes to the lines an uncommitted edit touched', async () => {
+    await writeFile(
+      path.join(cwd, 'src', 'app.ts'),
+      ['const a = 1;', 'const b = 22;', 'const c = 3;', 'const d = 4;'].join('\n') + '\n',
+      'utf8',
+    );
+
+    const scope = await resolveDiffScope(cwd);
+
+    expect([...scope.files]).toEqual(['src/app.ts']);
+    expect([...(scope.lines.get('src/app.ts') ?? [])]).toEqual([2]);
+  });
+
+  it('puts an untracked file in scope in full', async () => {
+    await writeFile(path.join(cwd, 'src', 'fresh.ts'), 'const e = 5;\n', 'utf8');
+
+    const scope = await resolveDiffScope(cwd);
+
+    expect([...scope.files]).toEqual(['src/fresh.ts']);
+    expect(scope.lines.has('src/fresh.ts')).toBe(false);
+    expect(isWithinDiffScope(scope, 'src/fresh.ts', 999)).toBe(true);
+  });
+
+  it('records every line of a multi-line insertion', async () => {
+    await writeFile(
+      path.join(cwd, 'src', 'app.ts'),
+      ['const a = 1;', 'const x = 9;', 'const y = 9;', 'const b = 2;', 'const c = 3;', 'const d = 4;'].join('\n') + '\n',
+      'utf8',
+    );
+
+    const scope = await resolveDiffScope(cwd);
+
+    expect([...(scope.lines.get('src/app.ts') ?? [])]).toEqual([2, 3]);
+  });
+
+  it('records nothing for a hunk that only removed lines', async () => {
+    await writeFile(
+      path.join(cwd, 'src', 'app.ts'),
+      ['const a = 1;', 'const c = 3;', 'const d = 4;'].join('\n') + '\n',
+      'utf8',
+    );
+
+    const scope = await resolveDiffScope(cwd);
+
+    expect(scope.files.has('src/app.ts')).toBe(true);
+    expect(scope.lines.get('src/app.ts')).toBeUndefined();
+    expect(isWithinDiffScope(scope, 'src/app.ts', 2)).toBe(true);
+  });
+
+  it('reads the index when asked for staged changes, and ignores untracked files', async () => {
+    await writeFile(
+      path.join(cwd, 'src', 'app.ts'),
+      ['const a = 11;', 'const b = 2;', 'const c = 3;', 'const d = 4;'].join('\n') + '\n',
+      'utf8',
+    );
+    await git('add', 'src/app.ts');
+    await writeFile(path.join(cwd, 'src', 'untracked.ts'), 'const z = 0;\n', 'utf8');
+
+    const scope = await resolveDiffScope(cwd, { staged: true });
+
+    expect(scope.ref).toBe('staged');
+    expect([...scope.files]).toEqual(['src/app.ts']);
+    expect([...(scope.lines.get('src/app.ts') ?? [])]).toEqual([1]);
+  });
+
+  it('compares against a named revision', async () => {
+    await writeFile(
+      path.join(cwd, 'src', 'app.ts'),
+      ['const a = 1;', 'const b = 2;', 'const c = 3;', 'const d = 44;'].join('\n') + '\n',
+      'utf8',
+    );
+    await commit('second');
+
+    const scope = await resolveDiffScope(cwd, { ref: 'HEAD~1' });
+
+    expect(scope.ref).toBe('HEAD~1');
+    expect([...(scope.lines.get('src/app.ts') ?? [])]).toEqual([4]);
+  });
+
+  it('refuses a revision that could be read as a flag', async () => {
+    expect(() => assertSafeRef('--upload-pack=touch /tmp/pwned')).toThrow(/Refusing to use/);
+    expect(() => assertSafeRef('-x')).toThrow(/Refusing to use/);
+    await expect(resolveDiffScope(cwd, { ref: '--output=/tmp/x' })).rejects.toThrow(/Refusing to use/);
+  });
+
+  it('accepts an ordinary ref range', () => {
+    expect(() => assertSafeRef('origin/main...HEAD')).not.toThrow();
+    expect(() => assertSafeRef('HEAD~3')).not.toThrow();
+  });
+});
+
+describe('runLocalSecurityScan with a diff scope', () => {
+  let cwd: string;
+
+  const git = (...args: string[]) => execFileAsync('git', args, { cwd });
+
+  beforeEach(async () => {
+    cwd = await mkdtemp(path.join(tmpdir(), 'dvalin-diff-scan-'));
+    await mkdir(path.join(cwd, 'src'), { recursive: true });
+    await git('init', '-q', '-b', 'main');
+  });
+
+  afterEach(async () => {
+    await rm(cwd, { recursive: true, force: true });
+  });
+
+  it('reports the risk the edit introduced and not the one already there', async () => {
+    await writeFile(
+      path.join(cwd, 'src', 'legacy.ts'),
+      [
+        'export function old(input: string) {',
+        '  return eval(input);', // scanner fixture
+        '}',
+      ].join('\n') + '\n',
+      'utf8',
+    );
+    await git('add', '-A');
+    await git('-c', 'user.email=test@example.com', '-c', 'user.name=Test', 'commit', '-q', '-m', 'base');
+
+    // An agent appends a new risk to a file that already had one.
+    await writeFile(
+      path.join(cwd, 'src', 'legacy.ts'),
+      [
+        'export function old(input: string) {',
+        '  return eval(input);', // scanner fixture
+        '}',
+        'export function added(req: any) {',
+        '  return exec("grep " + req.query.name);', // scanner fixture
+        '}',
+      ].join('\n') + '\n',
+      'utf8',
+    );
+
+    const wholeWorkspace = await runLocalSecurityScan(cwd);
+    expect(wholeWorkspace.findings.map(finding => finding.ruleId).sort())
+      .toEqual(['dvalin/eval', 'dvalin/shell-command-injection']);
+
+    const scoped = await runLocalSecurityScan(cwd, await resolveDiffScope(cwd));
+    expect(scoped.findings.map(finding => `${finding.ruleId}:${finding.startLine}`))
+      .toEqual(['dvalin/shell-command-injection:5']);
+  });
+
+  it('reports nothing when the diff is empty', async () => {
+    await writeFile(path.join(cwd, 'src', 'app.ts'), 'const apiKey = "sk-live-1234567890abcdef";\n', 'utf8'); // scanner fixture
+    await git('add', '-A');
+    await git('-c', 'user.email=test@example.com', '-c', 'user.name=Test', 'commit', '-q', '-m', 'base');
+
+    const scoped = await runLocalSecurityScan(cwd, await resolveDiffScope(cwd));
+
+    expect(scoped.findings).toEqual([]);
+  });
+});
+
+describe('runDvalinScanSuite with a diff scope', () => {
+  let cwd: string;
+
+  const git = (...args: string[]) => execFileAsync('git', args, { cwd });
+
+  beforeEach(async () => {
+    cwd = await mkdtemp(path.join(tmpdir(), 'dvalin-diff-suite-'));
+    await mkdir(path.join(cwd, 'src'), { recursive: true });
+    await git('init', '-q', '-b', 'main');
+  });
+
+  afterEach(async () => {
+    await rm(cwd, { recursive: true, force: true });
+  });
+
+  it('reports what the scan was narrowed to, and drops findings outside it', async () => {
+    await writeFile(path.join(cwd, 'src', 'old.ts'), 'const preTax = eval(raw);\n', 'utf8'); // scanner fixture
+    await git('add', '-A');
+    await git('-c', 'user.email=test@example.com', '-c', 'user.name=Test', 'commit', '-q', '-m', 'base');
+    await writeFile(path.join(cwd, 'src', 'new.ts'), 'const afterTax = eval(raw);\n', 'utf8'); // scanner fixture
+
+    const scope = await resolveDiffScope(cwd);
+    const result = await runDvalinScanSuite(cwd, { scanners: ['builtin'], scope });
+
+    expect(result.scope).toEqual({ ref: 'HEAD', files: 1 });
+    expect(result.findings.map(finding => finding.path)).toEqual(['src/new.ts']);
+  });
+
+  it('leaves the result unscoped when no scope is given', async () => {
+    await writeFile(path.join(cwd, 'src', 'old.ts'), 'const preTax = eval(raw);\n', 'utf8'); // scanner fixture
+
+    const result = await runDvalinScanSuite(cwd, { scanners: ['builtin'] });
+
+    expect(result.scope).toBeUndefined();
+    expect(result.findings).toHaveLength(1);
+  });
+});

--- a/tests/remediationLocalScan.test.ts
+++ b/tests/remediationLocalScan.test.ts
@@ -80,12 +80,80 @@ describe('runLocalSecurityScan', () => {
     expect(result.findings).toEqual([]);
   });
 
+  it('does not report risks that are only described in comments', async () => {
+    await writeFile(
+      path.join(cwd, 'src', 'notes.ts'),
+      [
+        '// Insecure use of eval() to parse inputs — do not do this.', // scanner fixture
+        '/*',
+        '  const legacy = eval(req.body.amount);', // scanner fixture
+        '*/',
+        '# shell-style comment: exec(req.query.cmd)', // scanner fixture
+        'export const safe = true;',
+      ].join('\n'),
+      'utf8',
+    );
+
+    const result = await runLocalSecurityScan(cwd);
+
+    expect(result.findings).toEqual([]);
+  });
+
+  it('still reports real code carrying a trailing comment', async () => {
+    await writeFile(
+      path.join(cwd, 'src', 'parse.ts'),
+      'const preTax = eval(req.body.preTax); // FIXME: parse properly\n', // scanner fixture
+      'utf8',
+    );
+
+    const result = await runLocalSecurityScan(cwd);
+
+    expect(result.findings.map(finding => finding.ruleId)).toEqual(['dvalin/eval']);
+  });
+
+  it('reports NoSQL injection through an interpolated $where', async () => {
+    await writeFile(
+      path.join(cwd, 'src', 'dao.ts'),
+      [
+        'export function search(userId: string) {',
+        "  return db.collection('allocations').find({", // scanner fixture
+        '    $where: `this.userId == ${userId}`,', // scanner fixture
+        '  });',
+        '}',
+      ].join('\n'),
+      'utf8',
+    );
+
+    const result = await runLocalSecurityScan(cwd);
+
+    expect(result.findings.map(finding => finding.ruleId)).toEqual(['dvalin/nosql-injection']);
+  });
+
+  it('treats credentials in test files as fixtures, but never an AWS key', async () => {
+    await mkdir(path.join(cwd, 'test'), { recursive: true });
+    await writeFile(
+      path.join(cwd, 'test', 'auth.test.ts'),
+      [
+        "const password = 'correcthorsebatterystaple';", // scanner fixture
+        "const key = 'AKIAIOSFODNN7EXAMPLE';", // scanner fixture
+      ].join('\n'),
+      'utf8',
+    );
+
+    const result = await runLocalSecurityScan(cwd);
+
+    expect(result.findings.map(finding => finding.ruleId)).toEqual(['dvalin/aws-access-key']);
+  });
+
   it('does not confuse ordinary strings containing update verbs with SQL concatenation', async () => {
     await writeFile(
       path.join(cwd, 'src', 'network.ts'),
       [
         "const headers = { Accept: 'application/json', 'User-Agent': 'product-update' };",
         "if (args.includes('update')) return true;",
+        // A response message that opens with a SQL verb but is not a query.
+        "res.send('delete ' + escapeHtml(req.params.uid) + Chr(39) + 's pet');", // scanner fixture
+        "res.send('select a plan ' + planName);", // scanner fixture
       ].join('\n'),
       'utf8',
     );

--- a/tests/scanCorpus.test.ts
+++ b/tests/scanCorpus.test.ts
@@ -1,0 +1,133 @@
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { runDvalinScanSuite } from '../src/remediation/scannerSuite.js';
+import { MATURE_LIBRARY, VULNERABLE_APP, materializeCorpus } from './fixtures/scanCorpus.js';
+
+const ROOT_PREFIX = 'dvalin-scan-corpus-';
+
+/** Only the builtin scanner: the external ones are absent on most machines. */
+const corpusScan = (root: string) => runDvalinScanSuite(root, { scanners: ['builtin'] });
+
+/**
+ * Acceptance criteria for the builtin scanner, measured against the shape of
+ * real repositories rather than hand-picked one-liners.
+ *
+ * The bar is not "does it match a regex" but "would a developer trust this":
+ * a well-audited library must scan silent, a deliberately vulnerable app must
+ * not, and the score must be able to tell the two apart.
+ */
+describe('builtin scanner, against real-world code shapes', () => {
+  let cwd: string;
+
+  beforeEach(async () => {
+    cwd = await mkdtemp(path.join(tmpdir(), ROOT_PREFIX));
+  });
+
+  afterEach(async () => {
+    await rm(cwd, { recursive: true, force: true });
+  });
+
+  describe('a well-audited library scans silent', () => {
+    beforeEach(async () => {
+      await materializeCorpus(cwd, MATURE_LIBRARY);
+    });
+
+    it('reports nothing at all', async () => {
+      const result = await corpusScan(cwd);
+
+      expect(result.findings.map(finding => `${finding.ruleId} ${finding.path}:${finding.startLine}`)).toEqual([]);
+    });
+
+    it('grades it A', async () => {
+      const result = await corpusScan(cwd);
+
+      expect(result.score).toBe(100);
+      expect(result.grade).toBe('A');
+    });
+
+    it('does not read test credentials as secrets', async () => {
+      const result = await corpusScan(cwd);
+
+      expect(result.findings.filter(finding => finding.path.startsWith('test/'))).toEqual([]);
+    });
+
+    it('does not read DOM teardown in a test harness as an XSS sink', async () => {
+      const result = await corpusScan(cwd);
+
+      expect(result.findings.filter(finding => finding.ruleId === 'dvalin/dom-html-injection')).toEqual([]);
+    });
+
+    it('does not scan vendored third-party code', async () => {
+      const result = await corpusScan(cwd);
+
+      expect(result.findings.filter(finding => finding.path.includes('vendor/'))).toEqual([]);
+    });
+  });
+
+  describe('a deliberately vulnerable app does not', () => {
+    beforeEach(async () => {
+      await materializeCorpus(cwd, VULNERABLE_APP);
+    });
+
+    it('reports evaluation of request input', async () => {
+      const result = await corpusScan(cwd);
+
+      expect(result.findings.map(finding => finding.ruleId)).toContain('dvalin/eval');
+    });
+
+    it('reports NoSQL injection through an interpolated $where', async () => {
+      const result = await corpusScan(cwd);
+
+      const nosql = result.findings.filter(finding => finding.ruleId === 'dvalin/nosql-injection');
+      expect(nosql.map(finding => finding.path)).toEqual(['app/data/allocations-dao.js']);
+    });
+
+    it('still does not scan vendored third-party code', async () => {
+      const result = await corpusScan(cwd);
+
+      expect(result.findings.filter(finding => finding.path.includes('vendor/'))).toEqual([]);
+    });
+
+    it('grades it F', async () => {
+      const result = await corpusScan(cwd);
+
+      expect(result.grade).toBe('F');
+    });
+  });
+
+  /**
+   * The invariant the score exists to satisfy. Measured before this suite
+   * landed, the builtin scanner scored axios 11/100 and NodeGoat 37/100 — the
+   * deliberately vulnerable app scored three times better than the audited
+   * library, which makes the number worse than no number at all.
+   */
+  it('scores the vulnerable app below the audited library', async () => {
+    const mature = await mkdtemp(path.join(tmpdir(), ROOT_PREFIX));
+    const vulnerable = await mkdtemp(path.join(tmpdir(), ROOT_PREFIX));
+    try {
+      await materializeCorpus(mature, MATURE_LIBRARY);
+      await materializeCorpus(vulnerable, VULNERABLE_APP);
+
+      const [matureResult, vulnerableResult] = await Promise.all([
+        corpusScan(mature),
+        corpusScan(vulnerable),
+      ]);
+
+      expect(vulnerableResult.score).toBeLessThan(matureResult.score);
+    } finally {
+      await rm(mature, { recursive: true, force: true });
+      await rm(vulnerable, { recursive: true, force: true });
+    }
+  });
+
+  it('runs the builtin scanner and nothing else', async () => {
+    await materializeCorpus(cwd, MATURE_LIBRARY);
+
+    const result = await runDvalinScanSuite(cwd, { scanners: ['builtin'] });
+
+    expect(result.scanners.map(scanner => scanner.id)).toEqual(['builtin']);
+    expect(result.scanners[0].status).toBe('completed');
+  });
+});


### PR DESCRIPTION
## Summary

The builtin scanner's score was **anti-correlated with security**. Measured against real repositories before this change:

| repo | before | after |
|---|---|---|
| axios | 11/100 **F**, 8 findings — **all false positives** | **100 A, 0** |
| express | 88 B, 1 false positive | **100 A, 0** |
| OWASP NodeGoat | 37 F, 4 true + 3 false, missed the NoSQL injection | **42 F, 4 — all true** |
| juice-shop | — | **0 F, 25**, incl. its real `$where` NoSQLi challenges |

NodeGoat — deliberately vulnerable — scored **three times better than axios**, because false positives scale with how thoroughly a project tests itself. A number that ranks a hardened library below a teaching target is worse than no number at all.

Four causes, all in the builtin rules:

- **Vendored code was scanned.** `**/*.min.js` only matched a literal `.min.js`, so `raphael-min.js` slipped through.
- **Test fixtures were read as secrets**, and DOM teardown in a test harness (`document.body.innerHTML = ''`) as an XSS sink.
- **Comments were read as code.** `// Insecure use of eval() to parse inputs` was reported as an eval sink, as was commented-out code inside a `/* */` block.
- **The SQL rule matched a bare verb**, so `res.send('delete ' + escapeHtml(req.params.uid))` — an HTTP message with escaped input — was reported as SQL injection.

Adds `dvalin/nosql-injection` for a value interpolated into `$where`, which runs JavaScript on the database server. Both NodeGoat's and juice-shop's real NoSQL challenges were previously missed entirely.

### Diff-range scanning

Adds `src/remediation/diffScope.ts`, so a scan can answer *"did this edit introduce anything?"* rather than *"what is wrong with this repository?"*. That is the question worth asking after an agent writes code; it is also the only form quiet enough to run on every save, and the one that lets CI block what a change **adds** without failing on findings that were already there.

Untracked files are in scope in full — an agent's brand-new file is entirely new, and `git diff` cannot see it.

| surface | usage |
|---|---|
| CLI | `--diff [ref]` / `--staged` |
| MCP | `dvalin_scan` `diff`: `"uncommitted"` \| `"staged"` \| any ref |
| Action | `diff: true` (pull_request only; needs `fetch-depth: 0`, degrades to a full scan with a warning) |
| VS Code | `dvalin.scanScope`, defaulting to `changed` |

Two deliberate boundaries:

1. **A scoped run reports a finding count, not a health grade.** A score computed from a forty-line diff does not describe the repository. `--fail-on` still applies, so the CI gate keeps working.
2. **Scoping is refused alongside `--fix` / `--verify` / `--draft-pr`.** A repair can touch lines the diff never named, so verifying it has to look wider than the scan did. That widening does not exist yet, so the combination errors rather than verifying against the wrong surface.

## Testing

- `npm run check` — **401 passing**, typecheck clean, run on top of current `main`.
- `editors/vscode`: 31 passing.
- New: `tests/scanCorpus.test.ts` (two corpora — a well-audited library must scan silent, a vulnerable app must not, and the score must separate them), `tests/remediationDiffScope.test.ts` (hunk parsing, untracked files, staged/ref modes, unsafe-ref rejection, and end-to-end scoped scans).
- Verified by hand against real clones of axios, express, NodeGoat, and juice-shop — the table above is measured, not estimated.
- The MCP path was exercised over real stdio, confirming a pre-existing `eval` is excluded while newly written risks are reported.

Corpora are materialized into a tmpdir at run time and carry `// scanner fixture` markers, so this repository's own scan does not flag them — verified: it still scans 100 A, 0 findings.

## Security and AI Governance

- [x] This change does not expand file, shell, network, model, or approval permissions.
- [x] If it changes agent behavior, prompts, policy, providers, audit logging, or release/build security, I updated the relevant governance evidence in `docs/`.
- [x] If it introduces a new model/provider/tool or new data flow, I completed `docs/governance/AI-CHANGE-IMPACT-ASSESSMENT.md`.

`diffScope` shells out to `git` via `execFile` with no shell, and validates the revision against a ref grammar — a leading dash would otherwise be read as a flag, and `--upload-pack=` is a real attack surface. Scoping is read-only and narrows what is reported; it never widens what is read. `docs/DVALIN.md` gained a "Scanning only what changed" section covering the scope semantics and both boundaries above. No new model, provider, tool, or data flow, so no impact assessment was required.

## Notes

**Branch choice:** this session began on `codex/security-runtime-foundation`, but both of its commits had already been squash-merged into `main` (#178, #179), leaving it 12 behind / 2 ahead with duplicate content. A PR from there would have re-proposed ~2,600 already-merged lines and reverted intervening work, so this is a fresh branch off `main` carrying only the session's changes.

The unrelated `eval/swebench/**` deletions sitting in the working tree were left alone — they predate this session.

**Follow-up:** with `dvalin.scanScope` defaulting to `changed`, `scanOnSave` is finally viable — every save now reads only what you just wrote. The VS Code extension is built at v0.15.0 but has never been published to either the VS Code Marketplace or Open VSX; that is the remaining gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
