### PR TITLE
docs(readme): catch both READMEs up to fix-record v2, and publish its evidence in the Action comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 <p align="center">
   <a href="https://github.com/arthurpanhku/dvalincode/releases/latest"><img src="https://img.shields.io/github/v/release/arthurpanhku/dvalincode?style=for-the-badge&color=818cf8&label=Release" alt="Release"></a>
   <a href="https://github.com/arthurpanhku/dvalincode/releases"><img src="https://img.shields.io/github/downloads/arthurpanhku/dvalincode/total?style=for-the-badge&color=blue&label=Downloads" alt="Downloads"></a>
-  <a href="#-tests"><img src="https://img.shields.io/badge/Tests-572%20passing%20%E2%9C%93-success?style=for-the-badge" alt="Tests"></a>
+  <a href="#-tests"><img src="https://img.shields.io/badge/Tests-584%20%2F%20584%20%E2%9C%93-success?style=for-the-badge" alt="Tests"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-green?style=for-the-badge" alt="License"></a>
   <a href="https://scorecard.dev/viewer/?uri=github.com/arthurpanhku/dvalincode"><img src="https://api.scorecard.dev/projects/github.com/arthurpanhku/dvalincode/badge" alt="OpenSSF Scorecard"></a>
   <a href="#-quick-install"><img src="https://img.shields.io/badge/Platforms-macOS%20·%20Windows%20·%20Linux-blue?style=for-the-badge" alt="Platforms"></a>
@@ -154,8 +154,19 @@ job. The reviewer does not have to trust the pipeline that produced it, or us.
 - repaired by claude-code — recorded, and not consulted for this verdict
 - targets: 1 before → 0 remaining
 - coverage: complete → complete
+- introduced: none (gate high/new)
+- outcome: verified
 - ✓ test: `npm run test` (exit 0)
 - audit chain: verify-eeb1bae7 @ 80881867270d
+```
+
+A repair that regressed says so in the same place, and fails the job with it:
+
+```
+❌ 916e2eeaf065 · NOT VERIFIED · scan-and-checks
+- introduced: 1 finding(s) the first scan did not report (gate high/new)
+  - critical dvalin/sql-injection — src/db.ts:31
+- outcome: regressed
 ```
 
 ### Or let your agent call it
@@ -869,8 +880,8 @@ RESTORE → COMPACT → COMMAND → BUILD → RUN → SAVE → RESPOND → DONE
 npm test
 ```
 
-**572 passing · 6 skipped · 73 files · all green.** The VS Code extension has a
-separate 37-test suite plus one opt-in published-package integration test.
+**584 core tests · 74 files · all green.** The VS Code extension has a separate
+37-test suite plus one opt-in published-package integration test.
 
 ---
 
@@ -991,7 +1002,7 @@ Contributions welcome. The codebase is intentionally small and surgical — see 
 ```sh
 git clone https://github.com/arthurpanhku/dvalincode
 cd dvalincode && npm install
-npm test                # 572 passing · 6 skipped ✅
+npm test                # 584/584 core tests ✅
 npm run typecheck
 ```
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 <p align="center">
   <a href="https://github.com/arthurpanhku/dvalincode/releases/latest"><img src="https://img.shields.io/github/v/release/arthurpanhku/dvalincode?style=for-the-badge&color=818cf8&label=Release" alt="Release"></a>
   <a href="https://github.com/arthurpanhku/dvalincode/releases"><img src="https://img.shields.io/github/downloads/arthurpanhku/dvalincode/total?style=for-the-badge&color=blue&label=Downloads" alt="Downloads"></a>
