### PR TITLE
Validate server.json against a vendored copy of its own schema

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,8 @@
         "@types/express": "^5.0.3",
         "@types/node": "^26.2.0",
         "@types/ws": "^8.5.14",
+        "ajv": "^8.20.0",
+        "ajv-formats": "^3.0.1",
         "concurrently": "^10.0.5",
         "playwright": "^1.61.1",
         "tsx": "^4.23.12",

--- a/package.json
+++ b/package.json
@@ -81,6 +81,8 @@
     "@types/express": "^5.0.3",
     "@types/node": "^26.2.0",
     "@types/ws": "^8.5.14",
+    "ajv": "^8.20.0",
+    "ajv-formats": "^3.0.1",
     "concurrently": "^10.0.5",
     "playwright": "^1.61.1",
     "tsx": "^4.23.12",

--- a/tests/fixtures/mcp-server.schema.json
+++ b/tests/fixtures/mcp-server.schema.json
@@ -1,0 +1,483 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
+  "title": "MCP Server Detail",
+  "$ref": "#/definitions/ServerDetail",
+  "definitions": {
+    "Repository": {
+      "type": "object",
+      "description": "Repository metadata for the MCP server source code. Enables users and security experts to inspect the code, improving transparency.",
+      "required": [
+        "url",
+        "source"
+      ],
+      "properties": {
+        "url": {
+          "type": "string",
+          "format": "uri",
+          "description": "Repository URL for browsing source code. Should support both web browsing and git clone operations.",
+          "example": "https://github.com/modelcontextprotocol/servers"
+        },
+        "source": {
+          "type": "string",
+          "description": "Repository hosting service identifier. Used by registries to determine validation and API access methods.",
+          "example": "github"
+        },
+        "id": {
+          "type": "string",
+          "description": "Repository identifier from the hosting service (e.g., GitHub repo ID). Owned and determined by the source forge. Should remain stable across repository renames and may be used to detect repository resurrection attacks - if a repository is deleted and recreated, the ID should change. For GitHub, use: gh api repos/<owner>/<repo> --jq '.id'",
+          "example": "b94b5f7e-c7c6-d760-2c78-a5e9b8a5b8c9"
+        },
+        "subfolder": {
+          "type": "string",
+          "description": "Optional relative path from repository root to the server location within a monorepo or nested package structure. Must be a clean relative path.",
+          "example": "src/everything"
+        }
+      }
+    },
+    "Server": {
+      "type": "object",
+      "required": [
+        "name",
+        "description",
+        "version"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Server name in reverse-DNS format. Must contain exactly one forward slash separating namespace from server name.",
+          "example": "io.github.user/weather",
+          "pattern": "^[a-zA-Z0-9.-]+/[a-zA-Z0-9._-]+$",
+          "minLength": 3,
+          "maxLength": 200
+        },
+        "description": {
+          "type": "string",
+          "description": "Clear human-readable explanation of server functionality. Should focus on capabilities, not implementation details.",
+          "example": "MCP server providing weather data and forecasts via OpenWeatherMap API",
+          "minLength": 1,
+          "maxLength": 100
+        },
+        "repository": {
+          "$ref": "#/definitions/Repository",
+          "description": "Optional repository metadata for the MCP server source code. Recommended for transparency and security inspection."
+        },
+        "version": {
+          "type": "string",
+          "maxLength": 255,
+          "example": "1.0.2",
+          "description": "Version string for this server. SHOULD follow semantic versioning (e.g., '1.0.2', '2.1.0-alpha'). Equivalent of Implementation.version in MCP specification. Non-semantic versions are allowed but may not sort predictably. Version ranges are rejected (e.g., '^1.2.3', '~1.2.3', '>=1.2.3', '1.x', '1.*')."
+        },
+        "websiteUrl": {
+          "type": "string",
+          "format": "uri",
+          "description": "Optional URL to the server's homepage, documentation, or project website. This provides a central link for users to learn more about the server. Particularly useful when the server has custom installation instructions or setup requirements.",
+          "example": "https://modelcontextprotocol.io/examples"
+        }
+      }
+    },
+    "Package": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "registryType",
+        "identifier",
+        "version",
+        "transport"
+      ],
+      "properties": {
+        "registryType": {
+          "type": "string",
+          "description": "Registry type indicating how to download packages (e.g., 'npm', 'pypi', 'oci', 'nuget', 'mcpb')",
+          "examples": [
+            "npm",
+            "pypi",
+            "oci",
+            "nuget",
+            "mcpb"
+          ]
+        },
+        "registryBaseUrl": {
+          "type": "string",
+          "format": "uri",
+          "description": "Base URL of the package registry",
+          "examples": [
+            "https://registry.npmjs.org",
+            "https://pypi.org",
+            "https://docker.io",
+            "https://api.nuget.org",
+            "https://github.com",
+            "https://gitlab.com"
+          ]
+        },
+        "identifier": {
+          "type": "string",
+          "description": "Package identifier - either a package name (for registries) or URL (for direct downloads)",
+          "examples": [
+            "@modelcontextprotocol/server-brave-search",
+            "https://github.com/example/releases/download/v1.0.0/package.mcpb"
+          ]
+        },
+        "version": {
+          "type": "string",
+          "description": "Package version. Must be a specific version. Version ranges are rejected (e.g., '^1.2.3', '~1.2.3', '>=1.2.3', '1.x', '1.*').",
+          "not": {
+            "const": "latest"
+          },
+          "example": "1.0.2",
+          "minLength": 1
+        },
+        "fileSha256": {
+          "type": "string",
+          "pattern": "^[a-f0-9]{64}$",
+          "description": "SHA-256 hash of the package file for integrity verification. Required for MCPB packages and optional for other package types. Authors are responsible for generating correct SHA-256 hashes when creating server.json. If present, MCP clients must validate the downloaded file matches the hash before running packages to ensure file integrity.",
+          "example": "fe333e598595000ae021bd27117db32ec69af6987f507ba7a63c90638ff633ce"
+        },
+        "runtimeHint": {
+          "type": "string",
+          "description": "A hint to help clients determine the appropriate runtime for the package. This field should be provided when `runtimeArguments` are present.",
+          "examples": [
+            "npx",
+            "uvx",
+            "docker",
+            "dnx"
+          ]
+        },
+        "transport": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StdioTransport"
+            },
+            {
+              "$ref": "#/definitions/StreamableHttpTransport"
+            },
+            {
+              "$ref": "#/definitions/SseTransport"
+            }
+          ],
+          "description": "Transport protocol configuration for the package"
+        },
+        "runtimeArguments": {
+          "type": "array",
+          "description": "A list of arguments to be passed to the package's runtime command (such as docker or npx). The `runtimeHint` field should be provided when `runtimeArguments` are present.",
+          "items": {
+            "$ref": "#/definitions/Argument"
+          }
+        },
+        "packageArguments": {
+          "type": "array",
+          "description": "A list of arguments to be passed to the package's binary.",
+          "items": {
+            "$ref": "#/definitions/Argument"
+          }
+        },
+        "environmentVariables": {
+          "type": "array",
+          "description": "A mapping of environment variables to be set when running the package.",
+          "items": {
+            "$ref": "#/definitions/KeyValueInput"
+          }
+        }
+      }
+    },
+    "Input": {
+      "type": "object",
+      "properties": {
+        "description": {
+          "description": "A description of the input, which clients can use to provide context to the user.",
+          "type": "string"
+        },
+        "isRequired": {
+          "type": "boolean",
+          "default": false
+        },
+        "format": {
+          "type": "string",
+          "description": "Specifies the input format. Supported values include `filepath`, which should be interpreted as a file on the user's filesystem.\n\nWhen the input is converted to a string, booleans should be represented by the strings \"true\" and \"false\", and numbers should be represented as decimal values.",
+          "enum": [
+            "string",
+            "number",
+            "boolean",
+            "filepath"
+          ],
+          "default": "string"
+        },
+        "value": {
+          "type": "string",
+          "description": "The default value for the input. If this is not set, the user may be prompted to provide a value. If a value is set, it should not be configurable by end users.\n\nIdentifiers wrapped in `{curly_braces}` will be replaced with the corresponding properties from the input `variables` map. If an identifier in braces is not found in `variables`, or if `variables` is not provided, the `{curly_braces}` substring should remain unchanged.\n"
+        },
+        "isSecret": {
+          "type": "boolean",
+          "description": "Indicates whether the input is a secret value (e.g., password, token). If true, clients should handle the value securely.",
+          "default": false
+        },
+        "default": {
+          "type": "string",
+          "description": "The default value for the input."
+        },
+        "choices": {
+          "type": "array",
+          "description": "A list of possible values for the input. If provided, the user must select one of these values.",
+          "items": {
+            "type": "string"
+          },
+          "example": []
+        }
+      }
+    },
+    "InputWithVariables": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/Input"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "variables": {
+              "type": "object",
+              "description": "A map of variable names to their values. Keys in the input `value` that are wrapped in `{curly_braces}` will be replaced with the corresponding variable values.",
+              "additionalProperties": {
+                "$ref": "#/definitions/Input"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "PositionalArgument": {
+      "description": "A positional input is a value inserted verbatim into the command line.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/InputWithVariables"
+        },
+        {
+          "type": "object",
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "positional"
+              ],
+              "example": "positional"
+            },
+            "valueHint": {
+              "type": "string",
+              "description": "An identifier-like hint for the value. This is not part of the command line, but can be used by client configuration and to provide hints to users.",
+              "example": "file_path"
+            },
+            "isRepeated": {
+              "type": "boolean",
+              "description": "Whether the argument can be repeated multiple times in the command line.",
+              "default": false
+            }
+          },
+          "anyOf": [
+            {
+              "required": [
+                "valueHint"
+              ]
+            },
+            {
+              "required": [
+                "value"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "NamedArgument": {
+      "description": "A command-line `--flag={value}`.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/InputWithVariables"
+        },
+        {
+          "type": "object",
+          "required": [
+            "type",
+            "name"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "named"
+              ],
+              "example": "named"
+            },
+            "name": {
+              "type": "string",
+              "description": "The flag name, including any leading dashes.",
+              "example": "--port"
+            },
+            "isRepeated": {
+              "type": "boolean",
+              "description": "Whether the argument can be repeated multiple times.",
+              "default": false
+            }
+          }
+        }
+      ]
+    },
+    "KeyValueInput": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/InputWithVariables"
+        },
+        {
+          "type": "object",
+          "required": [
+            "name"
+          ],
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "Name of the header or environment variable.",
+              "example": "SOME_VARIABLE"
+            }
+          }
+        }
+      ]
+    },
+    "Argument": {
+      "description": "Warning: Arguments construct command-line parameters that may contain user-provided input. This creates potential command injection risks if clients execute commands in a shell environment. For example, a malicious argument value like ';rm -rf ~/Development' could execute dangerous commands. Clients should prefer non-shell execution methods (e.g., posix_spawn) when possible to eliminate injection risks entirely. Where not possible, clients should obtain consent from users or agents to run the resolved command before execution.",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/PositionalArgument"
+        },
+        {
+          "$ref": "#/definitions/NamedArgument"
+        }
+      ]
+    },
+    "StdioTransport": {
+      "type": "object",
+      "required": [
+        "type"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "stdio"
+          ],
+          "description": "Transport type",
+          "example": "stdio"
+        }
+      }
+    },
+    "StreamableHttpTransport": {
+      "type": "object",
+      "required": [
+        "type",
+        "url"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "streamable-http"
+          ],
+          "description": "Transport type",
+          "example": "streamable-http"
+        },
+        "url": {
+          "type": "string",
+          "description": "URL template for the streamable-http transport. Variables in {curly_braces} reference argument valueHints, argument names, or environment variable names. After variable substitution, this should produce a valid URI.",
+          "example": "https://api.example.com/mcp"
+        },
+        "headers": {
+          "type": "array",
+          "description": "HTTP headers to include",
+          "items": {
+            "$ref": "#/definitions/KeyValueInput"
+          }
+        }
+      }
+    },
+    "SseTransport": {
+      "type": "object",
+      "required": [
+        "type",
+        "url"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "sse"
+          ],
+          "description": "Transport type",
+          "example": "sse"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri",
+          "description": "Server-Sent Events endpoint URL",
+          "example": "https://mcp-fs.example.com/sse"
+        },
+        "headers": {
+          "type": "array",
+          "description": "HTTP headers to include",
+          "items": {
+            "$ref": "#/definitions/KeyValueInput"
+          }
+        }
+      }
+    },
+    "ServerDetail": {
+      "description": "Schema for a static representation of an MCP server. Used in various contexts related to discovery, installation, and configuration.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/Server"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "$schema": {
+              "type": "string",
+              "format": "uri",
+              "description": "JSON Schema URI for this server.json format",
+              "example": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json"
+            },
+            "packages": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Package"
+              }
+            },
+            "remotes": {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/StreamableHttpTransport"
+                  },
+                  {
+                    "$ref": "#/definitions/SseTransport"
+                  }
+                ]
+              }
+            },
+            "_meta": {
+              "type": "object",
+              "description": "Extension metadata using reverse DNS namespacing for vendor-specific data",
+              "additionalProperties": true,
+              "properties": {
+                "io.modelcontextprotocol.registry/publisher-provided": {
+                  "type": "object",
+                  "description": "Publisher-provided metadata for downstream registries",
+                  "additionalProperties": true
+                }
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/tests/mcpServerManifest.test.ts
+++ b/tests/mcpServerManifest.test.ts
@@ -1,0 +1,106 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import Ajv from 'ajv';
+import addFormats from 'ajv-formats';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * `server.json` is the MCP registry listing, and the registry validates it only
+ * after the release has otherwise shipped — after npm, after the GitHub Release.
+ * `release.yml` therefore checks by hand what the registry checks, but it never
+ * validated the schema, which is how the manifest came to declare the
+ * 2025-07-09 schema while using the newer `registryType` / `runtimeArguments`
+ * field names. Anyone validating it against its own declared schema got two
+ * errors that had nothing to do with the file being wrong.
+ *
+ * These run on every pull request, offline, against a vendored copy of the
+ * schema — the release path gains no network dependency and no unpinned tool.
+ *
+ * The vendored copy is `tests/fixtures/mcp-server.schema.json`, fetched
+ * verbatim from the URL in its own `$id`. To move to a newer schema: replace
+ * that file and update `$schema` in `server.json`. Doing only one of the two
+ * fails the first test below, which is the drift this exists to prevent.
+ */
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+function readJson(relative: string): Record<string, any> {
+  return JSON.parse(readFileSync(path.join(repoRoot, relative), 'utf8'));
+}
+
+const manifest = readJson('server.json');
+const packageJson = readJson('package.json');
+const schema = readJson('tests/fixtures/mcp-server.schema.json');
+
+// ajv ships CJS; under ESM the callable lands on `.default`.
+const AjvCtor = ((Ajv as any).default ?? Ajv) as typeof Ajv;
+const applyFormats = ((addFormats as any).default ?? addFormats) as typeof addFormats;
+
+/** The dated segment of a schema URL — the part that differs when the two drift. */
+function schemaVersionOf(url: string): string {
+  return /\/schemas\/([^/]+)\//.exec(url)?.[1] ?? url;
+}
+
+function validateManifest(document: unknown): { valid: boolean; errors: string[] } {
+  const ajv = new AjvCtor({ allErrors: true, strict: false });
+  applyFormats(ajv);
+  const validate = ajv.compile(schema);
+  const valid = validate(document) as boolean;
+  return {
+    valid,
+    errors: (validate.errors ?? []).map(error => `${error.instancePath || '<root>'} ${error.message}`),
+  };
+}
+
+describe('the MCP registry manifest', () => {
+  it('declares the schema version vendored beside this test', () => {
+    // The pair that silently disagreed. `$id` is the schema's own statement of
+    // which version it is, so neither side can drift without failing here.
+    // Compared by version first: both URLs share a long prefix, and asserting
+    // on the whole string reports two truncated, identical-looking values.
+    expect(schemaVersionOf(manifest.$schema)).toBe(schemaVersionOf(schema.$id));
+    expect(manifest.$schema).toBe(schema.$id);
+  });
+
+  it('validates against that schema', () => {
+    const { valid, errors } = validateManifest(manifest);
+    expect(errors).toEqual([]);
+    expect(valid).toBe(true);
+  });
+
+  it('rejects the field naming that the older schema required', () => {
+    // The concrete regression: `registry_type` is what 2025-07-09 wanted, and
+    // silently accepting it again would put the manifest back out of step.
+    const older = structuredClone(manifest);
+    delete older.packages[0].registryType;
+    older.packages[0].registry_type = 'npm';
+
+    const { valid, errors } = validateManifest(older);
+    expect(valid).toBe(false);
+    expect(errors.join(' ')).toContain('registryType');
+  });
+
+  it('catches a description over the registry limit, which used to reach the registry', () => {
+    // `release.yml` checks this by hand because the registry answers with a 422
+    // after auth, after npm, after the GitHub Release. The schema already says
+    // maxLength 100, so validating against it covers the same ground earlier.
+    const wordy = { ...manifest, description: 'x'.repeat(101) };
+
+    const { valid, errors } = validateManifest(wordy);
+    expect(valid).toBe(false);
+    expect(errors.join(' ')).toContain('100 characters');
+  });
+
+  it('advertises the version the package actually publishes', () => {
+    // release.yml compares all three against the git tag. A tag does not exist
+    // at pull-request time, but their agreement with each other does.
+    expect(manifest.version).toBe(packageJson.version);
+    expect(manifest.packages[0].version).toBe(packageJson.version);
+  });
+
+  it('carries the mcpName the registry proves ownership with', () => {
+    // The registry rejects a listing whose npm package lacks a matching
+    // mcpName, and only says so after authenticating.
+    expect(packageJson.mcpName).toBe(manifest.name);
+  });
+});


### PR DESCRIPTION
## Summary

The half of #198 that missed the merge. #198 fixed `server.json`'s `$schema` declaration; this adds the guard that stops it drifting again — without which the same mismatch would recur unnoticed, since that is exactly how it arose.

**Why nothing caught it.** `release.yml:364` explains why its hand-rolled checks exist — *"The registry validates server.json only after everything else in the release has shipped"* — but they cover version match, npm existence, description length, and `mcpName`, and never the schema. A schema violation passes all four and reaches the registry. `grep` finds no schema validation anywhere in the release path.

`tests/mcpServerManifest.test.ts` closes that, offline, on every pull request:

- **the drift guard** — `server.json`'s `$schema` must equal the vendored schema's `$id`, so replacing one without the other fails. That is the pair that silently disagreed.
- **real validation** against `tests/fixtures/mcp-server.schema.json`, fetched verbatim from the URL in its own `$id` (sha256 `80fede68…`, verified against upstream).
- a regression test that the older `registry_type` naming is rejected.
- the cross-file invariants a schema cannot express: all three versions agree, and `package.json`'s `mcpName` matches `server.json`'s `name`.

Validating against the real schema **subsumes the hand-rolled 100-character check** — the schema states that bound itself (`maxLength: 100`). The release-time guards stay as defence in depth; they additionally compare against the git tag, which no pull-request-time test can do.

### Why vendored rather than `ajv-cli` in the release path

`npx ajv-cli` would pull unpinned code into the release path, which sits badly against a repository that SHA-pins every Action. A vendored schema plus an offline test adds no network dependency and no unpinned tool to release, at the cost of a file to keep in sync — which the `$id` check makes noisy rather than silent.

`ajv` and `ajv-formats` were **already installed** as transitive dependencies of the MCP SDK, so declaring them adds no package. Declaring them stops a future SDK bump from removing them out from under this test.

## Testing

- `npm run check` green — 504 tests, up from 498.
- **Mutation-checked against the real bug**: reverting `$schema` to `2025-07-09` fails with `expected '2025-07-09' to be '2025-09-29'`. The assertion compares the dated segment rather than the whole URL — the two share a long prefix, and asserting on the full string reports two truncated, identical-looking values.
- Also mutation-checked that `registry_type` in place of `registryType` fails, and that a 101-character description fails.
- `ajv` needs `.default` under ESM; that was established by running it rather than assumed.
- `npm ci` from the hand-trimmed lockfile installs cleanly and resolves `ajv@8.20.0` / `ajv-formats@3.0.1`.
- All of the above re-run after rebasing onto current `main`, not carried over from the pre-rebase branch.

## Security and AI Governance

- [x] This change does not expand file, shell, network, model, or approval permissions.
- [x] If it changes agent behavior, prompts, policy, providers, audit logging, or release/build security, I updated the relevant governance evidence in `docs/`.
- [x] If it introduces a new model/provider/tool or new data flow, I completed `docs/governance/AI-CHANGE-IMPACT-ASSESSMENT.md`.

Nothing triggers their conditions. One vendored schema, one test, two dev dependencies already in the tree — no tool, permission, data flow, prompt, or audit behaviour is touched, and the release path runs exactly the same commands against the same files. The diff is pure addition: 593 insertions, 0 deletions.

## Notes

The lockfile change is the two lines that declare the dev dependencies. `npm install` also wanted to strip `"libc"` from every optional platform package — this npm version rewriting unrelated entries — so that churn was left out; `npm ci` confirms the hand-trimmed lockfile is still coherent.

Keeping the vendored schema current is a manual step **by design**. If upstream publishes a newer version nothing here fails, because the manifest still validates against what it declares. Moving to a newer one is: replace `tests/fixtures/mcp-server.schema.json`, update `$schema` in `server.json`. Doing one without the other fails the drift guard. As of writing, `2025-09-29` is the newest published — `2025-10-27`, `2025-12-01`, `2026-01-15`, `latest` and `draft` all 404.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Kg6aassrPdFHVF4W9zLeX

---
_Generated by [Claude Code](https://claude.ai/code/session_013Kg6aassrPdFHVF4W9zLeX)_