### PR TITLE
test(mcp): prove a real MCP client can drive the server, in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,39 @@ jobs:
           version: local
           fail-on: high
 
+  # Whether a real harness can drive the MCP server was checked once, by hand,
+  # against Claude Code 2.1.226 and Codex 0.147.0, and recorded in a pull
+  # request. Both have shipped many versions since, and nothing would have said
+  # so if the server had stopped working.
+  #
+  # This does not install those CLIs — they need credentials, which a pull
+  # request from a fork cannot have. It drives the built binary with the
+  # reference MCP client instead, over a real pipe, which covers the failure
+  # that actually happened: the server misreading the protocol. A client-side
+  # change still needs a human, but a regression of ours no longer does.
+  mcp-interop:
+    name: MCP client interoperability
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      # actions/checkout v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          persist-credentials: false
+      # actions/setup-node v6.4.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      # The suite drives dist/, so a missing build is the one way it could pass
+      # by doing nothing. DVALIN_REQUIRE_MCP_INTEROP turns that into a failure.
+      - run: npm run build
+      - run: npx vitest run tests/mcp/clientInterop.test.ts
+        env:
+          DVALIN_REQUIRE_MCP_INTEROP: '1'
+
   # The VS Code extension has its own package and tsconfig, so the root
   # `npm run check` does not reach it. Without this job it would be invisible to
   # CI the way src/gui is — broken only at publish time.

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -16,13 +16,13 @@ The project does not intentionally vendor third-party source code into this repo
 |---|---:|
 | 0BSD | 2 |
 | Apache-2.0 | 27 |
-| BSD-2-Clause | 1 |
-| BSD-3-Clause | 4 |
+| BSD-2-Clause | 2 |
+| BSD-3-Clause | 6 |
 | CC-BY-4.0 | 1 |
 | CC0-1.0 | 1 |
-| ISC | 17 |
-| MIT | 484 |
-| MPL-2.0 | 12 |
+| ISC | 20 |
+| MIT | 521 |
+| MPL-2.0 | 24 |
 
 ## Packages
 
@@ -54,9 +54,12 @@ The project does not intentionally vendor third-party source code into this repo
 | `@docsearch/css` | 3.8.2 | MIT | CLI package |  |
 | `@docsearch/js` | 3.8.2 | MIT | CLI package |  |
 | `@docsearch/react` | 3.8.2 | MIT | CLI package |  |
-| `@emnapi/core` | 1.11.1 | MIT | CLI package, Web package |  |
-| `@emnapi/runtime` | 1.11.1 | MIT | CLI package, Web package |  |
-| `@emnapi/wasi-threads` | 1.2.2 | MIT | CLI package, Web package |  |
+| `@emnapi/core` | 1.11.1 | MIT | CLI package |  |
+| `@emnapi/core` | 2.0.0-alpha.3 | MIT | Web package |  |
+| `@emnapi/runtime` | 1.11.1 | MIT | CLI package |  |
+| `@emnapi/runtime` | 2.0.0-alpha.3 | MIT | Web package |  |
+| `@emnapi/wasi-threads` | 1.2.2 | MIT | CLI package |  |
+| `@emnapi/wasi-threads` | 2.0.1 | MIT | Web package |  |
 | `@esbuild/aix-ppc64` | 0.28.1 | MIT | CLI package |  |
 | `@esbuild/android-arm` | 0.28.1 | MIT | CLI package |  |
 | `@esbuild/android-arm64` | 0.28.1 | MIT | CLI package |  |
@@ -83,6 +86,7 @@ The project does not intentionally vendor third-party source code into this repo
 | `@esbuild/win32-arm64` | 0.28.1 | MIT | CLI package |  |
 | `@esbuild/win32-ia32` | 0.28.1 | MIT | CLI package |  |
 | `@esbuild/win32-x64` | 0.28.1 | MIT | CLI package |  |
+| `@hono/node-server` | 2.1.1 | MIT | CLI package |  |
 | `@iconify-json/simple-icons` | 1.2.89 | CC0-1.0 | CLI package |  |
 | `@iconify/types` | 2.0.0 | MIT | CLI package |  |
 | `@jridgewell/gen-mapping` | 0.3.13 | MIT | Web package |  |
@@ -90,26 +94,44 @@ The project does not intentionally vendor third-party source code into this repo
 | `@jridgewell/resolve-uri` | 3.1.2 | MIT | Web package |  |
 | `@jridgewell/sourcemap-codec` | 1.5.5 | MIT | CLI package, Web package |  |
 | `@jridgewell/trace-mapping` | 0.3.31 | MIT | Web package |  |
-| `@napi-rs/wasm-runtime` | 1.1.6 | MIT | CLI package, Web package |  |
+| `@modelcontextprotocol/sdk` | 1.30.0 | MIT | CLI package |  |
+| `@napi-rs/wasm-runtime` | 1.1.6 | MIT | CLI package |  |
+| `@napi-rs/wasm-runtime` | 1.2.2 | MIT | Web package |  |
 | `@nodelib/fs.scandir` | 2.1.5 | MIT | CLI package |  |
 | `@nodelib/fs.stat` | 2.0.5 | MIT | CLI package |  |
 | `@nodelib/fs.walk` | 1.2.8 | MIT | CLI package |  |
