### PR TITLE
release: 0.18.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 <p align="center">
   <a href="https://github.com/arthurpanhku/dvalincode/releases/latest"><img src="https://img.shields.io/github/v/release/arthurpanhku/dvalincode?style=for-the-badge&color=818cf8&label=Release" alt="Release"></a>
   <a href="https://github.com/arthurpanhku/dvalincode/releases"><img src="https://img.shields.io/github/downloads/arthurpanhku/dvalincode/total?style=for-the-badge&color=blue&label=Downloads" alt="Downloads"></a>
-  <a href="#-tests"><img src="https://img.shields.io/badge/Tests-372%20%2F%20372%20%E2%9C%93-success?style=for-the-badge" alt="Tests"></a>
+  <a href="#-tests"><img src="https://img.shields.io/badge/Tests-442%20%2F%20442%20%E2%9C%93-success?style=for-the-badge" alt="Tests"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-green?style=for-the-badge" alt="License"></a>
   <a href="https://scorecard.dev/viewer/?uri=github.com/arthurpanhku/dvalincode"><img src="https://api.scorecard.dev/projects/github.com/arthurpanhku/dvalincode/badge" alt="OpenSSF Scorecard"></a>
   <a href="#-quick-install"><img src="https://img.shields.io/badge/Platforms-macOS%20·%20Windows%20·%20Linux-blue?style=for-the-badge" alt="Platforms"></a>
@@ -85,7 +85,7 @@ steps:
   - uses: actions/checkout@v5
     with:
       fetch-depth: 0        # so the scan can reach the base commit
-  - uses: arthurpanhku/dvalincode@v0.17.0
+  - uses: arthurpanhku/dvalincode@v0.18.0
     with:
       fail-on: high
       diff: true            # only report on what this PR changed
@@ -777,7 +777,7 @@ RESTORE → COMPACT → COMMAND → BUILD → RUN → SAVE → RESPOND → DONE
 npm test
 ```
 
-**372 tests · 56 files · all green.**
+**442 tests · 62 files · all green.**
 
 ---
 
@@ -898,7 +898,7 @@ Contributions welcome. The codebase is intentionally small and surgical — see 
 ```sh
 git clone https://github.com/arthurpanhku/dvalincode
 cd dvalincode && npm install
-npm test                # 372/372 ✅
+npm test                # 442/442 ✅
 npm run typecheck
 ```
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -9,7 +9,7 @@
 <p align="center">
   <a href="https://github.com/arthurpanhku/dvalincode/releases/latest"><img src="https://img.shields.io/github/v/release/arthurpanhku/dvalincode?style=for-the-badge&color=818cf8&label=Release" alt="Release"></a>
   <a href="https://github.com/arthurpanhku/dvalincode/releases"><img src="https://img.shields.io/github/downloads/arthurpanhku/dvalincode/total?style=for-the-badge&color=blue&label=Downloads" alt="Downloads"></a>
-  <a href="#-测试"><img src="https://img.shields.io/badge/Tests-372%20%2F%20372%20%E2%9C%93-success?style=for-the-badge" alt="Tests"></a>
+  <a href="#-测试"><img src="https://img.shields.io/badge/Tests-442%20%2F%20442%20%E2%9C%93-success?style=for-the-badge" alt="Tests"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-green?style=for-the-badge" alt="License"></a>
   <a href="https://scorecard.dev/viewer/?uri=github.com/arthurpanhku/dvalincode"><img src="https://api.scorecard.dev/projects/github.com/arthurpanhku/dvalincode/badge" alt="OpenSSF Scorecard"></a>
   <a href="#-一行安装"><img src="https://img.shields.io/badge/Platforms-macOS%20·%20Windows%20·%20Linux-blue?style=for-the-badge" alt="Platforms"></a>
@@ -76,7 +76,7 @@ steps:
   - uses: actions/checkout@v5
     with:
       fetch-depth: 0        # 让扫描能取到 base commit
-  - uses: arthurpanhku/dvalincode@v0.17.0
+  - uses: arthurpanhku/dvalincode@v0.18.0
     with:
       fail-on: high
       diff: true            # 只报告这个 PR 改动的部分
@@ -683,7 +683,7 @@ RESTORE → COMPACT → COMMAND → BUILD → RUN → SAVE → RESPOND → DONE
 npm test
 ```
 
