### PR TITLE
feat(harness): carry scan coverage and fix records into headless output

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -21,6 +21,13 @@ Issues are the source of truth for status; this file is the map. Want one of the
   status, Problems context, output channel, and offline VFR command. A partial
   zero-finding scan is never presented as complete assurance.
   [Plan →](docs/VERIFICATION-SURFACES-PLAN.md)
+- **Verification in headless output** ([#205](https://github.com/arthurpanhku/dvalincode/issues/205)) —
+  `dvalincode run` now reports what its scanning covered and any Verified Fix
+  Record it filed, in `json` and `stream-json` as well as text. The surface with
+  no human present was the last one where "no findings" could mean a half-blind
+  scan. Coverage is reported, not folded into the exit code: a turn that
+  finished its task with an engine missing did not fail, and the caller gates on
+  it deliberately.
 - **Codex + Claude plugin payload** — one distributable directory contains both
   native manifests, a shared auto-discovered security-gate skill, and the same
   local MCP server. The clients can execute repairs; Dvalin remains the
@@ -47,7 +54,6 @@ Issues are the source of truth for status; this file is the map. Want one of the
 |---|---|---|
 | **Distribution + live conformance** | Publish the dual Codex/Claude payload and VS Code extension, then upgrade the weekly harness from configuration/handshake checks to a real `dvalin_scan` call on both current clients. Publish the dated compatibility result instead of an evergreen claim. | [Integrations](integrations/) · [Harness](.github/workflows/harness-interop.yml) |
 | **Fix-verification adoption** | Measure repositories reaching their first VFR, surface its hash in PR/release evidence, and shorten install-to-proof time. The contract is visible now; the remaining work is activation rather than another UI projection. | [Plan](docs/VERIFICATION-SURFACES-PLAN.md) · [FVP-1](docs/spec/FIX-VERIFICATION.md) |
-| **Headless runs carry no verification** | Every first-party surface a human watches now shows coverage; the one with no human present does not. A CI gate reading "no findings" from a half-blind scan is the machine-readable version of the bug the rest of this track closed. | [#205](https://github.com/arthurpanhku/dvalincode/issues/205) |
 | **Provider adapter conformance suite** | The executable half of [PCP-1](docs/spec/PROVIDER-CONFORMANCE.md) — the shared contract every provider must pass (egress containment, credential containment, audit, policy binding). Turns "should we trust a new provider?" into an objective gate. | [#118](https://github.com/arthurpanhku/dvalincode/issues/118) |
 | **Structured approval engine** | Upgrade boolean approvals to scoped grants ("allow `npm test` for this run") — subject, scope, expiry, recorded in audit. | [#53](https://github.com/arthurpanhku/dvalincode/issues/53) |
 | **Harness-mode + unattended-tier test coverage** | Pin the most governance-sensitive path (no human in the loop) with bypass-proof tests. | [#119](https://github.com/arthurpanhku/dvalincode/issues/119) |

--- a/docs/COMPETITIVE-ANALYSIS.md
+++ b/docs/COMPETITIVE-ANALYSIS.md
@@ -55,7 +55,6 @@ PR 上看不到、别的 agent 调不到。
 |---|---|---|
 | Distribution + live conformance | 安全扫描 / 分发 | [integrations/](https://github.com/arthurpanhku/dvalincode/tree/main/integrations) |
 | Fix-verification adoption（转向激活度量） | 安全扫描 / 证据 | [FVP-1](https://github.com/arthurpanhku/dvalincode/blob/main/docs/spec/FIX-VERIFICATION.md) |
-| headless 运行仍无验证输出 | 安全扫描 / 证据 | [#205](https://github.com/arthurpanhku/dvalincode/issues/205) |
 | provider 一致性套件 | 可审批性 | [#118](https://github.com/arthurpanhku/dvalincode/issues/118) |
 | 结构化授权 | 可审批性 | [#53](https://github.com/arthurpanhku/dvalincode/issues/53) |
 | harness / unattended 测试 | 可审批性 | [#119](https://github.com/arthurpanhku/dvalincode/issues/119) |

--- a/docs/HARNESS-MODE.md
+++ b/docs/HARNESS-MODE.md
@@ -111,9 +111,56 @@ trailer chat.ts prints.
   "wallSeconds": 92.4,
   "output": "final assistant message",
   "stopReason": "done | max_iterations | timeout | interrupted | error",
-  "error": "present only when ok=false"
+  "error": "present only when ok=false",
+  "verification": "present only when the turn scanned or filed a fix record"
 }
 ```
+
+#### `verification` — what the run's scanning covered
+
+Every surface a human watches reports scan coverage. This is the surface with
+**no human present**, which makes it the one where the omission does the most
+damage: a CI gate reading "no findings" from a run where half the engines never
+installed is the machine-readable form of the bug the rest of that work closed.
+
+```json
+"verification": {
+  "coverageStatus": "complete | partial | unknown",
+  "scans": [
+    {
+      "tool": "run_security_suite",
+      "toolCallId": "…",
+      "coverage": { "status": "partial", "scanners": [], "deferred": [], "exclusions": [], "notes": [] }
+    }
+  ],
+  "fixRecords": [
+    {
+      "recordHash": "…",
+      "path": "~/.dvalincode/security/fix-records/<hash>.json",
+      "executor": "codex",
+      "assurance": "scan-and-checks",
+      "verified": true,
+      "coverage": { "before": "complete", "after": "complete" }
+    }
+  ]
+}
+```
+
+- **`coverageStatus` is the weakest coverage the run has evidence of**, across
+  every scan it ran and every record it filed. Taking the best or the last would
+  let one complete scan speak for a partial one. `unknown` ranks below `partial`:
+  not knowing what ran is worse than knowing it was incomplete.
+- **The field is absent when the turn neither scanned nor filed a record.** That
+  is deliberately different from `coverageStatus: "unknown"`. A consumer that
+  cannot tell "nothing was scanned" from "the scan could not say what it looked
+  at" is back to the problem the field exists to solve.
+- **Records are not inlined.** A Verified Fix Record is already a portable file;
+  `path` is what you feed to `dvalincode security verify-fix <path>` to
+  re-derive the verdict offline, without re-running the agent. Only records
+  filed *during* this run, for *this* workspace, are listed — the store is
+  install-global, and a record written by `dvalin verify` carries that command's
+  own audit run, so there is no run id to join on.
+- **It does not affect the exit code.** See below.
 
 This is a superset of what `agent-driver.mjs` writes today — keep field names
 identical (`sessionId`, `runId`, `auditHead`, `iterationsUsed`, `usage`,
@@ -164,6 +211,22 @@ The interactive TUI still exits 130 on SIGINT, which is the Unix convention
 On every non-zero exit with `--output-format json|stream-json`, still emit the
 `result` object (`ok: false`, `error`, `stopReason`) before exiting — harnesses
 must never have to parse stderr.
+
+**Partial coverage does not change the exit code.** A turn that completed its
+task using a half-blind scanner did not fail, and folding coverage into the
+process exit would silently redefine exit 0 for every consumer that already
+depends on it. It would also put the wrong thing in code 5's seat: 5 means "it
+ran correctly and the answer was no", and `partial` is not an answer of no — it
+is a statement about how much of the question was examined. So the harness
+reports the status and leaves the decision to the caller:
+
+```bash
+dvalincode run --output-format json "scan and repair this repo" > run.json
+jq -e '.verification.coverageStatus == "complete"' run.json || exit 1
+```
+
+A caller wanting a findings gate should use `dvalin --fail-on`, which owns exit
+code 5 and is the surface designed for it.
 
 ### Migration: eval driver
 

--- a/docs/VERIFICATION-SURFACES-PLAN.md
+++ b/docs/VERIFICATION-SURFACES-PLAN.md
@@ -15,7 +15,7 @@
 > | 2 — TUI | ✅ including offline `verify-fix` |
 > | 3 — web GUI + desktop GUI | ✅ coverage badge in `web/src/components/DvalinWorkspace.tsx`; the §1.2 caveat line is gone |
 > | 4 — VS Code extension | ✅ coverage in the status bar, Problems context, and output channel — and beyond the original minimum, an offline VFR re-derivation command |
-> | *(not in this plan)* harness | ❌ tracked in [#205](https://github.com/arthurpanhku/dvalincode/issues/205) |
+> | *(not in this plan)* harness | ✅ coverage and fix-record refs in the `run` result — [#205](https://github.com/arthurpanhku/dvalincode/issues/205) |
 >
 > The GitHub Action, which this plan did not cover, also re-derives and publishes the
 > record on the pull request.

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -270,4 +270,25 @@ function writeTextResult(execution: HarnessRunExecution, io: RunCommandIO): void
     `--- Session: ${result.sessionId ?? 'n/a'} | ${result.iterationsUsed > 1 ? `(${result.iterationsUsed} iterations) ` : ''}Model: ${result.provider ?? 'unknown'}/${result.model ?? 'unknown'} ---\n`,
   );
   if (result.runId) io.stdout.write(`🔒 Audit: run ${result.runId} — \`dvalincode report --last\`\n`);
+  writeVerificationLines(result.verification, io);
+}
+
+/**
+ * The human-readable half. `json` and `stream-json` carry the whole envelope, so
+ * this only has to say the part a reader would otherwise have to know to ask
+ * for: what the scan covered, and where to re-derive any record it produced.
+ */
+function writeVerificationLines(verification: HarnessRunResult['verification'], io: RunCommandIO): void {
+  if (!verification) return;
+  const mark = verification.coverageStatus === 'complete' ? '🔎' : '⚠️';
+  io.stdout.write(`${mark} Scan coverage: ${verification.coverageStatus}\n`);
+  for (const scan of verification.scans) {
+    for (const entry of scan.coverage.deferred) io.stdout.write(`   · deferred: ${entry}\n`);
+    for (const entry of scan.coverage.exclusions) io.stdout.write(`   · excluded: ${entry}\n`);
+  }
+  for (const record of verification.fixRecords) {
+    io.stdout.write(
+      `📄 Fix record ${record.recordHash.slice(0, 12)} (${record.verified ? 'verified' : 'not verified'}, ${record.assurance}) — \`dvalincode security verify-fix ${record.path}\`\n`,
+    );
+  }
 }

--- a/src/harness/run.ts
+++ b/src/harness/run.ts
@@ -13,6 +13,7 @@ import {
   type UnattendedPermissionMode,
 } from '../core/policy.js';
 import { loadSession } from '../sessions/store.js';
+import { createVerificationCollector, type HarnessVerification } from './verification.js';
 
 export const DEFAULT_RUN_TIMEOUT_MINUTES = 25;
 
@@ -33,6 +34,20 @@ export type HarnessRunResult = {
   output: string;
   stopReason: HarnessStopReason;
   error?: string;
+  /**
+   * What the turn's security scanning covered, and any Verified Fix Record it
+   * filed. Absent when the turn did neither — which is deliberately different
+   * from a scan whose coverage came back `unknown`. A consumer that cannot tell
+   * "nothing was scanned" from "the scan could not say what it looked at" is
+   * back to the problem this field exists to solve.
+   *
+   * It does not affect `exitCode`. Coverage describes the scan, not the run:
+   * a turn that completed its task with a half-blind scanner did not fail, and
+   * folding that into the process exit would silently change a documented
+   * contract for every existing consumer. The status is reported so a caller
+   * can gate on it deliberately.
+   */
+  verification?: HarnessVerification;
 };
 
 export type HarnessRunRequest = {
@@ -100,31 +115,48 @@ export async function executeHarnessRun(
   let iterationsUsed = 0;
   let usage = { inputTokens: 0, outputTokens: 0 };
   let output = '';
+  let verificationCollector: ReturnType<typeof createVerificationCollector> | undefined;
 
   const finish = (
     exitCode: HarnessRunExecution['exitCode'],
     stopReason: HarnessStopReason,
     error?: string,
     auditHead?: string,
-  ): HarnessRunExecution => ({
-    exitCode,
-    result: {
-      ok: exitCode === 0,
-      sessionId,
-      runId,
-      auditHead,
-      policyHash,
-      provider,
-      model,
-      iterationsUsed,
-      toolCalls,
-      usage,
-      wallSeconds: (Date.now() - startedAt) / 1000,
-      output,
-      stopReason,
-      ...(error ? { error } : {}),
-    },
-  });
+  ): HarnessRunExecution => {
+    // Collected on every exit path, not only the successful one: a turn that
+    // scanned and then timed out still learned something about coverage, and
+    // dropping it would hide the scan precisely when the run needs explaining.
+    //
+    // Guarded because this runs inside the catch path too. A field that reports
+    // on the run must never be able to fail the run, or replace the error that
+    // actually ended it with one from the reporting itself.
+    let collected: HarnessVerification | undefined;
+    try {
+      collected = verificationCollector?.collect();
+    } catch {
+      collected = undefined;
+    }
+    return {
+      exitCode,
+      result: {
+        ok: exitCode === 0,
+        sessionId,
+        runId,
+        auditHead,
+        policyHash,
+        provider,
+        model,
+        iterationsUsed,
+        toolCalls,
+        usage,
+        wallSeconds: (Date.now() - startedAt) / 1000,
+        output,
+        stopReason,
+        ...(error ? { error } : {}),
+        ...(collected ? { verification: collected } : {}),
+      },
+    };
+  };
 
   let timeoutSignal: AbortSignal | undefined;
   try {
@@ -202,6 +234,13 @@ export async function executeHarnessRun(
     const config: Partial<TurnConfig> = { maxIterations };
     if (request.maxToolCalls !== undefined) config.maxToolCallsPerTurn = request.maxToolCalls;
 
+    // Snapshot the fix-record store before the turn so the run is credited only
+    // with records it filed. A record is written by whatever `dvalin verify` the
+    // agent reaches for, under that command's own audit run, so there is no run
+    // id to join on -- what is new since this point is the only honest answer.
+    verificationCollector = createVerificationCollector(cwd);
+    verificationCollector.begin();
+
     const turn = await runAgentTurn(
       {
         content: request.content,
@@ -233,6 +272,7 @@ export async function executeHarnessRun(
         onEvent: event => {
           if (event.type === 'tool_call') toolCalls++;
           if (event.type === 'llm_iteration') iterationsUsed = event.iteration;
+          verificationCollector?.observe(event);
           hooks.onEvent?.(event);
         },
         // A headless surface has no human approval channel. Any tool path that

--- a/src/harness/verification.ts
+++ b/src/harness/verification.ts
@@ -1,0 +1,166 @@
+import { readdirSync } from 'node:fs';
+import path from 'node:path';
+
+import type { AgentEvent } from '../agent/types.js';
+import {
+  SECURITY_COVERAGE_STATUSES,
+  securityProjectId,
+  type SecurityCoverage,
+  type SecurityCoverageStatus,
+} from '../security/contracts.js';
+import type { VerifiedFixRecord } from '../security/fixRecord.js';
+import { defaultFixRecordDir, listFixRecords } from '../security/fixRecordStore.js';
+
+/**
+ * What a headless run can say about the scanning it did.
+ *
+ * Every surface a human watches now shows coverage. This is the one with no
+ * human present, which makes it the one where a silent omission does the most
+ * damage: a CI gate reading "no findings" from a run where half the engines
+ * were missing is the machine-readable form of the bug the rest of this work
+ * closed.
+ */
+
+/** One security scan performed during the turn, with what it actually covered. */
+export type HarnessScanCoverage = {
+  /** The tool that ran the scan, e.g. `run_security_suite`. */
+  tool: string;
+  toolCallId: string;
+  coverage: SecurityCoverage;
+};
+
+/**
+ * A Verified Fix Record filed during the turn.
+ *
+ * The record itself is not inlined — it is already a portable file, and
+ * `path` is what a consumer feeds to `dvalincode security verify-fix` to
+ * re-derive the verdict offline without re-running the agent.
+ */
+export type HarnessFixRecordRef = {
+  recordHash: string;
+  path: string;
+  /** Who edited the code. Recorded here as it is in the record: never consulted. */
+  executor: string;
+  assurance: VerifiedFixRecord['assurance'];
+  verified: boolean;
+  coverage: { before: SecurityCoverageStatus; after: SecurityCoverageStatus };
+};
+
+export type HarnessVerification = {
+  /**
+   * The weakest coverage this run has evidence of, across every scan it ran and
+   * every record it filed. The single field a CI gate should read: taking the
+   * best or the last would let one complete scan speak for a partial one.
+   */
+  coverageStatus: SecurityCoverageStatus;
+  scans: HarnessScanCoverage[];
+  fixRecords: HarnessFixRecordRef[];
+};
+
+export type VerificationCollector = {
+  /** Note which records already existed, so the run is credited only with what it filed. */
+  begin(): void;
+  observe(event: AgentEvent): void;
+  /** `undefined` when the turn neither scanned nor filed a record — see below. */
+  collect(): HarnessVerification | undefined;
+};
+
+/** `unknown` is weaker than `partial`: not knowing what ran is worse than knowing it was incomplete. */
+const COVERAGE_RANK: Record<SecurityCoverageStatus, number> = { unknown: 0, partial: 1, complete: 2 };
+
+function isCoverageStatus(value: unknown): value is SecurityCoverageStatus {
+  return typeof value === 'string' && (SECURITY_COVERAGE_STATUSES as readonly string[]).includes(value);
+}
+
+/**
+ * Tool metadata is `Record<string, unknown>` by the time it reaches an event, so
+ * it is validated rather than cast. A malformed `coverage` is dropped: reporting
+ * a status this did not actually read would be the same failure one level up.
+ */
+function asCoverage(value: unknown): SecurityCoverage | undefined {
+  if (!value || typeof value !== 'object') return undefined;
+  const candidate = value as Partial<SecurityCoverage>;
+  if (!isCoverageStatus(candidate.status)) return undefined;
+  if (!Array.isArray(candidate.scanners)) return undefined;
+  if (!Array.isArray(candidate.exclusions) || !Array.isArray(candidate.deferred) || !Array.isArray(candidate.notes)) {
+    return undefined;
+  }
+  return candidate as SecurityCoverage;
+}
+
+/**
+ * Hashes of the records already on disk.
+ *
+ * Read from filenames rather than by parsing: `saveFixRecord` names every file
+ * after the record's own hash, so the directory listing is the hash set, and a
+ * store with thousands of records costs one readdir instead of thousands of
+ * re-derivations.
+ */
+function existingRecordHashes(dir: string): Set<string> {
+  try {
+    return new Set(
+      readdirSync(dir)
+        .filter(name => name.endsWith('.json'))
+        .map(name => name.slice(0, -'.json'.length)),
+    );
+  } catch {
+    // No store yet, or unreadable. Either way nothing pre-existed that this run
+    // could be wrongly credited with.
+    return new Set();
+  }
+}
+
+export function createVerificationCollector(
+  cwd: string,
+  resolveDir: () => string = defaultFixRecordDir,
+): VerificationCollector {
+  const scans: HarnessScanCoverage[] = [];
+  let known = new Set<string>();
+  let begun = false;
+
+  return {
+    begin() {
+      known = existingRecordHashes(resolveDir());
+      begun = true;
+    },
+
+    observe(event) {
+      if (event.type !== 'tool_result') return;
+      const coverage = asCoverage(event.metadata?.coverage);
+      if (coverage) scans.push({ tool: event.name, toolCallId: event.id, coverage });
+    },
+
+    collect() {
+      const dir = resolveDir();
+      // Without a starting point every record in the store would look new, so a
+      // collector that was never begun reports scans only.
+      const filed = begun
+        ? listFixRecords(dir, { projectId: securityProjectId(cwd) }).filter(
+            record => !known.has(record.recordHash),
+          )
+        : [];
+
+      if (!scans.length && !filed.length) return undefined;
+
+      const fixRecords: HarnessFixRecordRef[] = filed.map(record => ({
+        recordHash: record.recordHash,
+        path: path.join(dir, `${record.recordHash}.json`),
+        executor: record.executor,
+        assurance: record.assurance,
+        verified: record.verdict.verified,
+        coverage: { before: record.before.coverage.status, after: record.after.coverage.status },
+      }));
+
+      const statuses: SecurityCoverageStatus[] = [
+        ...scans.map(scan => scan.coverage.status),
+        ...fixRecords.flatMap(record => [record.coverage.before, record.coverage.after]),
+      ];
+      const coverageStatus = statuses.reduce(
+        (weakest, status) => (COVERAGE_RANK[status] < COVERAGE_RANK[weakest] ? status : weakest),
+        'complete' as SecurityCoverageStatus,
+      );
+
+      return { coverageStatus, scans, fixRecords };
+    },
+  };
+}

--- a/tests/commands/run.test.ts
+++ b/tests/commands/run.test.ts
@@ -130,6 +130,76 @@ describe('dvalincode run command', () => {
     expect(code).toBe(exitCode);
     expect(JSON.parse(io.out())).toMatchObject({ ok: false, stopReason, error: 'failed' });
   });
+
+  const partialRun = (): HarnessRunResult => result({
+    verification: {
+      coverageStatus: 'partial',
+      scans: [{
+        tool: 'run_security_suite',
+        toolCallId: 'tc_1',
+        coverage: {
+          status: 'partial',
+          scanners: [{ id: 'builtin', status: 'completed' }, { id: 'semgrep', status: 'missing' }],
+          exclusions: [],
+          deferred: ['Semgrep: missing'],
+          notes: [],
+        },
+      }],
+      fixRecords: [{
+        recordHash: 'a'.repeat(64),
+        path: '/records/aaa.json',
+        executor: 'codex',
+        assurance: 'scan-and-checks',
+        verified: true,
+        coverage: { before: 'partial', after: 'partial' },
+      }],
+    },
+  });
+
+  it('carries coverage and the fix record into json output', async () => {
+    const io = captureIo();
+    const fake = vi.fn(async (): Promise<HarnessRunExecution> => ({ exitCode: 0, result: partialRun() }));
+    const code = await runCommand(['scan'], { outputFormat: 'json' }, io, fake);
+
+    // The point of the whole field: a CI job reading this run's zero findings
+    // can see that half the engines never ran.
+    expect(code).toBe(0);
+    const parsed = JSON.parse(io.out());
+    expect(parsed.verification.coverageStatus).toBe('partial');
+    expect(parsed.verification.scans[0].coverage.deferred).toEqual(['Semgrep: missing']);
+    expect(parsed.verification.fixRecords[0].path).toBe('/records/aaa.json');
+  });
+
+  it('carries coverage into the stream-json result line', async () => {
+    const io = captureIo();
+    const fake = vi.fn(async (): Promise<HarnessRunExecution> => ({ exitCode: 0, result: partialRun() }));
+    await runCommand(['scan'], { outputFormat: 'stream-json', quiet: true }, io, fake);
+
+    const last = JSON.parse(io.out().trim().split('\n').at(-1)!);
+    expect(last).toMatchObject({ type: 'result' });
+    expect(last.verification.coverageStatus).toBe('partial');
+  });
+
+  it('states coverage and how to re-derive the record in text output', async () => {
+    const io = captureIo();
+    const fake = vi.fn(async (): Promise<HarnessRunExecution> => ({ exitCode: 0, result: partialRun() }));
+    await runCommand(['scan'], { outputFormat: 'text', quiet: true }, io, fake);
+
+    expect(io.out()).toContain('Scan coverage: partial');
+    expect(io.out()).toContain('deferred: Semgrep: missing');
+    expect(io.out()).toContain('security verify-fix /records/aaa.json');
+  });
+
+  it('says nothing about coverage when the run did no scanning', async () => {
+    const io = captureIo();
+    const fake = vi.fn(async (): Promise<HarnessRunExecution> => ({ exitCode: 0, result: result() }));
+    await runCommand(['write a readme'], { outputFormat: 'json' }, io, fake);
+
+    // Absent rather than `unknown`: an ordinary coding turn did not fail to
+    // determine coverage, it had no scan to determine coverage for.
+    expect(JSON.parse(io.out()).verification).toBeUndefined();
+    expect(io.out()).not.toContain('coverage');
+  });
 });
 
 describe('headless run validation and unattended policy', () => {

--- a/tests/harness/verification.test.ts
+++ b/tests/harness/verification.test.ts
@@ -1,0 +1,294 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+// Stubbed so the end-to-end block below reaches no provider, network, or agent
+// loop. What it exercises is the wiring in `executeHarnessRun` -- that the
+// collector is begun, fed every event, and collected on the way out.
+const runAgentTurn = vi.hoisted(() => vi.fn());
+vi.mock('../../src/agent/session.js', async importOriginal => {
+  const actual = await importOriginal<typeof import('../../src/agent/session.js')>();
+  return { ...actual, runAgentTurn };
+});
+
+import { executeHarnessRun } from '../../src/harness/run.js';
+import { createVerificationCollector } from '../../src/harness/verification.js';
+import { buildFixRecord } from '../../src/security/fixRecord.js';
+import { saveFixRecord } from '../../src/security/fixRecordStore.js';
+import { securityProjectId, type SecurityCoverage, type SecurityCoverageStatus } from '../../src/security/contracts.js';
+import type { AgentEvent } from '../../src/agent/types.js';
+
+const dirs: string[] = [];
+
+function tempDir(prefix: string): string {
+  const dir = mkdtempSync(path.join(tmpdir(), prefix));
+  dirs.push(dir);
+  return dir;
+}
+
+function coverage(status: SecurityCoverageStatus, deferred: string[] = []): SecurityCoverage {
+  return {
+    status,
+    scanners: [{ id: 'builtin', status: status === 'complete' ? 'completed' : 'missing' }],
+    exclusions: [],
+    deferred,
+    notes: [],
+  };
+}
+
+/** A tool_result carrying whatever a tool put in `metadata`. */
+function toolResult(metadata: Record<string, unknown>, name = 'run_security_suite'): AgentEvent {
+  return { type: 'tool_result', name, id: 'tc_1', output: 'ok', metadata };
+}
+
+/** A record that re-derives, so `listFixRecords` will not skip it. */
+function record(projectRoot: string, options: { before?: SecurityCoverageStatus; after?: SecurityCoverageStatus; at?: string } = {}) {
+  return buildFixRecord({
+    projectId: securityProjectId(projectRoot),
+    executor: 'codex',
+    before: {
+      scanId: 'scan_before',
+      completedAt: '2026-09-03T00:00:00.000Z',
+      coverage: coverage(options.before ?? 'complete'),
+      targets: [],
+    },
+    after: {
+      scanId: 'scan_after',
+      completedAt: '2026-09-03T00:01:00.000Z',
+      coverage: coverage(options.after ?? 'complete'),
+      remainingTargets: [],
+    },
+    checks: [],
+    generatedAt: options.at ?? '2026-09-03T00:02:00.000Z',
+  });
+}
+
+afterEach(() => {
+  while (dirs.length) rmSync(dirs.pop()!, { recursive: true, force: true });
+});
+
+describe('harness verification collector', () => {
+  let store: string;
+  let cwd: string;
+
+  beforeEach(() => {
+    store = tempDir('dvalin-fixrecords-');
+    cwd = tempDir('dvalin-workspace-');
+  });
+
+  const collector = () => createVerificationCollector(cwd, () => store);
+
+  it('reports nothing when the turn neither scanned nor filed a record', () => {
+    const subject = collector();
+    subject.begin();
+    subject.observe({ type: 'llm_iteration', iteration: 1 });
+
+    // Absent, not `unknown`. A caller must be able to tell "no scan happened"
+    // from "a scan could not say what it looked at" -- collapsing the two is
+    // the failure this field exists to prevent.
+    expect(subject.collect()).toBeUndefined();
+  });
+
+  it('carries the coverage a scan tool reported', () => {
+    const subject = collector();
+    subject.begin();
+    subject.observe(toolResult({ coverage: coverage('partial', ['semgrep: missing']) }));
+
+    const result = subject.collect();
+    expect(result?.coverageStatus).toBe('partial');
+    expect(result?.scans).toHaveLength(1);
+    expect(result?.scans[0]).toMatchObject({ tool: 'run_security_suite', toolCallId: 'tc_1' });
+    expect(result?.scans[0]?.coverage.deferred).toEqual(['semgrep: missing']);
+  });
+
+  it('reports the weakest coverage across several scans, not the last or the best', () => {
+    const subject = collector();
+    subject.begin();
+    subject.observe(toolResult({ coverage: coverage('partial') }));
+    subject.observe(toolResult({ coverage: coverage('complete') }));
+
+    // A later complete scan must not speak for the earlier partial one.
+    expect(subject.collect()?.coverageStatus).toBe('partial');
+    expect(subject.collect()?.scans).toHaveLength(2);
+  });
+
+  it('treats unknown as weaker than partial', () => {
+    const subject = collector();
+    subject.begin();
+    subject.observe(toolResult({ coverage: coverage('partial') }));
+    subject.observe(toolResult({ coverage: coverage('unknown') }));
+
+    expect(subject.collect()?.coverageStatus).toBe('unknown');
+  });
+
+  it('drops malformed coverage rather than reporting a status it did not read', () => {
+    const subject = collector();
+    subject.begin();
+    subject.observe(toolResult({ coverage: { status: 'mostly-fine' } }));
+    subject.observe(toolResult({ coverage: 'complete' }));
+    subject.observe(toolResult({ cases: [] }));
+
+    expect(subject.collect()).toBeUndefined();
+  });
+
+  it('credits the run only with records filed after it began', () => {
+    const before = record(cwd, { at: '2026-09-02T00:00:00.000Z' });
+    saveFixRecord(before, store);
+
+    const subject = collector();
+    subject.begin();
+    const during = record(cwd, { at: '2026-09-03T12:00:00.000Z' });
+    saveFixRecord(during, store);
+
+    const result = subject.collect();
+    expect(result?.fixRecords.map(entry => entry.recordHash)).toEqual([during.recordHash]);
+    expect(result?.fixRecords[0]).toMatchObject({
+      executor: 'codex',
+      assurance: 'scan-only',
+      path: path.join(store, `${during.recordHash}.json`),
+    });
+  });
+
+  it('ignores records belonging to another workspace', () => {
+    const other = tempDir('dvalin-other-workspace-');
+    const subject = collector();
+    subject.begin();
+    saveFixRecord(record(other), store);
+
+    // The store is install-global; another project's record is someone else's
+    // file paths and rule ids, and is not evidence about this run.
+    expect(subject.collect()).toBeUndefined();
+  });
+
+  it("folds a record's own coverage into the headline status", () => {
+    const subject = collector();
+    subject.begin();
+    saveFixRecord(record(cwd, { after: 'partial' }), store);
+
+    // The scan behind a record counts too: a repair verified against a
+    // half-blind rescan is exactly the case a gate must not read as clean.
+    expect(subject.collect()?.coverageStatus).toBe('partial');
+  });
+
+  it('reports scans even when begin() was never called', () => {
+    const subject = createVerificationCollector(cwd, () => store);
+    saveFixRecord(record(cwd), store);
+    subject.observe(toolResult({ coverage: coverage('complete') }));
+
+    // Without a starting point every record on disk would look new, so records
+    // are withheld -- but what the turn itself reported still stands.
+    const result = subject.collect();
+    expect(result?.scans).toHaveLength(1);
+    expect(result?.fixRecords).toEqual([]);
+  });
+
+  it('survives a fix-record store that does not exist', () => {
+    const subject = createVerificationCollector(cwd, () => path.join(store, 'absent'));
+    subject.begin();
+    subject.observe(toolResult({ coverage: coverage('complete') }));
+
+    expect(subject.collect()?.coverageStatus).toBe('complete');
+  });
+});
+
+describe('executeHarnessRun carries verification into its result', () => {
+  let store: string;
+  let cwd: string;
+
+  beforeEach(() => {
+    store = tempDir('dvalin-e2e-records-');
+    cwd = tempDir('dvalin-e2e-workspace-');
+    process.env.DVALINCODE_FIX_RECORD_DIR = store;
+    process.env.DVALINCODE_POLICY_FILE = path.join(cwd, 'absent-policy.json');
+    process.env.DVALINCODE_SESSIONS_DIR = path.join(cwd, 'sessions');
+    runAgentTurn.mockReset();
+  });
+
+  afterEach(() => {
+    delete process.env.DVALINCODE_FIX_RECORD_DIR;
+    delete process.env.DVALINCODE_POLICY_FILE;
+    delete process.env.DVALINCODE_SESSIONS_DIR;
+  });
+
+  /** A turn that emits the given events, then finishes normally. */
+  function turnEmitting(...events: AgentEvent[]) {
+    return async (_request: unknown, hooks: { onEvent?: (event: AgentEvent) => void }) => {
+      for (const event of events) hooks.onEvent?.(event);
+      return {
+        sessionId: 'dc_e2e',
+        providerId: 'mock',
+        model: 'mock-model',
+        policyHash: 'policy',
+        result: {
+          runId: 'run_e2e',
+          iterationsUsed: 1,
+          usage: { inputTokens: 1, outputTokens: 1 },
+          output: 'done',
+          stopReason: 'done',
+          auditHead: 'head',
+        },
+      };
+    };
+  }
+
+  it('reports the coverage a scan tool emitted during the turn', async () => {
+    runAgentTurn.mockImplementation(turnEmitting(toolResult({ coverage: coverage('partial', ['Semgrep: missing']) })));
+
+    const execution = await executeHarnessRun({ content: 'scan this repo', cwd });
+
+    expect(execution.exitCode).toBe(0);
+    expect(execution.result.verification?.coverageStatus).toBe('partial');
+    expect(execution.result.verification?.scans[0]?.coverage.deferred).toEqual(['Semgrep: missing']);
+  });
+
+  it('reports a fix record the turn filed, with a path that re-derives it', async () => {
+    const filed = record(cwd);
+    runAgentTurn.mockImplementation(async (_request: unknown, hooks: { onEvent?: (event: AgentEvent) => void }) => {
+      // Stands in for the agent shelling out to `dvalin verify`, which files the
+      // record under its own audit run -- there is no run id to join on.
+      saveFixRecord(filed, store);
+      return turnEmitting()(_request, hooks);
+    });
+
+    const execution = await executeHarnessRun({ content: 'fix and verify', cwd });
+
+    const reported = execution.result.verification?.fixRecords ?? [];
+    expect(reported.map(entry => entry.recordHash)).toEqual([filed.recordHash]);
+    expect(reported[0]?.path).toBe(path.join(store, `${filed.recordHash}.json`));
+  });
+
+  it('still reports coverage when the turn failed after scanning', async () => {
+    runAgentTurn.mockImplementation(async (_request: unknown, hooks: { onEvent?: (event: AgentEvent) => void }) => {
+      hooks.onEvent?.(toolResult({ coverage: coverage('unknown') }));
+      throw new Error('provider exploded');
+    });
+
+    const execution = await executeHarnessRun({ content: 'scan this repo', cwd });
+
+    // A run that scanned and then died still learned something about coverage.
+    expect(execution.exitCode).toBe(1);
+    expect(execution.result.verification?.coverageStatus).toBe('unknown');
+  });
+
+  it('leaves the exit code alone when coverage is partial', async () => {
+    runAgentTurn.mockImplementation(turnEmitting(toolResult({ coverage: coverage('partial') })));
+
+    const execution = await executeHarnessRun({ content: 'scan this repo', cwd });
+
+    // Deliberate, and the one decision here that touches an external contract:
+    // coverage describes the scan, not the run. A turn that completed its task
+    // with a half-blind scanner did not fail, and folding this into the process
+    // exit would silently redefine exit 0 for every existing consumer.
+    expect(execution.exitCode).toBe(0);
+    expect(execution.result.ok).toBe(true);
+  });
+
+  it('omits the field entirely for a turn that never scanned', async () => {
+    runAgentTurn.mockImplementation(turnEmitting({ type: 'llm_iteration', iteration: 1 }));
+
+    const execution = await executeHarnessRun({ content: 'write a readme', cwd });
+
+    expect(execution.result.verification).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Closes #205 — the last surface where a scan's coverage was invisible.

Every surface a human watches reports what a scan covered. The headless one did not, which makes it the one where the omission costs most: a CI gate reading "no findings" from a run where half the engines never installed is the machine-readable form of the bug the rest of this track closed.

`HarnessRunResult` now carries a `verification` envelope, so it reaches `json`, `stream-json`, the MCP `dvalin_run_task` result, and a line of text output without any of those needing to know about it.

```json
"verification": {
  "coverageStatus": "partial",
  "scans": [{ "tool": "run_security_suite", "toolCallId": "…", "coverage": { "status": "partial", "deferred": ["Semgrep CE: missing"], … } }],
  "fixRecords": [{ "recordHash": "…", "path": "…/fix-records/<hash>.json", "executor": "codex", "assurance": "scan-and-checks", "verified": true, "coverage": { "before": "complete", "after": "complete" } }]
}
```

## The decision the issue asked to make first

**Coverage does not change the exit code.** #205 flagged this as the one choice that alters an external contract, so stating it plainly:

A turn that finished its task with an engine missing did not fail. Folding that into the process exit would silently redefine exit 0 for every existing consumer. It would also put the wrong thing in code 5's seat — per HARNESS-MODE.md, 5 means *"it ran correctly and the answer was no"*, and `partial` is not an answer of no; it is a statement about how much of the question was examined. (`run` only ever exits 0–4 anyway; 5 belongs to `dvalin --fail-on`, which is the surface designed to gate on findings.)

So the status is reported and the caller gates deliberately:

```bash
dvalincode run --output-format json "scan and repair this repo" > run.json
jq -e '.verification.coverageStatus == "complete"' run.json || exit 1
```

## Design notes

- **`coverageStatus` is the weakest status the run has evidence of**, across every scan and every record. Taking the best or the last would let one complete scan speak for a partial one. `unknown` ranks below `partial`: not knowing what ran is worse than knowing it was incomplete.
- **The field is absent when the turn neither scanned nor filed a record** — deliberately not the same as `coverageStatus: "unknown"`. A consumer that cannot tell "nothing was scanned" from "the scan could not say what it looked at" is back where this started.
- **Fix records are matched by diffing the store around the turn, not by run id.** A record is written by whatever `dvalin verify` the agent reaches for, under *that command's* own audit run — there is no id to join on, so what is new since the turn began is the only honest answer. The pre-run snapshot reads filenames rather than parsing records, since `saveFixRecord` names each file after its own hash; a store with thousands of records costs one `readdir` instead of thousands of re-derivations.
- **Records are referenced by path, not inlined.** #205 explicitly allowed this: the record is already a portable file, and the path is what `dvalincode security verify-fix <path>` re-derives offline without re-running the agent. Only records for *this* workspace are listed — the store is install-global.
- **Malformed `coverage` metadata is dropped rather than coerced.** Tool metadata is `Record<string, unknown>` by the time it reaches an event; reporting a status this never actually read would be the same failure one level up.
- **Collection is guarded and runs on every exit path, including the catch.** A turn that scanned and then died still learned something about coverage, and a field that reports on a run must never be able to fail it or mask the error that ended it.

## Testing

`npm run check` — typecheck, GUI typecheck, and **544 passed** (525 on `main` + 19 new). One pre-existing unhandled `EPIPE` from `tests/mcp/stdio.test.ts` teardown, present on clean `main` too and not failing the run.

New: `tests/harness/verification.test.ts` (15) and four cases in `tests/commands/run.test.ts` covering the json, stream-json, text, and absent-field paths.

**Bypass-proof, verified by hand rather than asserted.** The CLI tests drive a fake executor, so they would not catch the wiring coming loose — the end-to-end block exists for that, and each mutation kills exactly the tests that cover it:

| Wiring removed from `src/harness/run.ts` | Result |
|---|---|
| `verificationCollector?.observe(event)` | 2 failed — coverage no longer reported, including on the error path |
| `verificationCollector.begin()` | 1 failed — every record on disk looks new, so the filed-during-run test breaks |
| `collect()` on non-zero exits | 1 failed — the "scanned then died" case |

Also ran `dvalin . --diff` over this change: no findings, coverage honestly reported `partial` (no external engines installed here — which is the thing this PR makes visible).

## Docs

`HARNESS-MODE.md` gains the field, its semantics, the gating one-liner, and the exit-code decision. ROADMAP moves #205 from Now/next into Recently shipped; the surfaces plan and the competitive analysis drop it from their outstanding lists.

## Security and AI Governance

- [x] This change does not expand file, shell, network, model, or approval permissions. — Read-only reporting: one `readdir` and one read of the existing fix-record store, both already reachable, and observation of events the harness already receives.
- [x] If it changes agent behavior, prompts, policy, providers, audit logging, or release/build security, I updated the relevant governance evidence in `docs/`. — No behavior change to the agent, policy, or audit chain; `HARNESS-MODE.md` updated for the new output field.
- [x] If it introduces a new model/provider/tool or new data flow, I completed `docs/governance/AI-CHANGE-IMPACT-ASSESSMENT.md`. — Not applicable; no new model, provider, or tool. The one new flow is a file path plus a hash already written to disk by the verification command.

## Notes

`run_security_scan` (the local-only scan tool) does not emit `coverage` in its metadata, so a turn that used only that tool reports no coverage. That is a gap in the tool rather than in the harness, and fixing it means giving the local scan a coverage envelope — out of scope here, worth its own issue if you want it tracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0186VyaiQq3MTo4i4mK8P3aW

---
_Generated by [Claude Code](https://claude.ai/code/session_0186VyaiQq3MTo4i4mK8P3aW)_