-| `@oxc-project/types` | 0.139.0 | MIT | CLI package, Web package |  |
-| `@rolldown/binding-android-arm64` | 1.1.5 | MIT | CLI package, Web package |  |
-| `@rolldown/binding-darwin-arm64` | 1.1.5 | MIT | CLI package, Web package |  |
-| `@rolldown/binding-darwin-x64` | 1.1.5 | MIT | CLI package, Web package |  |
-| `@rolldown/binding-freebsd-x64` | 1.1.5 | MIT | CLI package, Web package |  |
-| `@rolldown/binding-linux-arm-gnueabihf` | 1.1.5 | MIT | CLI package, Web package |  |
-| `@rolldown/binding-linux-arm64-gnu` | 1.1.5 | MIT | CLI package, Web package |  |
-| `@rolldown/binding-linux-arm64-musl` | 1.1.5 | MIT | CLI package, Web package |  |
-| `@rolldown/binding-linux-ppc64-gnu` | 1.1.5 | MIT | CLI package, Web package |  |
-| `@rolldown/binding-linux-s390x-gnu` | 1.1.5 | MIT | CLI package, Web package |  |
-| `@rolldown/binding-linux-x64-gnu` | 1.1.5 | MIT | CLI package, Web package |  |
-| `@rolldown/binding-linux-x64-musl` | 1.1.5 | MIT | CLI package, Web package |  |
-| `@rolldown/binding-openharmony-arm64` | 1.1.5 | MIT | CLI package, Web package |  |
-| `@rolldown/binding-wasm32-wasi` | 1.1.5 | MIT | CLI package, Web package |  |
-| `@rolldown/binding-win32-arm64-msvc` | 1.1.5 | MIT | CLI package, Web package |  |
-| `@rolldown/binding-win32-x64-msvc` | 1.1.5 | MIT | CLI package, Web package |  |
+| `@oxc-project/types` | 0.139.0 | MIT | CLI package |  |
+| `@oxc-project/types` | 0.142.0 | MIT | Web package |  |
+| `@rolldown/binding-android-arm64` | 1.1.5 | MIT | CLI package |  |
+| `@rolldown/binding-android-arm64` | 1.2.1 | MIT | Web package |  |
+| `@rolldown/binding-darwin-arm64` | 1.1.5 | MIT | CLI package |  |
+| `@rolldown/binding-darwin-arm64` | 1.2.1 | MIT | Web package |  |
+| `@rolldown/binding-darwin-x64` | 1.1.5 | MIT | CLI package |  |
+| `@rolldown/binding-darwin-x64` | 1.2.1 | MIT | Web package |  |
+| `@rolldown/binding-freebsd-x64` | 1.1.5 | MIT | CLI package |  |
+| `@rolldown/binding-freebsd-x64` | 1.2.1 | MIT | Web package |  |
+| `@rolldown/binding-linux-arm-gnueabihf` | 1.1.5 | MIT | CLI package |  |
+| `@rolldown/binding-linux-arm-gnueabihf` | 1.2.1 | MIT | Web package |  |
+| `@rolldown/binding-linux-arm64-gnu` | 1.1.5 | MIT | CLI package |  |
+| `@rolldown/binding-linux-arm64-gnu` | 1.2.1 | MIT | Web package |  |
+| `@rolldown/binding-linux-arm64-musl` | 1.1.5 | MIT | CLI package |  |
+| `@rolldown/binding-linux-arm64-musl` | 1.2.1 | MIT | Web package |  |
+| `@rolldown/binding-linux-ppc64-gnu` | 1.1.5 | MIT | CLI package |  |
+| `@rolldown/binding-linux-ppc64-gnu` | 1.2.1 | MIT | Web package |  |
+| `@rolldown/binding-linux-s390x-gnu` | 1.1.5 | MIT | CLI package |  |
+| `@rolldown/binding-linux-s390x-gnu` | 1.2.1 | MIT | Web package |  |
+| `@rolldown/binding-linux-x64-gnu` | 1.1.5 | MIT | CLI package |  |
+| `@rolldown/binding-linux-x64-gnu` | 1.2.1 | MIT | Web package |  |
+| `@rolldown/binding-linux-x64-musl` | 1.1.5 | MIT | CLI package |  |
+| `@rolldown/binding-linux-x64-musl` | 1.2.1 | MIT | Web package |  |
+| `@rolldown/binding-openharmony-arm64` | 1.1.5 | MIT | CLI package |  |
+| `@rolldown/binding-openharmony-arm64` | 1.2.1 | MIT | Web package |  |
+| `@rolldown/binding-wasm32-wasi` | 1.1.5 | MIT | CLI package |  |
+| `@rolldown/binding-wasm32-wasi` | 1.2.1 | MIT | Web package |  |
+| `@rolldown/binding-win32-arm64-msvc` | 1.1.5 | MIT | CLI package |  |
+| `@rolldown/binding-win32-arm64-msvc` | 1.2.1 | MIT | Web package |  |
+| `@rolldown/binding-win32-x64-msvc` | 1.1.5 | MIT | CLI package |  |
+| `@rolldown/binding-win32-x64-msvc` | 1.2.1 | MIT | Web package |  |
 | `@rolldown/pluginutils` | 1.0.1 | MIT | CLI package, Web package |  |
 | `@rollup/rollup-android-arm-eabi` | 4.62.2 | MIT | CLI package |  |
 | `@rollup/rollup-android-arm64` | 4.62.2 | MIT | CLI package |  |