-  <a href="#-tests"><img src="https://img.shields.io/badge/Tests-442%20%2F%20442%20%E2%9C%93-success?style=for-the-badge" alt="Tests"></a>
+  <a href="#-tests"><img src="https://img.shields.io/badge/Tests-572%20passing%20%E2%9C%93-success?style=for-the-badge" alt="Tests"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-green?style=for-the-badge" alt="License"></a>
   <a href="https://scorecard.dev/viewer/?uri=github.com/arthurpanhku/dvalincode"><img src="https://api.scorecard.dev/projects/github.com/arthurpanhku/dvalincode/badge" alt="OpenSSF Scorecard"></a>
   <a href="#-quick-install"><img src="https://img.shields.io/badge/Platforms-macOS%20·%20Windows%20·%20Linux-blue?style=for-the-badge" alt="Platforms"></a>
@@ -41,6 +41,8 @@ Fix record 2c9d71ac03e0 · VERIFIED · scan-and-checks
   executor: claude-code (recorded, not consulted)
   targets: 1 before · 0 remaining
   coverage: complete → complete
+  introduced: 0 (gate high/new)
+  outcome: verified
   ✓ test: npm run test (exit 0)
   audit: run verify-36509f42 @ 414644c75af0
 ```
@@ -50,6 +52,14 @@ these checks were observed to pass.* It is not a claim that your code is safe,
 and Dvalin will not let it be read as one — every record carries what the scan
 actually covered, and a repair no check could confirm does not pass.
 [The open profile →](docs/spec/FIX-VERIFICATION.md)
+
+A repair is a change, and a change can add as well as remove. So the record also
+carries what the re-scan saw that the first scan did not, and the gate threshold
+the verdict was reached under: a fix that removes an `eval` and introduces an SQL
+injection is recorded as `regressed` and does not verify. Neither does a record
+whose issuer never looked — `introduced: not determined` fails, because a
+verifier that skips the question must not score better than one that asks it and
+finds something.
 
 Dvalin is the independent security runtime between code generation and merge.
 Humans, coding agents, and CI call the same versioned contract for discovery,
@@ -181,9 +191,10 @@ re-scan through `dvalin_get_finding` and `dvalin_verify_findings`.
 That last one is the point: an agent that has just written a repair can ask for
 an independent verdict on it. Dvalin re-scans, runs the project's own checks
 itself, and returns a **Verified Fix Record** — what was targeted, what remains,
-which commands ran and the exit codes Dvalin observed, and how much of the
-codebase was actually covered. Whoever wrote the repair is recorded and never
-consulted. `dvalin_verify_fix` re-derives such a record offline, so the reviewer
+what the repair introduced that was not there before, the gate the verdict was
+reached under, which commands ran and the exit codes Dvalin observed, and how
+much of the codebase was actually covered. Whoever wrote the repair is recorded
+and never consulted. `dvalin_verify_fix` re-derives such a record offline, so the reviewer
 receiving it does not have to trust the tool that issued it.
 [FVP-1 →](docs/spec/FIX-VERIFICATION.md) Responses include MCP `structuredContent`; scanner
 readiness is available through `dvalin_list_scanners`. The same server exposes
@@ -670,6 +681,19 @@ Headless `run` and `mcp-serve` keep the same policy and audit chokepoint as
 the interactive clients. See the [unattended recipes](docs/RECIPES-UNATTENDED.md)
 for cron, CI, and external-agent examples.
 
+A run that scanned or filed a fix record also carries a `verification` envelope
+beside its answer — in `json`, in `stream-json`, and in the MCP `dvalin_run_task`
+result. `coverageStatus` is the *weakest* coverage the run has evidence of, so
+one complete scan cannot speak for a partial one, and any record it produced is
+listed by path for offline re-derivation. A CI gate can read it directly:
+
+```sh
+jq -e '.verification.coverageStatus == "complete"' run.json || exit 1
+```
+
+That is the same rule the pull-request comment applies, on the surface with no
+human watching. [Harness mode →](docs/HARNESS-MODE.md)
+
 ### Windows
 
 Download `dvalincode-v*-windows-x64.zip` from [Releases](https://github.com/arthurpanhku/dvalincode/releases/latest), unzip, then double-click `start.bat`.
@@ -845,8 +869,8 @@ RESTORE → COMPACT → COMMAND → BUILD → RUN → SAVE → RESPOND → DONE
 npm test
 ```
 