-**372 个测试 · 56 个文件 · 全部通过。**
+**442 个测试 · 62 个文件 · 全部通过。**
 
 ---
 
@@ -810,7 +810,7 @@ Linux 与 macOS 命令通过 <code>/bin/sh</code> 执行；Windows 命令通过�
 ```sh
 git clone https://github.com/arthurpanhku/dvalincode
 cd dvalincode && npm install
-npm test                # 372/372 ✅
+npm test                # 442/442 ✅
 npm run typecheck
 ```
 

--- a/docs/DVALIN.md
+++ b/docs/DVALIN.md
@@ -129,7 +129,7 @@ permissions:
   pull-requests: write     # only when comment: 'true'
 steps:
   - uses: actions/checkout@v5
-  - uses: arthurpanhku/dvalincode@v0.17.0
+  - uses: arthurpanhku/dvalincode@v0.18.0
     with:
       fail-on: high        # critical | high | medium | low | none
       scanners: builtin    # add semgrep,trivy,osv-scanner if on PATH

--- a/docs/examples/dvalin-scan.yml
+++ b/docs/examples/dvalin-scan.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5   # pin by commit digest in production
 
-      - uses: arthurpanhku/dvalincode@v0.17.0
+      - uses: arthurpanhku/dvalincode@v0.18.0
         with:
           # Fail the build on high or critical findings. Use 'none' to report
           # without blocking while you work through the backlog.
@@ -30,6 +30,6 @@ jobs:
       # Optional: add the external engines. Dvalin picks up whatever is on PATH.
       #
       # - run: pipx install semgrep
-      # - uses: arthurpanhku/dvalincode@v0.17.0
+      # - uses: arthurpanhku/dvalincode@v0.18.0
       #   with:
       #     scanners: builtin,semgrep,trivy,osv-scanner

--- a/editors/vscode/CHANGELOG.md
+++ b/editors/vscode/CHANGELOG.md
@@ -5,29 +5,30 @@ All notable changes to the Dvalin Security Scan extension.
 The version tracks the `dvalincode` CLI it is built against, so a given
 extension version and CLI version always mean the same scanner.
 
-## 0.17.0
+## 0.18.0
 
-First published release.
+First published release. Versions before this one were built but never reached
+a marketplace, so everything below is new to anyone installing it.
 
 ### Added
 
+- Security findings from the Dvalin scanner in the Problems panel, on the lines
+  that caused them. Scanning needs no API key, no model, and no account.
 - `dvalin.scanScope`, defaulting to `changed`: a scan reads only the lines you
   have not committed yet, including new files. This is what makes
   `dvalin.scanOnSave` usable — a save reports what you just wrote instead of
   everything the repository already carried. Set it to `workspace` to read
   everything, or when the folder is not a git repository.
+- A `Dvalin: Scan workspace` command, and a quick fix that runs the governed
+  `--fix --verify` flow in a terminal where you can watch and interrupt it.
+- Severity banded exactly as the CLI bands it, so the editor and a CI gate never
+  disagree about what "high" means.
 
-### Changed
+### Notes
 
-- Findings are substantially quieter. The scanner no longer reports vendored
-  third-party code, credentials in test fixtures, DOM teardown in a test
-  harness, or risks that appear only inside comments, and it no longer reads a
-  string that merely starts with a SQL verb as SQL injection.
-- Added detection for a value interpolated into a MongoDB `$where`, which
-  executes JavaScript on the database server.
-
-## 0.15.0
-
-Unpublished. Findings from the Dvalin scanner in the Problems panel, a
-`Dvalin: Scan workspace` command, scan-on-save, and a governed fix-and-verify
-action. No API key needed to scan.
+Findings are substantially quieter than earlier internal builds. The scanner no
+longer reports vendored third-party code, credentials in test fixtures, DOM
+teardown in a test harness, or risks that appear only inside comments, and it no
+longer reads a string that merely starts with a SQL verb as SQL injection. It
+also gained detection for a value interpolated into a MongoDB `$where`, which
+executes JavaScript on the database server.

--- a/editors/vscode/package-lock.json
+++ b/editors/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dvalincode-vscode",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dvalincode-vscode",
-      "version": "0.17.0",
+      "version": "0.18.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^26.1.0",

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "dvalincode-vscode",
   "displayName": "Dvalin Security Scan",
   "description": "Security findings from Dvalin in the Problems panel, with a governed fix-and-verify action. No API key needed to scan.",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "publisher": "arthurpanhku",
   "license": "MIT",
   "homepage": "https://dvalincode.dev",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dvalincode",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dvalincode",