@@ -168,6 +190,7 @@ The project does not intentionally vendor third-party source code into this repo
 | `@tailwindcss/postcss` | 4.3.3 | MIT | Web package |  |
 | `@tybys/wasm-util` | 0.10.3 | MIT | CLI package, Web package |  |
 | `@types/body-parser` | 1.19.6 | MIT | CLI package |  |
+| `@types/bun` | 1.3.14 | MIT | CLI package |  |
 | `@types/chai` | 5.2.3 | MIT | CLI package |  |
 | `@types/connect` | 3.4.38 | MIT | CLI package |  |
 | `@types/cors` | 2.8.19 | MIT | CLI package |  |
@@ -184,11 +207,11 @@ The project does not intentionally vendor third-party source code into this repo
 | `@types/mdast` | 4.0.4 | MIT | CLI package, Web package |  |
 | `@types/mdurl` | 2.0.0 | MIT | CLI package |  |
 | `@types/ms` | 2.1.0 | MIT | Web package |  |
-| `@types/node` | 26.1.1 | MIT | CLI package |  |
+| `@types/node` | 26.2.0 | MIT | CLI package |  |
 | `@types/qs` | 6.15.1 | MIT | CLI package |  |
 | `@types/range-parser` | 1.2.7 | MIT | CLI package |  |
-| `@types/react` | 19.2.17 | MIT | Web package |  |
-| `@types/react-dom` | 19.2.3 | MIT | Web package |  |
+| `@types/react` | 19.2.18 | MIT | Web package |  |
+| `@types/react-dom` | 19.2.4 | MIT | Web package |  |
 | `@types/send` | 1.2.1 | MIT | CLI package |  |
 | `@types/serve-static` | 2.2.0 | MIT | CLI package |  |
 | `@types/unist` | 3.0.3 | MIT | CLI package, Web package |  |
@@ -216,7 +239,7 @@ The project does not intentionally vendor third-party source code into this repo
 | `@typescript/typescript-win32-x64` | 7.0.2 | Apache-2.0 | CLI package, Web package |  |
 | `@ungap/structured-clone` | 1.3.1 | ISC | Web package |  |
 | `@ungap/structured-clone` | 1.3.2 | ISC | CLI package |  |
-| `@vitejs/plugin-react` | 6.0.4 | MIT | Web package |  |
+| `@vitejs/plugin-react` | 6.0.5 | MIT | Web package |  |
 | `@vitest/expect` | 4.1.10 | MIT | CLI package |  |
 | `@vitest/mocker` | 4.1.10 | MIT | CLI package |  |
 | `@vitest/pretty-format` | 4.1.10 | MIT | CLI package |  |
@@ -243,6 +266,8 @@ The project does not intentionally vendor third-party source code into this repo
 | `@vueuse/metadata` | 12.8.2 | MIT | CLI package |  |
 | `@vueuse/shared` | 12.8.2 | MIT | CLI package |  |
 | `accepts` | 2.0.0 | MIT | CLI package |  |
+| `ajv` | 8.20.0 | MIT | CLI package |  |
+| `ajv-formats` | 3.0.1 | MIT | CLI package |  |
 | `algoliasearch` | 5.55.1 | MIT | CLI package |  |
 | `ansi-regex` | 6.2.2 | MIT | CLI package |  |
 | `ansi-styles` | 6.2.3 | MIT | CLI package |  |
@@ -255,6 +280,7 @@ The project does not intentionally vendor third-party source code into this repo
 | `body-parser/node_modules/content-type` | 2.0.0 | MIT | CLI package |  |
 | `braces` | 3.0.3 | MIT | CLI package |  |
 | `browserslist` | 4.28.6 | MIT | Web package |  |
+| `bun-types` | 1.3.14 | MIT | CLI package |  |
 | `bytes` | 3.1.2 | MIT | CLI package |  |
 | `call-bind-apply-helpers` | 1.0.2 | MIT | CLI package |  |
 | `call-bound` | 1.0.4 | MIT | CLI package |  |
@@ -278,6 +304,7 @@ The project does not intentionally vendor third-party source code into this repo
 | `cookie-signature` | 1.2.2 | MIT | CLI package |  |
 | `copy-anything` | 4.0.5 | MIT | CLI package |  |
 | `cors` | 2.8.6 | MIT | CLI package |  |
+| `cross-spawn` | 7.0.6 | MIT | CLI package |  |
 | `csstype` | 3.2.3 | MIT | CLI package, Web package |  |
 | `debug` | 4.4.3 | MIT | CLI package, Web package |  |
 | `decode-named-character-reference` | 1.3.0 | MIT | Web package |  |
@@ -304,11 +331,15 @@ The project does not intentionally vendor third-party source code into this repo
 | `estree-util-is-identifier-name` | 3.0.0 | MIT | Web package |  |
 | `estree-walker` | 3.0.3 | MIT | CLI package |  |
 | `etag` | 1.8.1 | MIT | CLI package |  |
