### PR TITLE
test: drop describe.sequential, which vitest 5 removed

### DIFF
--- a/tests/remediationScannerSuite.test.ts
+++ b/tests/remediationScannerSuite.test.ts
@@ -5,7 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { dvalinScannerInstallPlan, listDvalinScanners, runDvalinScanSuite } from '../src/remediation/scannerSuite.js';
 import { consumeScannerWorkspaceGrant, issueScannerWorkspaceGrant } from '../src/server/scannerWorkspaceGrants.js';
 
-describe.sequential('Dvalin scanner suite', () => {
+describe('Dvalin scanner suite', { concurrent: false }, () => {
   let cwd: string;
 
   beforeEach(async () => {

--- a/tests/securitySarifImport.test.ts
+++ b/tests/securitySarifImport.test.ts
@@ -9,7 +9,7 @@ import {
 import { buildDvalinProgram } from '../src/dvalinCli.js';
 import { listRemediationCases } from '../src/remediation/cases.js';
 
-describe.sequential('security SARIF handoff', () => {
+describe('security SARIF handoff', { concurrent: false }, () => {
   let home: string;
   let workspace: string;
   let originalHome: string | undefined;

--- a/tests/securityWorkflow.test.ts
+++ b/tests/securityWorkflow.test.ts
@@ -44,7 +44,7 @@ async function needsWork() {
   return createSecurityWorkflow({ root: home, result: initial, gate });
 }
 
-describe.sequential('persistent security workflow', () => {
+describe('persistent security workflow', { concurrent: false }, () => {
   it('resumes by id and passes once the re-scan clears the target and a check was observed', async () => {
     const created = await needsWork();
     expect(created.state).toBe('needs_work');


### PR DESCRIPTION
## Summary

Unblocks #222 (`build(deps): bump the node-runtime group with 5 updates`), whose `test` job is the one red check on any open pull request right now.

That bump takes vitest from 4.1.11 to 5.0.0, and vitest 5 removes `sequential` from the chainable suite modifiers — its own types now list `concurrent | only | skip | todo | shuffle`. Three suites use `describe.sequential`, so they fail to collect at all:

```
TypeError: describe.sequential is not a function
 ❯ tests/remediationScannerSuite.test.ts:8:10
 ❯ tests/securitySarifImport.test.ts:12:10
 ❯ tests/securityWorkflow.test.ts:47:10

Test Files  3 failed | 70 passed | 1 skipped (74)
```

Replaced with the options form, `describe(name, { concurrent: false }, fn)`, rather than a bare `describe`. Bare would pass today — nothing in `vitest.config.ts` turns concurrency on, and suites are sequential by default — but these three share a temp `HOME` and a workspace across their tests, and the marker is what records that. Dropping it would leave the constraint true only by accident, and silently violated the day someone sets `concurrent: true`.

This is deliberately separate from the bump so #222 stays a lockfile change and goes green on a rebase, rather than carrying an unrelated test edit.

## Testing

Ran both ways round, because a fix that only works under the new version would strand `main`:

| vitest | lockfile | `npx vitest run` | `tsc --noEmit` |
|---|---|---|---|
| 4.1.11 | this branch (`main`) | 584 passed / 74 files | clean |
| 5.0.0 | from #222 | 584 passed / 74 files | clean |

The failure was reproduced first on #222's lockfile (3 suites failing to collect, as above), then the same command was run again after the change and came back green.

## Security and AI Governance

- [x] This change does not expand file, shell, network, model, or approval permissions.
- [x] If it changes agent behavior, prompts, policy, providers, audit logging, or release/build security, I updated the relevant governance evidence in `docs/`. — none of those change; the edit is three test-suite declarations.
- [x] If it introduces a new model/provider/tool or new data flow, I completed `docs/governance/AI-CHANGE-IMPACT-ASSESSMENT.md`. — no new model, provider, tool, or data flow.

## Notes

After this lands, #222 needs a rebase (`·@·d·ependabot r·ebase`) to pick it up; its CI cannot go green before then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015f83ci81a7cKYf253ckwTb

---
_Generated by [Claude Code](https://claude.ai/code/session_015f83ci81a7cKYf253ckwTb)_