-**518 core tests · 70 files · all green.** The VS Code extension has a separate
-37-test suite plus one opt-in published-package integration test.
+**572 passing · 6 skipped · 73 files · all green.** The VS Code extension has a
+separate 37-test suite plus one opt-in published-package integration test.
 
 ---
 
@@ -967,7 +991,7 @@ Contributions welcome. The codebase is intentionally small and surgical — see 
 ```sh
 git clone https://github.com/arthurpanhku/dvalincode
 cd dvalincode && npm install
-npm test                # 518/518 core tests ✅
+npm test                # 572 passing · 6 skipped ✅
 npm run typecheck
 ```
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -9,7 +9,7 @@
 <p align="center">
   <a href="https://github.com/arthurpanhku/dvalincode/releases/latest"><img src="https://img.shields.io/github/v/release/arthurpanhku/dvalincode?style=for-the-badge&color=818cf8&label=Release" alt="Release"></a>
   <a href="https://github.com/arthurpanhku/dvalincode/releases"><img src="https://img.shields.io/github/downloads/arthurpanhku/dvalincode/total?style=for-the-badge&color=blue&label=Downloads" alt="Downloads"></a>
-  <a href="#-测试"><img src="https://img.shields.io/badge/Tests-442%20%2F%20442%20%E2%9C%93-success?style=for-the-badge" alt="Tests"></a>
+  <a href="#-测试"><img src="https://img.shields.io/badge/Tests-572%20passing%20%E2%9C%93-success?style=for-the-badge" alt="Tests"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-green?style=for-the-badge" alt="License"></a>
   <a href="https://scorecard.dev/viewer/?uri=github.com/arthurpanhku/dvalincode"><img src="https://api.scorecard.dev/projects/github.com/arthurpanhku/dvalincode/badge" alt="OpenSSF Scorecard"></a>
   <a href="#-一行安装"><img src="https://img.shields.io/badge/Platforms-macOS%20·%20Windows%20·%20Linux-blue?style=for-the-badge" alt="Platforms"></a>
@@ -38,6 +38,8 @@ Fix record 2c9d71ac03e0 · VERIFIED · scan-and-checks
   executor: claude-code (recorded, not consulted)
   targets: 1 before · 0 remaining
   coverage: complete → complete
+  introduced: 0 (gate high/new)
+  outcome: verified
   ✓ test: npm run test (exit 0)
   audit: run verify-36509f42 @ 414644c75af0
 ```
@@ -46,6 +48,12 @@ Fix record 2c9d71ac03e0 · VERIFIED · scan-and-checks
 「你的代码安全了」这种断言，Dvalin 也不允许它被这样解读 —— 每份记录都带着这次扫描
 究竟覆盖了什么，而一个没有任何检查能确认的修复，不会通过。
 [开放规范 →](docs/spec/FIX-VERIFICATION.md)
+
+修复本身也是一次改动，而改动既会移除问题，也可能带来新问题。所以记录里还带着复扫
+看到、而首扫没有看到的东西，以及这次判定所依据的门禁阈值：一个删掉了 `eval`、却引入
+了 SQL 注入的修复，会被记为 `regressed`，不予通过。签发方根本没去看的记录同样不通过
+—— `introduced: not determined` 直接失败，因为「不去查」绝不能比「查了并且查出问题」
+得分更高。
 
 Dvalin 是放在“代码生成”和“允许合并”之间的独立安全运行时。人类开发者、Coding
 Agent 和 CI 调用同一套版本化协议完成发现、修复与验证。它既可以独立运行，也可以通过
@@ -573,6 +581,18 @@ dvalincode mcp-serve             # 供外部 Agent 调用的任务级 stdio MCP 
 无头 `run` 和 `mcp-serve` 与交互客户端共用同一个策略与审计关卡。cron、CI
 和外部 Agent 示例见[无人值守配方](docs/RECIPES-UNATTENDED.md)。
 
+扫描过、或者产出过 fix record 的运行，还会在结果旁边带上一份 `verification` 信封 ——
+`json`、`stream-json` 以及 MCP `dvalin_run_task` 的返回里都有。`coverageStatus` 取的
+是这次运行**有证据支持的最弱**覆盖度，因此一次完整扫描不能替一次部分扫描背书；产出
+的记录按路径列出，可离线复验。CI 门禁可以直接读它：
+
+```sh
+jq -e '.verification.coverageStatus == "complete"' run.json || exit 1
+```
+
+这和 PR 评论用的是同一条规则，只是用在没有人盯着的那个界面上。
+[Harness 模式 →](docs/HARNESS-MODE.md)
+
 ### Windows
 
 从 [Releases](https://github.com/arthurpanhku/dvalincode/releases/latest) 下载 `dvalincode-v*-windows-x64.zip`，解压后双击 `start.bat`。
@@ -738,7 +758,7 @@ RESTORE → COMPACT → COMMAND → BUILD → RUN → SAVE → RESPOND → DONE
 npm test
 ```
 