+| `eventsource` | 3.0.7 | MIT | CLI package |  |
+| `eventsource-parser` | 3.1.1 | MIT | CLI package |  |
 | `expect-type` | 1.3.0 | Apache-2.0 | CLI package |  |
 | `express` | 5.2.1 | MIT | CLI package |  |
-| `express-rate-limit` | 8.6.1 | MIT | CLI package |  |
+| `express-rate-limit` | 8.6.2 | MIT | CLI package |  |
 | `extend` | 3.0.2 | MIT | Web package |  |
+| `fast-deep-equal` | 3.1.3 | MIT | CLI package |  |
 | `fast-glob` | 3.3.3 | MIT | CLI package |  |
+| `fast-uri` | 3.1.5 | BSD-3-Clause | CLI package |  |
 | `fastq` | 1.20.1 | ISC | CLI package |  |
 | `fdir` | 6.5.0 | MIT | Web package |  |
 | `fill-range` | 7.1.1 | MIT | CLI package |  |
@@ -333,7 +364,8 @@ The project does not intentionally vendor third-party source code into this repo
 | `hast-util-to-jsx-runtime` | 2.3.6 | MIT | Web package |  |
 | `hast-util-to-text` | 4.0.2 | MIT | Web package |  |
 | `hast-util-whitespace` | 3.0.0 | MIT | CLI package, Web package |  |
-| `highlight.js` | 11.11.1 | BSD-3-Clause | Web package |  |
+| `highlight.js` | 11.12.0 | BSD-3-Clause | Web package |  |
+| `hono` | 4.13.3 | MIT | CLI package |  |
 | `hookable` | 5.5.3 | MIT | CLI package |  |
 | `html-url-attributes` | 3.0.1 | MIT | Web package |  |
 | `html-void-elements` | 3.0.0 | MIT | CLI package |  |
@@ -341,7 +373,7 @@ The project does not intentionally vendor third-party source code into this repo
 | `iconv-lite` | 0.7.2 | MIT | CLI package |  |
 | `inherits` | 2.0.4 | ISC | CLI package |  |
 | `inline-style-parser` | 0.2.7 | MIT | Web package |  |
-| `ip-address` | 10.2.0 | MIT | CLI package |  |
+| `ip-address` | 10.5.0 | MIT | CLI package |  |
 | `ipaddr.js` | 1.9.1 | MIT | CLI package |  |
 | `is-alphabetical` | 2.0.1 | MIT | Web package |  |
 | `is-alphanumerical` | 2.0.1 | MIT | Web package |  |
@@ -353,7 +385,11 @@ The project does not intentionally vendor third-party source code into this repo
 | `is-plain-obj` | 4.1.0 | MIT | Web package |  |
 | `is-promise` | 4.0.0 | MIT | CLI package |  |
 | `is-what` | 5.5.0 | MIT | CLI package |  |
+| `isexe` | 2.0.0 | ISC | CLI package |  |
 | `jiti` | 2.7.0 | MIT | Web package |  |
+| `jose` | 6.2.9 | MIT | CLI package |  |
+| `json-schema-traverse` | 1.0.0 | MIT | CLI package |  |
+| `json-schema-typed` | 8.0.2 | BSD-2-Clause | CLI package |  |
 | `lightningcss` | 1.32.0 | MPL-2.0 | CLI package, Web package |  |
 | `lightningcss-android-arm64` | 1.32.0 | MPL-2.0 | CLI package, Web package |  |
 | `lightningcss-darwin-arm64` | 1.32.0 | MPL-2.0 | CLI package, Web package |  |
@@ -368,7 +404,8 @@ The project does not intentionally vendor third-party source code into this repo
 | `lightningcss-win32-x64-msvc` | 1.32.0 | MPL-2.0 | CLI package, Web package |  |
 | `longest-streak` | 3.1.0 | MIT | Web package |  |
 | `lowlight` | 3.3.0 | MIT | Web package |  |
-| `lucide-react` | 1.27.0 | ISC | Web package |  |
+| `lowlight/node_modules/highlight.js` | 11.11.2 | BSD-3-Clause | Web package |  |
+| `lucide-react` | 1.31.0 | ISC | Web package |  |
 | `magic-string` | 0.30.21 | MIT | CLI package, Web package |  |
 | `mark.js` | 8.11.1 | MIT | CLI package |  |
 | `markdown-table` | 3.0.4 | MIT | Web package |  |
@@ -425,8 +462,7 @@ The project does not intentionally vendor third-party source code into this repo
 | `minisearch` | 7.2.0 | MIT | CLI package |  |
 | `mitt` | 3.0.1 | MIT | CLI package |  |
 | `ms` | 2.1.3 | MIT | CLI package, Web package |  |
-| `nanoid` | 3.3.15 | MIT | CLI package |  |
-| `nanoid` | 3.3.16 | MIT | Web package |  |
+| `nanoid` | 3.3.18 | MIT | CLI package, Web package |  |
 | `negotiator` | 1.0.0 | MIT | CLI package |  |
 | `node-releases` | 2.0.51 | MIT | Web package |  |
 | `object-assign` | 4.1.1 | MIT | CLI package |  |