-      "version": "0.17.0",
+      "version": "0.18.0",
       "license": "MIT",
       "dependencies": {
         "chalk": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dvalincode",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "Open security engineering for code written by humans and AI agents.",
   "type": "module",
   "license": "MIT",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/arthurpanhku/dvalincode",
     "source": "github"
   },
-  "version": "0.17.0",
+  "version": "0.18.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "dvalincode",
-      "version": "0.17.0",
+      "version": "0.18.0",
       "transport": {
         "type": "stdio"
       },

--- a/src/version.ts
+++ b/src/version.ts
@@ -5,4 +5,4 @@
  * Everything that reports a version — the CLI `--version`, the trust report, and
  * the self-update check — imports from here so the copies can never drift.
  */
-export const VERSION = '0.17.0';
+export const VERSION = '0.18.0';


### PR DESCRIPTION
## Summary

Prepares the `v0.18.0` tag. No feature changes — this is the version bump plus two corrections.

**Every field the release workflow gates on**, simulated against the tag before committing:

```
✓ package.json             0.18.0
✓ src/version.ts           0.18.0
✓ server.json              0.18.0
✓ server.json packages[0]  0.18.0
✓ editors/vscode           0.18.0
```

Both lockfiles are synced too (`npm install --package-lock-only`), and `npm ci` verified at the root and in `editors/vscode` — that is what CI actually runs, and a lockfile disagreeing with its package.json is a way to fail a release late.

## Two corrections worth calling out

**Test counts had drifted again.** The badge and prose said **372**; the suite measures **442 across 62 files**. Fixed in three places per README, including the build-from-source snippet that still said `npm test # 372/372 ✅`. This is the same drift the 0.17.0 release commit had to correct, which suggests it wants a check rather than a habit — noted below.

**The extension changelog claimed 0.17.0 was the "first published release". It was not.** 0.15.0 and 0.17.0 were both built and never reached a marketplace — I checked both registries again while writing this and neither has the extension. Left as-is, that sentence would have shipped a false claim in the one document a marketplace visitor actually reads. 0.18.0 is now correctly labelled as the first published release, and its entry describes everything the extension does rather than a diff against a version nobody could install.

**Deliberately not bumped:** `docs/DVALIN.md:50` — *"This changed in 0.17.0"* records when the gate exit code changed. That is a fact about that release, not a version pin.

## Testing

- `npm run check` — **442 passing**, typecheck clean.
- `npm ci` verified at root and in `editors/vscode`.
- Built binaries report `0.18.0` (`dvalincode --version` and `dvalin --version`).
- `vsce package` → **8 files, 21.91 KB**, manifest `Version="0.18.0" Publisher="arthurpanhku"`.
- `server.json` description is 91 chars (registry limit 100) and `mcpName` matches `server.json` name — both are gates that only fail *after* auth, late in a release.
- Repo still self-scans 100/100 A.

## Security and AI Governance

- [x] This change does not expand file, shell, network, model, or approval permissions.
- [x] If it changes agent behavior, prompts, policy, providers, audit logging, or release/build security, I updated the relevant governance evidence in `docs/`.
- [x] If it introduces a new model/provider/tool or new data flow, I completed `docs/governance/AI-CHANGE-IMPACT-ASSESSMENT.md`.

Version metadata and documentation only — no code paths change. No new model, provider, tool, or data flow.

## What the tag will do

Pushing `v0.18.0` after this merges publishes: npm (with provenance), the GitHub Release, the MCP registry, the Homebrew formula, and — newly — the VS Code Marketplace and Open VSX.

**The two extension publishes will skip** until `VSCE_PAT` and `OVSX_PAT` exist as repository secrets. That is by design: a missing token warns rather than failing the release. The trade-off is that a silent skip looks like a successful release, so if 0.18.0 reaches npm but not the marketplaces, check the run's warnings first — `editors/vscode/PUBLISHING.md` covers the account setup, including the two steps that actually block people.

## Suggested follow-up

The test-count drift has now needed manual correction twice. A tiny CI step that compares the badge against the measured count would end it. Happy to add it separately rather than widen a release PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