-**518 个核心测试 · 70 个文件 · 全部通过。** VS Code 扩展另有 37 个测试，
+**572 个通过 · 6 个跳过 · 73 个文件 · 全绿。** VS Code 扩展另有 37 个测试，
 以及一个可选的已发布包集成测试。
 
 ---
@@ -866,7 +886,7 @@ Linux 与 macOS 命令通过 <code>/bin/sh</code> 执行；Windows 命令通过�
 ```sh
 git clone https://github.com/arthurpanhku/dvalincode
 cd dvalincode && npm install
-npm test                # 518/518 核心测试 ✅
+npm test                # 572 个通过 · 6 个跳过 ✅
 npm run typecheck
 ```
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -9,7 +9,7 @@
 <p align="center">
   <a href="https://github.com/arthurpanhku/dvalincode/releases/latest"><img src="https://img.shields.io/github/v/release/arthurpanhku/dvalincode?style=for-the-badge&color=818cf8&label=Release" alt="Release"></a>
   <a href="https://github.com/arthurpanhku/dvalincode/releases"><img src="https://img.shields.io/github/downloads/arthurpanhku/dvalincode/total?style=for-the-badge&color=blue&label=Downloads" alt="Downloads"></a>
-  <a href="#-测试"><img src="https://img.shields.io/badge/Tests-572%20passing%20%E2%9C%93-success?style=for-the-badge" alt="Tests"></a>
+  <a href="#-测试"><img src="https://img.shields.io/badge/Tests-584%20%2F%20584%20%E2%9C%93-success?style=for-the-badge" alt="Tests"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-green?style=for-the-badge" alt="License"></a>
   <a href="https://scorecard.dev/viewer/?uri=github.com/arthurpanhku/dvalincode"><img src="https://api.scorecard.dev/projects/github.com/arthurpanhku/dvalincode/badge" alt="OpenSSF Scorecard"></a>
   <a href="#-一行安装"><img src="https://img.shields.io/badge/Platforms-macOS%20·%20Windows%20·%20Linux-blue?style=for-the-badge" alt="Platforms"></a>
@@ -141,8 +141,19 @@ runner 会仅凭这个文件本身重新推导它 —— 重算哈希，并从�
 - repaired by claude-code — recorded, and not consulted for this verdict
 - targets: 1 before → 0 remaining
 - coverage: complete → complete
+- introduced: none (gate high/new)
+- outcome: verified
 - ✓ test: `npm run test` (exit 0)
 - audit chain: verify-eeb1bae7 @ 80881867270d
+```
+
+引入了新问题的修复，会在同一个地方说清楚，并让这个 job 失败：
+
+```
+❌ 916e2eeaf065 · NOT VERIFIED · scan-and-checks
+- introduced: 1 finding(s) the first scan did not report (gate high/new)
+  - critical dvalin/sql-injection — src/db.ts:31
+- outcome: regressed
 ```
 
 ### 或者让你的 agent 调用它
@@ -758,7 +769,7 @@ RESTORE → COMPACT → COMMAND → BUILD → RUN → SAVE → RESPOND → DONE
 npm test
 ```
 