@@ -438,17 +474,18 @@ The project does not intentionally vendor third-party source code into this repo
 | `parse-entities` | 4.0.2 | MIT | Web package |  |
 | `parse-entities/node_modules/@types/unist` | 2.0.11 | MIT | Web package |  |
 | `parseurl` | 1.3.3 | MIT | CLI package |  |
+| `path-key` | 3.1.1 | MIT | CLI package |  |
 | `path-to-regexp` | 8.4.2 | MIT | CLI package |  |
 | `pathe` | 2.0.3 | MIT | CLI package |  |
 | `perfect-debounce` | 1.0.0 | MIT | CLI package |  |
 | `picocolors` | 1.1.1 | ISC | CLI package, Web package |  |
 | `picomatch` | 2.3.2 | MIT | CLI package |  |
 | `picomatch` | 4.0.5 | MIT | Web package |  |
-| `playwright` | 1.62.0 | Apache-2.0 | CLI package |  |
-| `playwright-core` | 1.62.0 | Apache-2.0 | CLI package |  |
+| `pkce-challenge` | 5.0.1 | MIT | CLI package |  |
+| `playwright` | 1.62.1 | Apache-2.0 | CLI package |  |
+| `playwright-core` | 1.62.1 | Apache-2.0 | CLI package |  |
 | `playwright/node_modules/fsevents` | 2.3.2 | MIT | CLI package |  |
-| `postcss` | 8.5.16 | MIT | CLI package |  |
-| `postcss` | 8.5.23 | MIT | Web package |  |
+| `postcss` | 8.5.26 | MIT | CLI package, Web package |  |
 | `postcss-value-parser` | 4.2.0 | MIT | Web package |  |
 | `preact` | 10.29.4 | MIT | CLI package |  |
 | `property-information` | 7.1.0 | MIT | Web package |  |
@@ -469,9 +506,11 @@ The project does not intentionally vendor third-party source code into this repo
 | `remark-parse` | 11.0.0 | MIT | Web package |  |
 | `remark-rehype` | 11.1.2 | MIT | Web package |  |
 | `remark-stringify` | 11.0.0 | MIT | Web package |  |
+| `require-from-string` | 2.0.2 | MIT | CLI package |  |
 | `reusify` | 1.1.0 | MIT | CLI package |  |
 | `rfdc` | 1.4.1 | MIT | CLI package |  |
-| `rolldown` | 1.1.5 | MIT | CLI package, Web package |  |
+| `rolldown` | 1.1.5 | MIT | CLI package |  |
+| `rolldown` | 1.2.1 | MIT | Web package |  |
 | `rollup` | 4.62.2 | MIT | CLI package |  |
 | `router` | 2.2.0 | MIT | CLI package |  |
 | `run-parallel` | 1.2.0 | MIT | CLI package |  |
@@ -482,6 +521,8 @@ The project does not intentionally vendor third-party source code into this repo
 | `send` | 1.2.1 | MIT | CLI package |  |
 | `serve-static` | 2.2.1 | MIT | CLI package |  |
 | `setprototypeof` | 1.2.0 | ISC | CLI package |  |
+| `shebang-command` | 2.0.0 | MIT | CLI package |  |
+| `shebang-regex` | 3.0.0 | MIT | CLI package |  |
 | `shell-quote` | 1.9.0 | MIT | CLI package |  |
 | `shiki` | 2.5.0 | MIT | CLI package |  |
 | `side-channel` | 1.1.1 | MIT | CLI package |  |
@@ -517,7 +558,7 @@ The project does not intentionally vendor third-party source code into this repo
 | `trim-lines` | 3.0.1 | MIT | CLI package, Web package |  |
 | `trough` | 2.2.0 | MIT | Web package |  |
 | `tslib` | 2.8.1 | 0BSD | CLI package, Web package |  |
-| `tsx` | 4.23.1 | MIT | CLI package |  |
+| `tsx` | 4.23.12 | MIT | CLI package |  |
 | `type-is` | 2.1.0 | MIT | CLI package |  |
 | `type-is/node_modules/content-type` | 2.0.0 | MIT | CLI package |  |
 | `typescript` | 7.0.2 | Apache-2.0 | CLI package, Web package |  |
@@ -535,7 +576,19 @@ The project does not intentionally vendor third-party source code into this repo
 | `vfile` | 6.0.3 | MIT | CLI package, Web package |  |
 | `vfile-message` | 4.0.3 | MIT | CLI package, Web package |  |
 | `vite` | 8.1.4 | MIT | CLI package |  |
