### PR TITLE
test(providers): pin EG-5 and EG-6 on the redirect hop (trimmed from #213)

### DIFF
--- a/tests/providers.test.ts
+++ b/tests/providers.test.ts
@@ -238,6 +238,96 @@ describe('governed provider egress', () => {
     expect(fetchMock).toHaveBeenCalledOnce();
   });
 
+  // ── PCP-1 MUST assertions that were implemented but never asserted ──────
+  //
+  // Each is bypass-proof: deleting the corresponding guard in
+  // src/providers/egress.ts turns exactly the matching test red. Verified by
+  // hand; see the PR body.
+
+  it('EG-4: bounds the redirect chain instead of returning the last response', async () => {
+    // Every hop redirects, forever. Without the bound the loop would either run
+    // until the mock ran out or hand back the final 307 as though it were a
+    // completion -- the second is the dangerous one, because the caller cannot
+    // tell a redirect from an answer.
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(null, { status: 307, headers: { location: 'https://provider.example/v1/chat/completions' } }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+    const { createOpenAICompatibleProvider } = await import('../src/providers/openaiCompatible.js');
+    const provider = createOpenAICompatibleProvider({ baseUrl: 'https://provider.example/v1', model: 'm' });
+
+    await expect(provider.chat({
+      messages: [{ role: 'user', content: 'hello' }],
+      runtime: { policy: resolvePolicy([{ network: 'on' }]) },
+    })).rejects.toThrow(/exceeded \d+ redirects/);
+
+    // The chain is bounded, not merely reported: the request count is finite
+    // and small. An unbounded loop would have kept calling the mock.
+    expect(fetchMock.mock.calls.length).toBeLessThanOrEqual(6);
+  });
+
+  it('EG-5: rejects a non-http(s) scheme before any bytes are sent', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(completionResponse());
+    vi.stubGlobal('fetch', fetchMock);
+    const { createOpenAICompatibleProvider } = await import('../src/providers/openaiCompatible.js');
+    const provider = createOpenAICompatibleProvider({ baseUrl: 'ftp://provider.example/v1', model: 'm' });
+
+    await expect(provider.chat({
+      messages: [{ role: 'user', content: 'hello' }],
+      runtime: { policy: resolvePolicy([{ network: 'on' }]) },
+    })).rejects.toThrow(/unsupported protocol/);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('EG-5: rejects a non-http(s) scheme reached through a redirect', async () => {
+    // The scheme check has to hold on every hop, not just the configured base:
+    // a redirect is attacker-influenced in a way the base URL is not.
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(null, { status: 307, headers: { location: 'file:///etc/passwd' } }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+    const { createOpenAICompatibleProvider } = await import('../src/providers/openaiCompatible.js');
+    const provider = createOpenAICompatibleProvider({ baseUrl: 'https://provider.example/v1', model: 'm' });
+
+    await expect(provider.chat({
+      messages: [{ role: 'user', content: 'hello' }],
+      runtime: { policy: resolvePolicy([{ network: 'on' }]) },
+    })).rejects.toThrow(/unsupported protocol/);
+    // One call for the original hop; nothing was sent to the file: destination.
+    expect(fetchMock).toHaveBeenCalledOnce();
+  });
+
+  it('EG-6: rejects a URL carrying embedded credentials before any bytes are sent', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(completionResponse());
+    vi.stubGlobal('fetch', fetchMock);
+    const { createOpenAICompatibleProvider } = await import('../src/providers/openaiCompatible.js');
+    const provider = createOpenAICompatibleProvider({
+      baseUrl: 'https://user:pass@provider.example/v1',
+      model: 'm',
+    });
+
+    await expect(provider.chat({
+      messages: [{ role: 'user', content: 'hello' }],
+      runtime: { policy: resolvePolicy([{ network: 'on' }]) },
+    })).rejects.toThrow(/embedded credentials/);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('EG-6: rejects embedded credentials reached through a redirect', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(null, { status: 307, headers: { location: 'https://user:pass@provider.example/v1/chat/completions' } }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+    const { createOpenAICompatibleProvider } = await import('../src/providers/openaiCompatible.js');
+    const provider = createOpenAICompatibleProvider({ baseUrl: 'https://provider.example/v1', model: 'm' });
+
+    await expect(provider.chat({
+      messages: [{ role: 'user', content: 'hello' }],
+      runtime: { policy: resolvePolicy([{ network: 'on' }]) },
+    })).rejects.toThrow(/embedded credentials/);
+    expect(fetchMock).toHaveBeenCalledOnce();
+  });
+
   it('allows redirects when network policy is on', async () => {
     const fetchMock = vi.fn()
       .mockResolvedValueOnce(

--- a/tests/providers.test.ts
+++ b/tests/providers.test.ts
@@ -238,46 +238,13 @@ describe('governed provider egress', () => {
     expect(fetchMock).toHaveBeenCalledOnce();
   });
 
-  // ── PCP-1 MUST assertions that were implemented but never asserted ──────
+  // ── EG-5 / EG-6 on the redirect hop ────────────────────────────────────
   //
-  // Each is bypass-proof: deleting the corresponding guard in
-  // src/providers/egress.ts turns exactly the matching test red. Verified by
-  // hand; see the PR body.
-
-  it('EG-4: bounds the redirect chain instead of returning the last response', async () => {
-    // Every hop redirects, forever. Without the bound the loop would either run
-    // until the mock ran out or hand back the final 307 as though it were a
-    // completion -- the second is the dangerous one, because the caller cannot
-    // tell a redirect from an answer.
-    const fetchMock = vi.fn().mockResolvedValue(
-      new Response(null, { status: 307, headers: { location: 'https://provider.example/v1/chat/completions' } }),
-    );
-    vi.stubGlobal('fetch', fetchMock);
-    const { createOpenAICompatibleProvider } = await import('../src/providers/openaiCompatible.js');
-    const provider = createOpenAICompatibleProvider({ baseUrl: 'https://provider.example/v1', model: 'm' });
-
-    await expect(provider.chat({
-      messages: [{ role: 'user', content: 'hello' }],
-      runtime: { policy: resolvePolicy([{ network: 'on' }]) },
-    })).rejects.toThrow(/exceeded \d+ redirects/);
-
-    // The chain is bounded, not merely reported: the request count is finite
-    // and small. An unbounded loop would have kept calling the mock.
-    expect(fetchMock.mock.calls.length).toBeLessThanOrEqual(6);
-  });
-
-  it('EG-5: rejects a non-http(s) scheme before any bytes are sent', async () => {
-    const fetchMock = vi.fn().mockResolvedValue(completionResponse());
-    vi.stubGlobal('fetch', fetchMock);
-    const { createOpenAICompatibleProvider } = await import('../src/providers/openaiCompatible.js');
-    const provider = createOpenAICompatibleProvider({ baseUrl: 'ftp://provider.example/v1', model: 'm' });
-
-    await expect(provider.chat({
-      messages: [{ role: 'user', content: 'hello' }],
-      runtime: { policy: resolvePolicy([{ network: 'on' }]) },
-    })).rejects.toThrow(/unsupported protocol/);
-    expect(fetchMock).not.toHaveBeenCalled();
-  });
+  // The base-URL cases live above. These two cover the hop that a configured
+  // base URL cannot: `assertProviderUrlAllowed` runs on every iteration, and a
+  // `Location` header is attacker-influenced in a way the operator's own base
+  // URL is not. Moving that check to construction time, or hoisting it out of
+  // the loop, would leave every base-URL test green and only these two red.
 
   it('EG-5: rejects a non-http(s) scheme reached through a redirect', async () => {
     // The scheme check has to hold on every hop, not just the configured base:
@@ -295,22 +262,6 @@ describe('governed provider egress', () => {
     })).rejects.toThrow(/unsupported protocol/);
     // One call for the original hop; nothing was sent to the file: destination.
     expect(fetchMock).toHaveBeenCalledOnce();
-  });
-
-  it('EG-6: rejects a URL carrying embedded credentials before any bytes are sent', async () => {
-    const fetchMock = vi.fn().mockResolvedValue(completionResponse());
-    vi.stubGlobal('fetch', fetchMock);
-    const { createOpenAICompatibleProvider } = await import('../src/providers/openaiCompatible.js');
-    const provider = createOpenAICompatibleProvider({
-      baseUrl: 'https://user:pass@provider.example/v1',
-      model: 'm',
-    });
-
-    await expect(provider.chat({
-      messages: [{ role: 'user', content: 'hello' }],
-      runtime: { policy: resolvePolicy([{ network: 'on' }]) },
-    })).rejects.toThrow(/embedded credentials/);
-    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it('EG-6: rejects embedded credentials reached through a redirect', async () => {


### PR DESCRIPTION
## Summary

**The tests in this PR are @dchaudhari7177's work, from #213.** Their commit `207f837` is preserved unmodified in this branch's history; the only commit of mine removes what #211 had already landed.

#213 and #211 both answered #206. #211 merged first — my error, I checked the open-PR list before #213 existed and did not re-check before merging. #213 was the stronger submission, and this is the part of it that #211 does not cover.

I could not push the trim to #213's branch (the fork is outside this session's authorized repositories), so it lands here instead. #213 is being closed with a pointer to this PR.

## What survives the trim

Two tests, both covering the redirect hop:

- `EG-5: rejects a non-http(s) scheme reached through a redirect` — `Location: file:///etc/passwd`
- `EG-6: rejects embedded credentials reached through a redirect` — `Location: https://user:pass@…`

Removed as duplicates of what #211 landed: the EG-4 bound test and the base-URL cases for EG-5 and EG-6.

## Why these two are not redundant

@dchaudhari7177's argument, quoted from #213: *"`assertProviderUrlAllowed` is called on every hop, and the redirect hop is the one that matters — a `Location` header is attacker-influenced in a way a configured base URL is not."*

That is correct, and I verified it rather than taking it on reasoning alone. Simulating the regression a refactor would plausibly introduce — validating only the first hop:

```diff
-    assertProviderUrlAllowed(current, configuredOrigin);
+    if (redirects === 0) assertProviderUrlAllowed(current, configuredOrigin);
```

exactly three tests fail:

```
× blocks redirects to metadata URLs           (pre-existing)
× EG-5: …reached through a redirect            (this PR)
× EG-6: …reached through a redirect            (this PR)
```

Every base-URL test, #211's included, stays green. A change hoisting that check out of the loop or moving it to construction time would land clean on `main` as it stands and be caught only by these two.

## Verification

- Full suite on this branch: **525 passed** (523 on `main` + 2). `tsc --noEmit` clean.
- Mutation above re-run after the trim: still exactly those two tests, so nothing load-bearing was removed with the duplicates.
- Offline throughout; mocked `fetch`, no real network call (PCP-1 T-1).

## Note

#211's EG-4 test, now on `main`, asserts `toHaveBeenCalledTimes(6)`. #213's version used `toBeLessThanOrEqual(6)`, which does not need editing if `MAX_REDIRECTS` changes. Not changed here — out of scope for a trim — but worth doing when that area is next touched.

Related: #214, the AU-1 audit gap on the redirect-bound path, found while reviewing these.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0186VyaiQq3MTo4i4mK8P3aW

---
_Generated by [Claude Code](https://claude.ai/code/session_0186VyaiQq3MTo4i4mK8P3aW)_