-**572 个通过 · 6 个跳过 · 73 个文件 · 全绿。** VS Code 扩展另有 37 个测试，
+**584 个核心测试 · 74 个文件 · 全部通过。** VS Code 扩展另有 37 个测试，
 以及一个可选的已发布包集成测试。
 
 ---
@@ -886,7 +897,7 @@ Linux 与 macOS 命令通过 <code>/bin/sh</code> 执行；Windows 命令通过�
 ```sh
 git clone https://github.com/arthurpanhku/dvalincode
 cd dvalincode && npm install
-npm test                # 572 个通过 · 6 个跳过 ✅
+npm test                # 584/584 核心测试 ✅
 npm run typecheck
 ```
 

--- a/action.yml
+++ b/action.yml
@@ -273,6 +273,40 @@ runs:
                 `- targets: ${rec.before.targets.length} before → ${rec.after.remainingTargets.length} remaining`,
                 `- coverage: ${rec.before.coverage.status} → ${rec.after.coverage.status}`,
               );
+              // What the repair *added*. A reviewer reading only "targets: 1 → 0"
+              // learns half of what the record knows: the verdict already fails on
+              // a regression, and the evidence for it has to be visible here or the
+              // comment understates why. A v1 record never asked, and must not be
+              // allowed to read as though it asked and found nothing.
+              if (rec.schema === "dvalin-fix-record/v2") {
+                const gate = rec.gate ? ` (gate ${rec.gate.threshold}/${rec.gate.mode})` : "";
+                const introduced = rec.after.introduced;
+                if (introduced === null || introduced === undefined) {
+                  lines.push(`- introduced: **not determined**${gate}`);
+                } else if (introduced.length === 0) {
+                  lines.push(`- introduced: none${gate}`);
+                } else {
+                  lines.push(`- introduced: **${introduced.length}** finding(s) the first scan did not report${gate}`);
+                  // The severity the gate itself read, not the raw SARIF level:
+                  // a listed finding must not appear milder than the threshold
+                  // that blocked on it.
+                  const graded = (f) => {
+                    const score = Number.parseFloat(f.securitySeverity);
+                    if (score >= 9) return "critical";
+                    if (f.severity === "error" || score >= 7) return "high";
+                    if (f.severity === "warning" || score >= 4) return "medium";
+                    return "low";
+                  };
+                  for (const f of introduced.slice(0, 5)) {
+                    const where = f.startLine ? `\`${f.path}:${f.startLine}\`` : `\`${f.path}\``;
+                    lines.push(`  - ${graded(f)} \`${f.ruleId}\` — ${where}`);
+                  }
+                  if (introduced.length > 5) lines.push(`  - _…and ${introduced.length - 5} more._`);
+                }
+                if (rec.outcome) lines.push(`- outcome: \`${rec.outcome}\``);
+              } else {
+                lines.push("- _issued under v1 rules — whether the repair introduced new findings was not evaluated_");
+              }
               for (const check of rec.checks.slice(0, 8)) {
                 lines.push(`- ${check.passed ? "✓" : "✗"} ${check.kind}: \`${check.command}\`${check.exitCode === null ? "" : ` (exit ${check.exitCode})`}`);
               }