-| `vite` | 8.1.5 | MIT | Web package |  |
+| `vite` | 8.2.1 | MIT | Web package |  |
+| `vite/node_modules/lightningcss` | 1.33.0 | MPL-2.0 | Web package |  |
+| `vite/node_modules/lightningcss-android-arm64` | 1.33.0 | MPL-2.0 | Web package |  |
+| `vite/node_modules/lightningcss-darwin-arm64` | 1.33.0 | MPL-2.0 | Web package |  |
+| `vite/node_modules/lightningcss-darwin-x64` | 1.33.0 | MPL-2.0 | Web package |  |
+| `vite/node_modules/lightningcss-freebsd-x64` | 1.33.0 | MPL-2.0 | Web package |  |
+| `vite/node_modules/lightningcss-linux-arm-gnueabihf` | 1.33.0 | MPL-2.0 | Web package |  |
+| `vite/node_modules/lightningcss-linux-arm64-gnu` | 1.33.0 | MPL-2.0 | Web package |  |
+| `vite/node_modules/lightningcss-linux-arm64-musl` | 1.33.0 | MPL-2.0 | Web package |  |
+| `vite/node_modules/lightningcss-linux-x64-gnu` | 1.33.0 | MPL-2.0 | Web package |  |
+| `vite/node_modules/lightningcss-linux-x64-musl` | 1.33.0 | MPL-2.0 | Web package |  |
+| `vite/node_modules/lightningcss-win32-arm64-msvc` | 1.33.0 | MPL-2.0 | Web package |  |
+| `vite/node_modules/lightningcss-win32-x64-msvc` | 1.33.0 | MPL-2.0 | Web package |  |
 | `vite/node_modules/picomatch` | 4.0.5 | MIT | CLI package |  |
 | `vitepress` | 1.6.4 | MIT | CLI package |  |
 | `vitepress/node_modules/@esbuild/aix-ppc64` | 0.21.5 | MIT | CLI package |  |
@@ -568,13 +621,15 @@ The project does not intentionally vendor third-party source code into this repo
 | `vitest/node_modules/picomatch` | 4.0.4 | MIT | CLI package |  |
 | `vue` | 3.5.39 | MIT | CLI package |  |
 | `webview-bun` | 2.4.0 | MIT | CLI package |  |
+| `which` | 2.0.2 | ISC | CLI package |  |
 | `why-is-node-running` | 2.3.0 | MIT | CLI package |  |
 | `wrap-ansi` | 9.0.2 | MIT | CLI package |  |
 | `wrappy` | 1.0.2 | ISC | CLI package |  |
-| `ws` | 8.21.1 | MIT | CLI package |  |
+| `ws` | 8.21.3 | MIT | CLI package |  |
 | `y18n` | 5.0.8 | ISC | CLI package |  |
 | `yargs` | 18.0.0 | MIT | CLI package |  |
 | `yargs-parser` | 22.0.0 | ISC | CLI package |  |
 | `zod` | 4.4.3 | MIT | CLI package |  |
+| `zod-to-json-schema` | 3.25.2 | ISC | CLI package |  |
 | `zwitch` | 2.0.4 | MIT | CLI package, Web package |  |
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "dvalincode": "dist/index.js"
       },
       "devDependencies": {
+        "@modelcontextprotocol/sdk": "^1.30.0",
         "@types/bun": "^1.3.14",
         "@types/cors": "^2.8.17",
         "@types/express": "^5.0.3",
@@ -875,6 +876,19 @@
         "node": ">=18"
       }
     },
+    "node_modules/@hono/node-server": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.1.1.tgz",
+      "integrity": "sha512-ELuehkj5VCBdgEw9zs+ivkKwyzzUCSQuE96YmiPvn1ECBoZCczbFXJLeEGMTYjphP6gydh4pHMqEYPVMYUVgQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
     "node_modules/@iconify-json/simple-icons": {
       "version": "1.2.89",
       "resolved": "https://registry.npmjs.org/@iconify-json/simple-icons/-/simple-icons-1.2.89.tgz",
@@ -898,6 +912,47 @@
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+      "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9 || ^2.0.5",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.6",
@@ -2632,6 +2687,41 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/algoliasearch": {
       "version": "5.55.1",
       "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.55.1.tgz",
@@ -3009,6 +3099,21 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
@@ -3246,6 +3351,29 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.1.tgz",
+      "integrity": "sha512-EKN1vKAMcZ8MlYMpaNuxN6R9yakzH6uajHcHVTqWJzvu5pWw9DyhbP35HH8MVBQ+dZjAfDxk+A8NiR9KWaXiyQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -3318,6 +3446,13 @@
         "express": ">= 4.11"
       }
     },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fast-glob": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
@@ -3333,6 +3468,23 @@
       "engines": {
         "node": ">=8.6.0"
       }
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fastq": {
       "version": "1.20.1",
