### PR TITLE
feat(fix-record): issue v2 from both producers (2/2)

### DIFF
--- a/src/commands/dvalin.ts
+++ b/src/commands/dvalin.ts
@@ -11,6 +11,7 @@ import { sha256 } from '../audit/hash.js';
 import { deriveCoverage, findingTargetFingerprint, securityProjectId, snapshotFinding, type SecurityCoverage } from '../security/contracts.js';
 import { renderCoverage } from '../security/render.js';
 import { FIX_EXECUTORS, buildFixRecord, renderFixRecord, type FixExecutor } from '../security/fixRecord.js';
+import type { SecurityCheckEvidence } from '../security/workflow.js';
 import { saveFixRecord } from '../security/fixRecordStore.js';
 import {
   EXECUTOR_IDS,
@@ -310,23 +311,15 @@ async function runAutomatedRemediation(input: {
   // Issued whether or not the gate passed: a record that says a repair did not
   // verify is exactly as useful as one that says it did, and dropping it on
   // failure would leave the only unrecorded outcome the one worth recording.
-  const record = buildFixRecord({
-    projectId: securityProjectId(input.root),
+  const record = buildRunFixRecord({
+    root: input.root,
     executor: fixExecutorFor(executor.id),
-    before: {
-      scanId: input.before.id,
-      completedAt: input.before.completedAt,
-      coverage: deriveCoverage(input.before),
-      targets: input.findings.map(snapshotFinding),
-    },
-    after: {
-      scanId: after.id,
-      completedAt: after.completedAt,
-      coverage: deriveCoverage(after),
-      remainingTargets: remainingTargets(input.findings, after),
-    },
-    changes: await changesFrom(cwd),
+    before: input.before,
+    after,
+    targets: input.findings,
+    baseline: input.baselineFindings,
     checks: verification.evidence,
+    changes: await changesFrom(cwd),
   });
   saveFixRecord(record);
   if (input.recordPath) {
@@ -367,6 +360,70 @@ function remainingTargets(
   return originals
     .map(snapshotFinding)
     .filter(target => present.has(target.targetFingerprint));
+}
+
+/**
+ * Assemble the record for one `--fix --verify` run.
+ *
+ * Extracted from the run so the evidence it carries can be asserted without
+ * standing up an executor, a worktree, and a git tree. The gap that made this
+ * worth extracting: with the assembly inline, a change that stopped supplying
+ * the regression evidence broke nothing any test could see.
+ */
+export function buildRunFixRecord(input: {
+  root: string;
+  executor: FixExecutor;
+  before: DvalinScanSuiteResult;
+  after: DvalinScanSuiteResult;
+  targets: DvalinScanSuiteResult['findings'];
+  baseline: DvalinScanSuiteResult['findings'];
+  checks: SecurityCheckEvidence[];
+  changes?: { files: string[]; diffHash: string };
+}) {
+  return buildFixRecord({
+    projectId: securityProjectId(input.root),
+    executor: input.executor,
+    before: {
+      scanId: input.before.id,
+      completedAt: input.before.completedAt,
+      coverage: deriveCoverage(input.before),
+      targets: input.targets.map(snapshotFinding),
+    },
+    after: {
+      scanId: input.after.id,
+      completedAt: input.after.completedAt,
+      coverage: deriveCoverage(input.after),
+      remainingTargets: remainingTargets(input.targets, input.after),
+    },
+    regression: {
+      // `high` and `new` encode the rule this path already applied through
+      // `evaluateVerificationGate`, which failed on findings scoring 7 or more
+      // that the baseline did not have. Recording it makes that rule part of
+      // the record instead of a property of whichever command issued it.
+      gate: { threshold: 'high', mode: 'new' },
+      introduced: introducedSince(input.baseline, input.after),
+    },
+    ...(input.changes ? { changes: input.changes } : {}),
+    checks: input.checks,
+  });
+}
+
+/**
+ * What the re-scan sees that the baseline did not — the repair's side effects.
+ *
+ * Compared against the baseline rather than the targets, so a finding that was
+ * already in the repository before the repair is not blamed on it. Unfiltered
+ * by severity: the record keeps the observation, and the recorded threshold
+ * decides what blocks.
+ */
+export function introducedSince(
+  baseline: DvalinScanSuiteResult['findings'],
+  after: DvalinScanSuiteResult,
+): ReturnType<typeof snapshotFinding>[] {
+  const known = new Set(baseline.map(finding => snapshotFinding(finding).fingerprint));
+  return after.findings
+    .map(snapshotFinding)
+    .filter(finding => !known.has(finding.fingerprint));
 }
 
 /**

--- a/src/security/workflow.ts
+++ b/src/security/workflow.ts
@@ -197,6 +197,8 @@ export async function verifySecurityWorkflow(input: {
   if (workflow.state !== 'verifying') workflow = await transitionSecurityWorkflow(workflow, 'verifying');
   const checks = input.checks ?? [];
   const at = new Date().toISOString();
+  const originalTargetKeys = new Set(originalGate(workflow).blocking.map(finding => finding.targetFingerprint));
+  const initialFingerprints = new Set(workflow.initialScan.findings.map(finding => finding.fingerprint));
   const record = buildFixRecord({
     workflowId: workflow.id,
     projectId: workflow.projectId,
@@ -212,7 +214,18 @@ export async function verifySecurityWorkflow(input: {
       completedAt: input.result.completedAt,
       coverage: input.coverage
         ?? unknownCoverage('The verifying scan did not record its coverage.'),
-      remainingTargets: input.gate.blocking,
+      // Only the original targets. `gate.blocking` also carries findings the
+      // repair introduced, and folding the two into one field is what let this
+      // path and the --fix path mean different things by the same record.
+      remainingTargets: input.gate.blocking.filter(finding => originalTargetKeys.has(finding.targetFingerprint)),
+    },
+    regression: {
+      gate: { threshold: input.gate.threshold, mode: input.gate.mode },
+      // The complete set, not the gate's threshold-filtered one: the record
+      // keeps the observation so a stricter reader can re-decide from it.
+      introduced: input.result.findings
+        .map(snapshotFinding)
+        .filter(finding => !initialFingerprints.has(finding.fingerprint)),
     },
     ...(input.changes ? { changes: input.changes } : {}),
     checks,

--- a/tests/dvalinCommand.test.ts
+++ b/tests/dvalinCommand.test.ts
@@ -4,7 +4,9 @@ import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { AuditSink } from '../src/audit/log.js';
 import {
+  buildRunFixRecord,
   dvalinFailureThresholdMet,
+  introducedSince,
   parseDvalinScannerIds,
   parsePorcelainZ,
   renderDvalinResult,
@@ -168,5 +170,105 @@ describe('parsePorcelainZ', () => {
 
   it('reports nothing for a clean tree', () => {
     expect(parsePorcelainZ('')).toEqual([]);
+  });
+});
+
+describe('introduced findings on the --fix path', () => {
+  const scan = (findings: DvalinScanSuiteResult['findings']): DvalinScanSuiteResult => ({
+    id: 'scan', source: 'Dvalin Security Suite', startedAt: 'a', completedAt: 'b',
+    score: 90, grade: 'B', totalResults: findings.length, skippedResults: 0,
+    metrics: { critical: 0, high: findings.length, medium: 0, low: 0, files: 1, rules: 1 },
+    scanners: [{ id: 'builtin', name: 'Built-in', category: 'secrets', description: '', available: true, homepage: '', status: 'completed', findings: findings.length, durationMs: 1 }],
+    findings,
+  });
+
+  const evalFinding: DvalinScanSuiteResult['findings'][number] = {
+    id: 'one', source: 'Dvalin Local Scan', ruleId: 'dvalin/eval', ruleName: 'Eval',
+    severity: 'error', securitySeverity: '8.0', message: 'eval', path: 'src/app.ts', startLine: 4, tags: [], prompt: 'x',
+  };
+  const sqlFinding: DvalinScanSuiteResult['findings'][number] = {
+    ...evalFinding, id: 'two', ruleId: 'dvalin/sql-string-concatenation', securitySeverity: '9.1',
+    message: 'sql', path: 'src/db.ts', startLine: 12,
+  };
+
+  it('reports what the re-scan has that the baseline did not', () => {
+    const introduced = introducedSince([evalFinding], scan([evalFinding, sqlFinding]));
+
+    // The bug this closes: the repair cleared its target and added an
+    // injection, and the record used to call that verified.
+    expect(introduced.map(finding => finding.ruleId)).toEqual(['dvalin/sql-string-concatenation']);
+  });
+
+  it('does not blame the repair for what the baseline already had', () => {
+    expect(introducedSince([evalFinding, sqlFinding], scan([evalFinding, sqlFinding]))).toEqual([]);
+  });
+
+  it('reports an empty list rather than nothing when the repair added nothing', () => {
+    // Distinct from the `null` that means nobody looked -- which is the whole
+    // reason the field is three-state.
+    expect(introducedSince([evalFinding], scan([evalFinding]))).toEqual([]);
+  });
+
+  it('keeps findings below the blocking threshold in the list', () => {
+    const note = { ...evalFinding, id: 'three', ruleId: 'dvalin/style', severity: 'note' as const, securitySeverity: '1.0', path: 'src/x.ts' };
+    const introduced = introducedSince([], scan([note]));
+
+    // The record keeps the observation; the recorded threshold decides what
+    // blocks. Filtering here would throw away evidence a stricter reader wants.
+    expect(introduced.map(finding => finding.ruleId)).toEqual(['dvalin/style']);
+  });
+});
+
+describe('the record a --fix --verify run issues', () => {
+  const scan = (id: string, findings: DvalinScanSuiteResult['findings']): DvalinScanSuiteResult => ({
+    id, source: 'Dvalin Security Suite', startedAt: 'a', completedAt: 'b',
+    score: 90, grade: 'B', totalResults: findings.length, skippedResults: 0,
+    metrics: { critical: 0, high: findings.length, medium: 0, low: 0, files: 1, rules: 1 },
+    scanners: [{ id: 'builtin', name: 'Built-in', category: 'secrets', description: '', available: true, homepage: '', status: 'completed', findings: findings.length, durationMs: 1 }],
+    findings,
+  });
+
+  const evalFinding: DvalinScanSuiteResult['findings'][number] = {
+    id: 'one', source: 'Dvalin Local Scan', ruleId: 'dvalin/eval', ruleName: 'Eval',
+    severity: 'error', securitySeverity: '8.0', message: 'eval', path: 'src/app.ts', startLine: 4, tags: [], prompt: 'x',
+  };
+  const sqlFinding: DvalinScanSuiteResult['findings'][number] = {
+    ...evalFinding, id: 'two', ruleId: 'dvalin/sql-string-concatenation', securitySeverity: '9.1',
+    message: 'sql', path: 'src/db.ts', startLine: 12,
+  };
+  const passing = [{ kind: 'test', command: 'npm test', exitCode: 0, passed: true }];
+
+  const build = (after: DvalinScanSuiteResult) => buildRunFixRecord({
+    root: '/tmp/project',
+    executor: 'codex',
+    before: scan('before', [evalFinding]),
+    after,
+    targets: [evalFinding],
+    baseline: [evalFinding],
+    checks: passing,
+  });
+
+  it('refuses a repair that cleared its target and introduced an injection', () => {
+    const record = build(scan('after', [sqlFinding]));
+
+    // The defect, on the path that had it: the eval target is gone and the
+    // project's checks pass, and before this the record said VERIFIED while
+    // the command itself rejected the run a moment later.
+    expect(record.after.remainingTargets).toHaveLength(0);
+    expect(record.verdict.verified).toBe(false);
+    expect(record.outcome).toBe('regressed');
+  });
+
+  it('verifies a clean repair, and says what it looked for', () => {
+    const record = build(scan('after', []));
+    expect(record.verdict.verified).toBe(true);
+    expect(record.outcome).toBe('verified');
+    expect(record.after.introduced).toEqual([]);
+  });
+
+  it('carries the rule it was judged under so a third party can re-derive it', () => {
+    const record = build(scan('after', []));
+    expect(record.schema).toBe('dvalin-fix-record/v2');
+    expect(record.gate).toEqual({ threshold: 'high', mode: 'new' });
   });
 });

--- a/tests/securityWorkflow.test.ts
+++ b/tests/securityWorkflow.test.ts
@@ -121,4 +121,70 @@ describe.sequential('persistent security workflow', () => {
     expect(second.state).toBe('needs_work');
     expect(second.verification?.record?.after.remainingTargets).toHaveLength(1);
   });
+
+  it('refuses a repair that cleared its target but introduced a new one', async () => {
+    const created = await needsWork();
+    const introduced: DvalinScanSuiteResult['findings'][number] = {
+      id: 'two', source: 'Dvalin Local Scan', ruleId: 'dvalin/sql-string-concatenation', ruleName: 'SQLi',
+      severity: 'error', securitySeverity: '9.1', message: 'SQL built by concatenation',
+      path: 'src/db.ts', startLine: 12, tags: [], prompt: 'Fix it',
+    };
+    const after = result([introduced]);
+
+    const verified = await verifySecurityWorkflow({
+      workflow: created,
+      result: after,
+      gate: evaluateWorkflowVerificationGate(created, after),
+      checks: [passingCheck],
+    });
+
+    // The original eval finding is gone and the project's checks pass, so the
+    // question v1 asked is answered yes. The repair still traded one injection
+    // for another, and the record has to say so.
+    const record = verified.verification?.record;
+    expect(record?.after.remainingTargets).toHaveLength(0);
+    expect(record?.after.introduced?.map(f => f.ruleId)).toEqual(['dvalin/sql-string-concatenation']);
+    expect(record?.verdict.verified).toBe(false);
+    expect(record?.outcome).toBe('regressed');
+    expect(verified.state).toBe('needs_work');
+  });
+
+  it('issues a v2 record carrying the gate it was judged under', async () => {
+    const created = await needsWork();
+    const after = result([]);
+    const verified = await verifySecurityWorkflow({
+      workflow: created,
+      result: after,
+      gate: evaluateWorkflowVerificationGate(created, after),
+      checks: [passingCheck],
+    });
+
+    const record = verified.verification?.record;
+    expect(record?.schema).toBe('dvalin-fix-record/v2');
+    expect(record?.gate).toEqual({ threshold: 'high', mode: 'all' });
+    // Looked for and none found -- distinct from the null that means nobody looked.
+    expect(record?.after.introduced).toEqual([]);
+    expect(record?.outcome).toBe('verified');
+  });
+
+  it('does not blame the repair for a finding the baseline already had', async () => {
+    const created = await needsWork();
+    const preexisting: DvalinScanSuiteResult['findings'][number] = {
+      ...finding, id: 'one', ruleId: 'dvalin/eval',
+    };
+    // The same finding the workflow started from, still present: that is a
+    // remaining target, not something this repair introduced.
+    const after = result([preexisting]);
+    const verified = await verifySecurityWorkflow({
+      workflow: created,
+      result: after,
+      gate: evaluateWorkflowVerificationGate(created, after),
+      checks: [passingCheck],
+    });
+
+    const record = verified.verification?.record;
+    expect(record?.after.introduced).toEqual([]);
+    expect(record?.after.remainingTargets).toHaveLength(1);
+    expect(record?.outcome).toBe('target-remains');
+  });
 });


### PR DESCRIPTION
## Summary

**Stacked on #217** — base is `claude/fix-record-v2-shape`, so review that first. This is where the defect actually closes.

#217 added the shape and the version-aware re-derivation without changing what any command emits. This switches the two producers to supply the regression evidence, so records issued from here on are v2 and a repair that trades one vulnerability for another can no longer be called verified.

## What each path was doing

**`dvalin verify <workflow>`** was computing the right thing and putting it in the wrong place. `gate.blocking` holds the original targets still present *and* the findings the repair introduced, and the whole set went into `after.remainingTargets`. Now they are separated — targets filtered by the original target keys, introduced derived from the initial scan's fingerprints — with the gate's own `threshold` and `mode` recorded beside them.

**`dvalin . --fix --verify`** was not computing it for the record at all. It had the baseline in hand and used it in `evaluateVerificationGate` (which fails on findings scoring ≥ 7 the baseline lacked), but none of that reached `buildFixRecord`. So:

```
331  saveFixRecord(record)      ← says VERIFIED, written to --record, printed
340  if (!gate.passed) throw    ← "1 new high/critical finding target(s) appeared"
```

A record saying verified, on disk and re-deriving cleanly, for a repair the command rejects a moment later — and then collected by the Evidence Pack, the Action's PR comment, and anything else reading the store.

It now records `introduced` plus a gate of `high`/`new`, which is the rule that path already applied — written down rather than implied by which command happened to run.

**The ordering dissolves rather than needing a patch.** With the regression inside the record, filing before the gate throws is no longer a contradiction: the record already says the repair regressed. That the problem disappears instead of needing its own fix is the sign the shape was the right one.

## One extraction, and why it is not tidying

Record assembly on the `--fix` path moved into `buildRunFixRecord`. With it inline, I mutated the call site to `introduced: null` and **no test failed** — `introducedSince` was unit-tested, but the call site needs an executor, a worktree, and a git tree to reach. A helper that is tested while its only caller is not is the same shape of gap as the original defect: correct machinery, unverified wiring.

Extracting it makes the wiring assertable. Both mutations now fail tests.

## Testing

`npm run check` — both typechecks and **554 passed** (544 on #217 + 10 new). `dvalin . --diff` over the change: 0 findings.

**Mutation-tested.** Every switch is pinned by a test that fails when it is undone:

| Mutation | Result |
|---|---|
| workflow path stops supplying `regression` | 3 failed |
| workflow path puts `introduced` back into `remainingTargets` (the original conflation) | 1 failed |
| `--fix` call site supplies `introduced: null` | 2 failed |
| `--fix` records a `none` threshold, which would block nothing | 2 failed |

The headline case is asserted directly on both paths: a repair that clears its target, passes the project's checks, and introduces a critical SQL injection now yields `verified: false`, `outcome: 'regressed'`.

## Security and AI Governance

- [x] This change does not expand file, shell, network, model, or approval permissions. — Set arithmetic over scan results already in memory; no new I/O, subprocess, or egress.
- [x] If it changes agent behavior, prompts, policy, providers, audit logging, or release/build security, I updated the relevant governance evidence in `docs/`. — No agent, policy, or audit behavior change. The verdict rules are documented in FVP-1 by #217.
- [x] If it introduces a new model/provider/tool or new data flow, I completed `docs/governance/AI-CHANGE-IMPACT-ASSESSMENT.md`. — Not applicable; no new model, provider, or tool.

## Known residual divergence, not fixed here

`evaluateVerificationGate` also fails a run when the worktree has **no code changes**, and that condition is still not represented in the verdict. A run where the targets vanished, the checks passed, and nothing was edited would produce `verified: true` while the command throws. It is far rarer than the regression case and it is a different question — whether a record should have to prove a change happened at all — so it is not folded in here. The record already carries `changes` (files + diff hash), so the natural fix is a further FVP assertion rather than more producer logic. Say the word and I will file it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0186VyaiQq3MTo4i4mK8P3aW

---
_Generated by [Claude Code](https://claude.ai/code/session_0186VyaiQq3MTo4i4mK8P3aW)_