--- a/tests/actionSummaryRender.test.ts
+++ b/tests/actionSummaryRender.test.ts
@@ -1,0 +1,170 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterAll, describe, expect, it } from 'vitest';
+import {
+  buildFixRecord,
+  verifyFixRecord,
+  type FixRecordGate,
+  type FixRecordInput,
+} from '../src/security/fixRecord.js';
+import type { SecurityCoverage, SecurityFindingSnapshot } from '../src/security/contracts.js';
+
+/**
+ * The pull-request comment is JavaScript embedded in YAML embedded in a shell
+ * script, so nothing typechecks it and nothing renders it until a real workflow
+ * runs. It shipped once already reading only `remainingTargets`, which made a
+ * regressed repair's comment look like a clean one's.
+ *
+ * These run the actual script out of action.yml against records this repo's own
+ * builder produced, and assert on the comment a reviewer would read.
+ */
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const actionYaml = readFileSync(path.join(repoRoot, 'action.yml'), 'utf8');
+const summaryScript = extractSummaryScript(actionYaml);
+const workdirs: string[] = [];
+
+afterAll(() => {
+  for (const dir of workdirs) rmSync(dir, { recursive: true, force: true });
+});
+
+/** The `node -e '…'` body of the "Build summary" step. */
+function extractSummaryScript(yamlText: string): string {
+  const step = yamlText.slice(yamlText.indexOf('name: Build summary'));
+  const start = step.indexOf("node -e '");
+  const body = step.slice(start + "node -e '".length);
+  const end = body.indexOf("'\n");
+  expect(start, 'the summary step still runs node -e').toBeGreaterThan(-1);
+  expect(end, 'the node -e script is still terminated by a single quote').toBeGreaterThan(-1);
+  return body.slice(0, end);
+}
+
+const complete: SecurityCoverage = {
+  status: 'complete',
+  scanners: [{ id: 'builtin', status: 'completed' }],
+  exclusions: [],
+  deferred: [],
+  notes: [],
+};
+
+function finding(overrides: Partial<SecurityFindingSnapshot> = {}): SecurityFindingSnapshot {
+  return {
+    fingerprint: 'fp-1',
+    targetFingerprint: 'tfp-1',
+    findingId: 'one',
+    source: 'Dvalin Local Scan',
+    scanner: 'builtin',
+    ruleId: 'dvalin/eval',
+    severity: 'error',
+    message: 'eval on user input',
+    path: 'src/app.ts',
+    startLine: 4,
+    tags: [],
+    ...overrides,
+  };
+}
+
+const gate: FixRecordGate = { threshold: 'high', mode: 'new' };
+const sqlInjection = finding({
+  fingerprint: 'fp-new',
+  ruleId: 'dvalin/sql-injection',
+  securitySeverity: '9.1',
+  message: 'string-concatenated SQL',
+  path: 'src/db.ts',
+  startLine: 31,
+});
+
+function input(overrides: Partial<FixRecordInput> = {}): FixRecordInput {
+  return {
+    projectId: 'abc123',
+    executor: 'claude-code',
+    before: { scanId: 'scan-a', completedAt: '2026-01-01T00:00:00Z', coverage: complete, targets: [finding()] },
+    after: { scanId: 'scan-b', completedAt: '2026-01-01T00:10:00Z', coverage: complete, remainingTargets: [] },
+    checks: [{ kind: 'test', command: 'npm run test', exitCode: 0, passed: true }],
+    generatedAt: '2026-01-01T00:11:00Z',
+    version: '0.18.0',
+    ...overrides,
+  };
+}
+
+/** Runs the extracted script the way the step does: in a directory holding its inputs. */
+function renderComment(recordInput: FixRecordInput | null): string {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'dvalin-action-summary-'));
+  workdirs.push(dir);
+  writeFileSync(
+    path.join(dir, 'dvalin-result.json'),
+    JSON.stringify({
+      score: 100,
+      grade: 'A',
+      findings: [],
+      metrics: { critical: 0, high: 0, medium: 0, low: 0, files: 12 },
+      coverage: { status: 'complete', deferred: [], exclusions: [] },
+      scanners: [{ id: 'builtin', status: 'completed' }],
+    }),
+  );
+  if (recordInput) {
+    const verification = verifyFixRecord(buildFixRecord(recordInput));
+    expect(verification.ok, 'the fixture record re-derives').toBe(true);
+    writeFileSync(path.join(dir, 'dvalin-fix-record.json'), JSON.stringify(verification));
+  }
+  execFileSync(process.execPath, ['-e', summaryScript], { cwd: dir, env: { ...process.env, GITHUB_STEP_SUMMARY: '' } });
+  return readFileSync(path.join(dir, 'dvalin-summary.md'), 'utf8');
+}
+
+describe('the pull-request comment the action posts', () => {
+  it('keeps the node script free of the quote that would break its shell wrapper', () => {
+    // The script is passed as `node -e '…'` inside a single-quoted shell word.
+    expect(summaryScript).not.toContain("'");
+  });
+
+  it('reports a clean v2 repair with the gate it was judged under', () => {
+    const body = renderComment(input({ regression: { gate, introduced: [] } }));
+    expect(body).toContain('**VERIFIED**');
+    expect(body).toContain('- introduced: none (gate high/new)');
+    expect(body).toContain('- outcome: `verified`');
+  });
+
+  it('names what a regressed repair introduced, and where', () => {
+    const body = renderComment(input({ regression: { gate, introduced: [sqlInjection] } }));
+    expect(body).toContain('**NOT VERIFIED**');
+    expect(body).toContain('- introduced: **1** finding(s) the first scan did not report (gate high/new)');
+    // Graded the way the gate read it (securitySeverity 9.1), not as raw SARIF
+    // `error` — a listed finding must not look milder than the rule that blocked it.
+    expect(body).toContain('  - critical `dvalin/sql-injection` — `src/db.ts:31`');
+    expect(body).toContain('- outcome: `regressed`');
+  });
+
+  it('says plainly when the verifier did not determine what was introduced', () => {
+    const body = renderComment(input({ regression: { gate, introduced: null } }));
+    expect(body).toContain('- introduced: **not determined** (gate high/new)');
+    expect(body).toContain('- outcome: `unverifiable`');
+  });
+
+  it('does not let a v1 record read as though it asked about regressions', () => {
+    const body = renderComment(input());
+    expect(body).toContain('**VERIFIED**');
+    expect(body).toContain('issued under v1 rules');
+    expect(body).not.toContain('- introduced:');
+    expect(body).not.toContain('- outcome:');
+  });
+
+  it('reports a record that does not re-derive instead of rendering it', () => {
+    const dir = mkdtempSync(path.join(os.tmpdir(), 'dvalin-action-summary-'));
+    workdirs.push(dir);
+    const record = buildFixRecord(input({ regression: { gate, introduced: [] } }));
+    // Edited after issue: the verdict no longer follows from the evidence.
+    const tampered = { ...record, after: { ...record.after, remainingTargets: [finding()] } };
+    writeFileSync(path.join(dir, 'dvalin-result.json'), JSON.stringify({
+      score: 100, grade: 'A', findings: [],
+      metrics: { critical: 0, high: 0, medium: 0, low: 0, files: 12 },
+      coverage: { status: 'complete', deferred: [], exclusions: [] },
+      scanners: [],
+    }));
+    writeFileSync(path.join(dir, 'dvalin-fix-record.json'), JSON.stringify(verifyFixRecord(tampered)));
+    execFileSync(process.execPath, ['-e', summaryScript], { cwd: dir, env: { ...process.env, GITHUB_STEP_SUMMARY: '' } });
+    const body = readFileSync(path.join(dir, 'dvalin-summary.md'), 'utf8');
+    expect(body).toContain('did not re-derive on the runner');
+  });
+});


