### PR TITLE
Update the registry descriptions, and point server.json at the schema it conforms to

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dvalincode",
   "version": "0.18.0",
-  "description": "Open security engineering for code written by humans and AI agents.",
+  "description": "Open security engineering for code written by humans and AI agents — every repair carries its own offline-verifiable proof.",
   "type": "module",
   "license": "MIT",
   "repository": {

--- a/server.json
+++ b/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-07-09/server.schema.json",
   "name": "io.github.arthurpanhku/dvalincode",
-  "description": "Deterministic security scanning that needs no model or API key, plus governed coding tasks.",
+  "description": "Deterministic security scanning, no model or API key, plus offline-verifiable proof a fix worked.",
   "repository": {
     "url": "https://github.com/arthurpanhku/dvalincode",
     "source": "github"

--- a/server.json
+++ b/server.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-07-09/server.schema.json",
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
   "name": "io.github.arthurpanhku/dvalincode",
   "description": "Deterministic security scanning, no model or API key, plus offline-verifiable proof a fix worked.",
   "repository": {


### PR DESCRIPTION
## Summary

Follow-up to #197. Two registry descriptions, one schema declaration, and the test that would have caught the schema problem before it shipped.

**The two registry descriptions were left behind by #197.** Both still described the project as it was before independent verification became the point:

| | before | after |
|---|---|---|
| `package.json` (npm) | Open security engineering for code written by humans and AI agents. | …— every repair carries its own offline-verifiable proof. |
| `server.json` (MCP registry) | Deterministic security scanning that needs no model or API key, plus governed coding tasks. | Deterministic security scanning, no model or API key, plus offline-verifiable proof a fix worked. |

The MCP one was not just stale in tone — it was inaccurate about what the server does. #197 added `dvalin_verify_fix`, and `dvalin_verify_findings` now runs the project's own checks. The registry description mentioned neither.

**`server.json` declared a schema it did not satisfy.** Pre-existing, and found while validating the description change rather than by reading the file:

```
$schema: .../2025-07-09/server.schema.json     ← declared
packages[0]: Additional properties are not allowed ('registryType', 'runtimeArguments')
packages[0]: 'registry_type' is a required property
```

The file uses the newer field names and is valid against `2025-09-29`, so anyone validating it against its own declared schema got two errors that had nothing to do with the file being wrong. `2025-09-29` is also the newest schema published — `2025-10-27`, `2025-12-01`, `2026-01-15`, `latest` and `draft` all 404. Publication is unaffected either way: `mcp-publisher` validates against the registry's current schema, not this field.

**Nothing was checking for that.** `release.yml:364` explains why its hand-rolled checks exist — *"The registry validates server.json only after everything else in the release has shipped"* — but they cover version match, npm existence, description length and `mcpName`, and never the schema. A schema violation passes all four and reaches the registry, which is exactly what happened.

`tests/mcpServerManifest.test.ts` closes that, offline, on every pull request:

- **the drift guard**: `server.json`'s `$schema` must equal the vendored schema's `$id`, so replacing one without the other fails. That is the pair that silently disagreed.
- **real validation** against `tests/fixtures/mcp-server.schema.json`, fetched verbatim from the URL in its own `$id` (sha256 `80fede68…`).
- a regression test that the older `registry_type` naming is now rejected.
- the cross-file invariants a schema cannot express: all three versions agree, and `package.json`'s `mcpName` matches `server.json`'s `name`.

Validating against the real schema also **subsumes the hand-rolled 100-character check** — the schema states that bound itself (`maxLength: 100`), so the test catches an over-long description too. The release-time guards are left in place as defence in depth; they additionally compare against the git tag, which no pull-request-time test can do.

### Why vendored rather than `ajv-cli` in the release path

Reaching for `npx ajv-cli` would pull unpinned code into the release path, which sits badly against a repository that SHA-pins every Action. A vendored schema plus an offline test adds no network dependency and no unpinned tool to release, at the cost of a file to keep in sync — which the `$id` check makes noisy rather than silent.

`ajv` and `ajv-formats` were **already installed** as transitive dependencies of the MCP SDK, so declaring them adds no package. It stops a future SDK bump from removing them out from under this test.

## Testing

- `npm run check` green — 504 tests, up from 498.
- The new test was mutation-checked against the real bug: reverting `$schema` to `2025-07-09` fails it with `expected '2025-07-09' to be '2025-09-29'`. The assertion compares the dated segment rather than the whole URL, because the two URLs share a long prefix and asserting on the full string reports two truncated, identical-looking values.
- Also mutation-checked that `registry_type` in place of `registryType` fails, and that a 101-character description fails.
- `server.json` validates against **the schema it declares** — the check reads `doc["$schema"]` and validates against that, which is precisely the condition that failed before.
- `npm ci` from the edited lockfile installs cleanly and resolves `ajv@8.20.0` / `ajv-formats@3.0.1`.
- The three assertions `release.yml` and `publish-mcp-registry.yml` make by hand were re-run against the result: description 97 chars, versions agree, `mcpName` matches.

## Security and AI Governance

- [x] This change does not expand file, shell, network, model, or approval permissions.
- [x] If it changes agent behavior, prompts, policy, providers, audit logging, or release/build security, I updated the relevant governance evidence in `docs/`.
- [x] If it introduces a new model/provider/tool or new data flow, I completed `docs/governance/AI-CHANGE-IMPACT-ASSESSMENT.md`.

Nothing triggers their conditions. Three metadata strings, one vendored schema, and a test — no tool, permission, data flow, prompt, or audit behaviour is touched, and the release path runs exactly the same commands against the same files. The two new dev dependencies were already in the tree. (For contrast, #197 left two of these deliberately unticked.)

## Notes

The lockfile change is the two lines that declare the dev dependencies. `npm install` also wanted to strip `"libc"` from every optional platform package — this npm version rewriting unrelated entries — so that churn was left out deliberately; `npm ci` was run afterwards to confirm the hand-trimmed lockfile is still coherent.

Keeping the vendored schema current is a manual step by design. If upstream publishes a newer version, nothing here fails — the manifest still validates against what it declares. Moving to it is: replace `tests/fixtures/mcp-server.schema.json`, update `$schema` in `server.json`. Doing one without the other fails the drift guard.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Kg6aassrPdFHVF4W9zLeX