### PR TITLE
test(providers): pin the EG-4, EG-5 and EG-6 URL rejections (closes #206)

### DIFF
--- a/tests/providers.test.ts
+++ b/tests/providers.test.ts
@@ -238,6 +238,96 @@ describe('governed provider egress', () => {
     expect(fetchMock).toHaveBeenCalledOnce();
   });
 
+  // ── PCP-1 MUST assertions that were implemented but never asserted ──────
+  //
+  // Each is bypass-proof: deleting the corresponding guard in
+  // src/providers/egress.ts turns exactly the matching test red. Verified by
+  // hand; see the PR body.
+
+  it('EG-4: bounds the redirect chain instead of returning the last response', async () => {
+    // Every hop redirects, forever. Without the bound the loop would either run
+    // until the mock ran out or hand back the final 307 as though it were a
+    // completion -- the second is the dangerous one, because the caller cannot
+    // tell a redirect from an answer.
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(null, { status: 307, headers: { location: 'https://provider.example/v1/chat/completions' } }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+    const { createOpenAICompatibleProvider } = await import('../src/providers/openaiCompatible.js');
+    const provider = createOpenAICompatibleProvider({ baseUrl: 'https://provider.example/v1', model: 'm' });
+
+    await expect(provider.chat({
+      messages: [{ role: 'user', content: 'hello' }],
+      runtime: { policy: resolvePolicy([{ network: 'on' }]) },
+    })).rejects.toThrow(/exceeded \d+ redirects/);
+
+    // The chain is bounded, not merely reported: the request count is finite
+    // and small. An unbounded loop would have kept calling the mock.
+    expect(fetchMock.mock.calls.length).toBeLessThanOrEqual(6);
+  });
+
+  it('EG-5: rejects a non-http(s) scheme before any bytes are sent', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(completionResponse());
+    vi.stubGlobal('fetch', fetchMock);
+    const { createOpenAICompatibleProvider } = await import('../src/providers/openaiCompatible.js');
+    const provider = createOpenAICompatibleProvider({ baseUrl: 'ftp://provider.example/v1', model: 'm' });
+
+    await expect(provider.chat({
+      messages: [{ role: 'user', content: 'hello' }],
+      runtime: { policy: resolvePolicy([{ network: 'on' }]) },
+    })).rejects.toThrow(/unsupported protocol/);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('EG-5: rejects a non-http(s) scheme reached through a redirect', async () => {
+    // The scheme check has to hold on every hop, not just the configured base:
+    // a redirect is attacker-influenced in a way the base URL is not.
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(null, { status: 307, headers: { location: 'file:///etc/passwd' } }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+    const { createOpenAICompatibleProvider } = await import('../src/providers/openaiCompatible.js');
+    const provider = createOpenAICompatibleProvider({ baseUrl: 'https://provider.example/v1', model: 'm' });
+
+    await expect(provider.chat({
+      messages: [{ role: 'user', content: 'hello' }],
+      runtime: { policy: resolvePolicy([{ network: 'on' }]) },
+    })).rejects.toThrow(/unsupported protocol/);
+    // One call for the original hop; nothing was sent to the file: destination.
+    expect(fetchMock).toHaveBeenCalledOnce();
+  });
+
+  it('EG-6: rejects a URL carrying embedded credentials before any bytes are sent', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(completionResponse());
+    vi.stubGlobal('fetch', fetchMock);
+    const { createOpenAICompatibleProvider } = await import('../src/providers/openaiCompatible.js');
+    const provider = createOpenAICompatibleProvider({
+      baseUrl: 'https://user:pass@provider.example/v1',
+      model: 'm',
+    });
+
+    await expect(provider.chat({
+      messages: [{ role: 'user', content: 'hello' }],
+      runtime: { policy: resolvePolicy([{ network: 'on' }]) },
+    })).rejects.toThrow(/embedded credentials/);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('EG-6: rejects embedded credentials reached through a redirect', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(null, { status: 307, headers: { location: 'https://user:pass@provider.example/v1/chat/completions' } }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+    const { createOpenAICompatibleProvider } = await import('../src/providers/openaiCompatible.js');
+    const provider = createOpenAICompatibleProvider({ baseUrl: 'https://provider.example/v1', model: 'm' });
+
+    await expect(provider.chat({
+      messages: [{ role: 'user', content: 'hello' }],
+      runtime: { policy: resolvePolicy([{ network: 'on' }]) },
+    })).rejects.toThrow(/embedded credentials/);
+    expect(fetchMock).toHaveBeenCalledOnce();
+  });
+
   it('allows redirects when network policy is on', async () => {
     const fetchMock = vi.fn()
       .mockResolvedValueOnce(


### PR DESCRIPTION
Closes #206. First slice of #118. **No production code changes.**

## Bypass-proof check — done by hand, per T-2

Disabled each guard in `src/providers/egress.ts` in turn:

| guard disabled | tests that went red |
|---|---|
| `redirects === MAX_REDIRECTS` (EG-4) | `× EG-4: bounds the redirect chain…` — 1 failed, 27 passed |
| scheme check (EG-5) | `× EG-5: …before any bytes are sent`, `× EG-5: …through a redirect` — 2 failed, 26 passed |
| `url.username \|\| url.password` (EG-6) | `× EG-6: …before any bytes are sent`, `× EG-6: …through a redirect` — 2 failed, 26 passed |

Each guard's removal turns **exactly its own tests** red and nothing else — that specificity is the part worth checking, since a test that goes red for an unrelated reason proves as little as one that stays green.

Restored → 28 passed.

## Two tests each for EG-5 and EG-6

I added a redirect variant for both, beyond the one test per assertion asked for. The reason: `assertProviderUrlAllowed` is called on **every hop**, and the redirect hop is the one that matters — a `Location` header is attacker-influenced in a way a configured base URL is not. A guard applied only at entry would pass the base-URL test and still let a redirect to `file:///etc/passwd` or `https://user:pass@…` through. Cheap to cover, and it pins the thing actually worth defending.

## "Before any bytes are sent"

Every test asserts the transport call count, not just the thrown error:

- base-URL rejections: `expect(fetchMock).not.toHaveBeenCalled()`
- redirect rejections: `expect(fetchMock).toHaveBeenCalledOnce()` — the original hop only; nothing reached the rejected destination

## One note on EG-4

Its test asserts both the error **and** that the request count stays bounded (`≤ 6`). Without the second assertion, an unbounded loop that happened to throw for some other reason would pass it. The mock redirects forever, so the bound is the only thing that stops it.

## Verification

- `npx vitest run tests/providers.test.ts` — **28 passed** (23 before, 5 new)
- Fully offline, mocked `fetch` throughout (T-1) — no real network call
- Full suite unchanged against `main`'s pre-existing failures on this machine

## Out of scope, as stated

Parametrizing over every adapter, the AU/PO/BE families, and the report format stay in #118.

## Process note

The issue says to comment to claim and I didn't — same as on #207. CONTRIBUTING doesn't require it; happy to follow claim-first going forward, and to close this if someone else has it in flight.