@@ -3574,6 +3726,16 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/hono": {
+      "version": "4.13.3",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.3.tgz",
+      "integrity": "sha512-r8AO2mYHoLxSHkgafNeC/BXyb2vWRxD3jem4Ts+ptav8oTG5FIRifAjuJEmZI4bSvvc2ns0GxmIYiZnHqN3mMw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
     "node_modules/hookable": {
       "version": "5.5.3",
       "resolved": "https://registry.npmjs.org/hookable/-/hookable-5.5.3.tgz",
@@ -3700,6 +3862,37 @@
       "funding": {
         "url": "https://github.com/sponsors/mesqueeb"
       }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.9",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.9.tgz",
+      "integrity": "sha512-XrchZOFZUl/T3vTwRe8XK+cJrGtMF4th1ARnDfwbBXFKThGhlsxEE4Zu03AD/bjJSt/9jT/mxrOCkJWOg77aPA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "dev": true,
+      "license": "BSD-2-Clause"
     },
     "node_modules/lightningcss": {
       "version": "1.32.0",
@@ -4294,6 +4487,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/path-to-regexp": {
       "version": "8.4.2",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
@@ -4335,6 +4538,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
       }
     },
     "node_modules/playwright": {
@@ -4538,6 +4751,16 @@
       "integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/reusify": {
       "version": "1.1.0",
@@ -4748,6 +4971,29 @@
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/shell-quote": {
       "version": "1.9.0",
@@ -6099,6 +6345,22 @@
       "integrity": "sha512-0+ugnQlcUHmuW+iLeb+Lzb8rGUJh7WEdXvNsuvaVEXT3EagK380XdD7heVJu0Ek/mNxMY3G2JM142YRQ1hDUGQ==",
       "license": "MIT"
     },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
@@ -6206,6 +6468,16 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "dev": true,
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
       }
     },
     "node_modules/zwitch": {

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "zod": "^4.1.13"
   },
   "devDependencies": {
+    "@modelcontextprotocol/sdk": "^1.30.0",
     "@types/bun": "^1.3.14",
     "@types/cors": "^2.8.17",
     "@types/express": "^5.0.3",

--- a/tests/mcp/clientInterop.test.ts
+++ b/tests/mcp/clientInterop.test.ts
@@ -1,0 +1,137 @@
+import { existsSync } from 'node:fs';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+
+/**
+ * Interoperability, not unit behaviour.
+ *
+ * `server.test.ts` calls the server in-process with request strings this
+ * repository writes itself, which cannot catch a misreading of the protocol —
+ * both sides would be wrong in the same way. This drives the built binary as a
+ * child process over a real pipe, using the reference client implementation,
+ * which is what an actual harness does.
+ *
+ * That is the class of bug this exists for: negotiating the protocol version by
+ * echoing the client's own value back was a real regression here, and it would
+ * have looked correct to any test that built its own requests.
+ */
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const CLI = path.resolve(HERE, '../../dist/index.js');
+
+/**
+ * The build is a precondition, not an optional extra. Locally it is friendlier
+ * to say so than to fail cryptically; in CI a missing build must be loud, or
+ * this stops running the day someone reorders a job and nobody notices.
+ */
+const BUILT = existsSync(CLI);
+if (!BUILT && process.env.DVALIN_REQUIRE_MCP_INTEROP === '1') {
+  throw new Error(`MCP interop tests require a build: ${CLI} is missing. Run \`npm run build\` first.`);
+}
+
+const suite = BUILT ? describe : describe.skip;
+
+suite('an independent MCP client can drive the published server', () => {
+  let workspace: string;
+  let client: Client;
+
+  beforeAll(async () => {
+    workspace = await mkdtemp(path.join(tmpdir(), 'dvalin-mcp-interop-'));
+    await writeFile(
+      path.join(workspace, 'app.js'),
+      ['export function run(req) {', '  return eval(req.body.expression);', '}', ''].join('\n'), // scanner fixture
+      'utf8',
+    );
+
+    client = new Client({ name: 'dvalin-interop-test', version: '1.0.0' });
+    await client.connect(
+      new StdioClientTransport({
+        command: process.execPath,
+        args: [CLI, 'mcp-serve', '--workspace', workspace],
+        cwd: workspace,
+      }),
+    );
+  }, 60_000);
+
+  afterAll(async () => {
+    await client?.close();
+    if (workspace) await rm(workspace, { recursive: true, force: true });
+  });
+
+  it('completes the handshake and reports who it is', () => {
+    const server = client.getServerVersion();
+
+    expect(server?.name).toBeTruthy();
+    expect(server?.version).toBeTruthy();
+  });
+
+  it('advertises the tools an agent is told to call', async () => {
+    const { tools } = await client.listTools();
+    const names = tools.map(tool => tool.name).sort();
+
+    // The set documented in integrations/claude-code/README.md. A tool that
+    // silently disappears breaks instructions people have already committed.
+    expect(names).toEqual([
+      'dvalin_get_evidence',
+      'dvalin_get_finding',
+      'dvalin_get_session',
+      'dvalin_list_scanners',
+      'dvalin_run_task',
+      'dvalin_scan',
+      'dvalin_verify_findings',
+    ]);
+  });
+
+  it('gives every tool a description and a valid input schema', async () => {
+    const { tools } = await client.listTools();
+
+    for (const tool of tools) {
+      expect(tool.description, `${tool.name} has no description`).toBeTruthy();
+      expect(tool.inputSchema?.type, `${tool.name} has no object input schema`).toBe('object');
+    }
+  });
+
+  it('runs a real scan through a tool call and returns findings a client can read', async () => {
+    const result = await client.callTool({
+      name: 'dvalin_scan',
+      arguments: { scanners: ['builtin'] },
+    });
+
+    expect(result.isError).toBeFalsy();
+    const content = result.content as Array<{ type: string; text?: string }>;
+    const text = content.find(part => part.type === 'text')?.text ?? '';
+    const body = JSON.parse(text) as {
+      totalFindings: number;
+      findings: Array<{ ruleId: string; path: string }>;
+    };
+
+    expect(body.totalFindings).toBeGreaterThan(0);
+    expect(body.findings.map(finding => finding.ruleId)).toContain('dvalin/eval');
+    expect(body.findings[0]!.path).toBe('app.js');
+  }, 60_000);
+
+  it('reports an unknown tool as a tool error, not a protocol error', async () => {
+    // MCP puts a failed call in the result rather than the JSON-RPC envelope,
+    // so a client sees a usable message instead of a broken transport.
+    const result = await client.callTool({ name: 'dvalin_not_a_tool', arguments: {} });
+
+    expect(result.isError).toBe(true);
+
+    // And the session survives it: one bad call must not end the connection.
+    const { tools } = await client.listTools();
+    expect(tools.length).toBeGreaterThan(0);
+  }, 60_000);
+
+  it('rejects a workspace outside the launch allowlist', async () => {
+    const result = await client.callTool({
+      name: 'dvalin_scan',
+      arguments: { cwd: '/', scanners: ['builtin'] },
+    });
+
+    expect(result.isError).toBe(true);
+  }, 60_000);
+});


### PR DESCRIPTION
## Summary

Whether a harness can actually use the MCP server was established **once, by hand**, against Claude Code 2.1.226 and Codex 0.147.0, and recorded in #170. Codex has since shipped **0.149.0** and is building 0.150 — the claim is two minor versions stale, and nothing in CI would have noticed if the server had broken in between.

**The existing tests cannot close that gap.** `tests/mcp/server.test.ts` calls the server in-process with request strings this repository writes itself:

```ts
function request(id: number, method: string, params?: unknown): string {
  return JSON.stringify({ jsonrpc: '2.0', id, method, ... });
}
```

A misreading of the protocol would look correct from both sides at once. That is precisely the shape of the bug fixed in #169 — *"negotiate the protocol version instead of echoing it back"* — and no test that builds its own requests would have caught it.

`tests/mcp/stdio.test.ts` doesn't cover it either: that tests Dvalin as an MCP *client* connecting to other servers, not our server.

## What this adds

`tests/mcp/clientInterop.test.ts` drives **the built binary as a child process over a real pipe**, using the reference client from `@modelcontextprotocol/sdk`:

| Check | Why |
|---|---|
| Handshake + server identity | The connection a harness makes before anything else |
| All 7 tools listed | A tool that silently disappears breaks instructions people already committed |
| Every tool has a description and object schema | A client cannot call what it cannot read |
| Real `dvalin_scan` call returns findings | The actual thing agents are told to do, end to end |
| Unknown tool → `isError`, session survives | MCP puts failures in the result, not the envelope |
| `cwd` outside the allowlist → refused | The workspace boundary, exercised over the wire |

An independent implementation on the other end is the entire point. Testing an MCP server with a client written by the same people proves only that they agree with themselves.

## It cannot quietly stop running

The suite drives `dist/`, so a missing build is the one way it could pass by doing nothing. That is handled explicitly:

```
without a build, locally:   Test Files 1 skipped (1) · Tests 6 skipped (6)
without a build, in CI:     Error: MCP interop tests require a build … Test Files 1 failed (1)
```

`DVALIN_REQUIRE_MCP_INTEROP=1` is set on the new `mcp-interop` job, which builds first. Both directions verified by hand before committing.

## Testing

- `npm run check` — **407 passing** (401 + the 6 new), typecheck clean.
- The 6 interop tests verified green against a real build, and verified to skip/fail correctly with `dist/` removed.
- `ci.yml` parsed with a YAML parser: jobs are `test, e2e, shell-cross-platform, dvalin, mcp-interop, vscode-extension`, and the env is on the right step.
- Two of my own assertions were wrong on first run and are corrected here, not worked around: MCP returns an unknown tool as `isError` rather than a protocol error, which the server was already doing right.

## Security and AI Governance

- [x] This change does not expand file, shell, network, model, or approval permissions.
- [x] If it changes agent behavior, prompts, policy, providers, audit logging, or release/build security, I updated the relevant governance evidence in `docs/`.
- [x] If it introduces a new model/provider/tool or new data flow, I completed `docs/governance/AI-CHANGE-IMPACT-ASSESSMENT.md`.

Test-only. No model, no credentials, no network — which is deliberate, so it runs on pull requests from forks. `@modelcontextprotocol/sdk` is a **devDependency**; runtime `dependencies` are unchanged and the package still ships none. `THIRD_PARTY_NOTICES.md` is regenerated because the generator reads the whole lockfile (580 → 635 lines). The new job pins actions by SHA, sets `persist-credentials: false`, and takes only `contents: read`.

## Notes

**What this deliberately does not cover:** a change on the *client* side. Installing Claude Code or Codex needs credentials a fork's pull request cannot have, and a job that silently skips without them is worse than no job. So: a vendor breaking us still needs a human to notice; a regression of **ours** no longer does. That is the half worth automating.

If you want the other half, the natural follow-up is a scheduled (not per-PR) job with repository secrets that installs both CLIs and checks they still connect — plus a recorded "last verified against" version so drift is visible rather than assumed. Happy to add it; it is a different trade-off and worth deciding separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