### PR DESCRIPTION
## Summary

A review of what landed since the READMEs were last touched (#216, #217, #218) turned up three stale front-page claims and one real gap in the Action.

**Fix-record samples showed v1 output.** Since #218 both producers issue v2, so `renderFixRecord` prints `introduced` with the gate it was judged under and the `outcome`. A record printed today matched neither the old sample nor a v1 one, which carries its own "issued under v1 rules" note instead. Samples now show what the command prints, and the paragraph beside the hero block states the claim v2 actually added: a repair that removes an `eval` and introduces an SQL injection is recorded as `regressed` and does not verify — and a record whose issuer never looked does not verify either.

**The Action published the proof without the regression evidence.** `action.yml` built its pull-request comment from `remainingTargets`, `coverage` and `checks`, and never read `after.introduced`, `gate` or `outcome`. So the surface that puts the record next to the diff showed a regressed repair the same way it shows a clean one — `targets: 1 → 0` under a NOT VERIFIED header, with the reason buried in verdict prose. It now names what the re-scan saw that the first scan did not, with the gate and the outcome; introduced findings are listed with the severity the gate itself read (`securitySeverity` first, then the SARIF level), because a finding must not look milder in the list than in the rule that blocked on it. A v1 record gets the note rather than the fields.

The severity gate needed no change: a regressed v2 record already re-derives to `verified: false` and fails the job. What was missing was the evidence for it.

**The headless `verification` envelope from #216 was undocumented.** The README already argues that "no findings" without coverage is not an answer; the surface where that costs most is the one with no human reading it, and it now carries coverage and any fix record's path in `json`, `stream-json` and the MCP `dvalin_run_task` result. Documented with the `jq` gate a CI job would actually write.

**Test counts were stale and disagreed with each other** — a `442 / 442` badge over a "518 core tests · 70 files" section.

**The contributors table was missing two people.** `git log` on main carries commits from Samran Asif ([@webdevsamran](https://github.com/webdevsamran), #211) and [@dchaudhari7177](https://github.com/dchaudhari7177) (#213, #212) that the table did not list. Names and handles taken from the commits and pull requests themselves.

Every change is mirrored in `README.zh-CN.md`, except the MCP record description, which that file condenses and does not carry.

## Testing

- `npx vitest run` — 584 passing across 74 files, none skipped (the counts the READMEs now quote).
- `npx tsc -p tsconfig.json --noEmit` — clean.
- New `tests/actionSummaryRender.test.ts` (6 tests) extracts the `node -e` script out of `action.yml` and runs it against records built by this repo's own `buildFixRecord` + `verifyFixRecord`, asserting the comment a reviewer would read for v2-clean, v2-regressed, v2-undetermined, v1, and a record edited after issue. It also pins the invariant that the script stays free of the single quote that would break its shell wrapper — the comment is JavaScript inside YAML inside a shell script, and nothing else typechecks it.
- Mutation-checked: pointing the schema comparison at a version that never matches fails the three v2 cases.

## Security and AI Governance

- [x] This change does not expand file, shell, network, model, or approval permissions.
- [x] If it changes agent behavior, prompts, policy, providers, audit logging, or release/build security, I updated the relevant governance evidence in `docs/`. — none of those change here; the Action edit affects only how an already-computed verdict is displayed, and `docs/spec/FIX-VERIFICATION.md` already gained FV-10a/FV-10b/FV-12a in #217.
- [x] If it introduces a new model/provider/tool or new data flow, I completed `docs/governance/AI-CHANGE-IMPACT-ASSESSMENT.md`. — no new model, provider, tool, or data flow.

## Notes

Two things left alone on purpose:

- The workflow example still pins `arthurpanhku/dvalincode@v0.18.0`. The v2 records and this rendering ship together in the next release, so the pin is consistent as it stands; bumping it is a release-cadence decision.
- The closing blockquote on the Action comment ("attests that these findings were gone and these checks were observed to pass") is unchanged — still accurate, and for a v2 record the `introduced` line above it already carries the stronger claim.

The contributors table also still lists [@shivasb42](https://github.com/shivasb42) and [@adity982](https://github.com/adity982), who have no commits in `git log`; the section credits issues and ideas as well as code, so they were left in place rather than pruned.

One correction worth flagging for anyone reading the branch history: the first commit put `572 passing · 6 skipped · 73 files` in the READMEs. That measurement came from a run against a still-installing `node_modules`; the skips were an artifact of it. The second commit corrects all six spots to 584 / 74.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015f83ci81a7cKYf253ckwTb